### PR TITLE
fix: tighten gh-address-cr agent guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ scripts/final_gate.sh --auto-clean --audit-id run-YYYYMMDD owner/repo 123
 If `scripts/final_gate.sh` fails:
 
 1. Read the pending table in terminal output and the printed audit summary path.
-2. For each pending thread, verify both operations were completed: `post_reply` and `resolve_thread`.
+2. For each pending thread, verify both operations were completed: `scripts/post_reply.sh` and `scripts/resolve_thread.sh`.
 3. Re-run `scripts/run_once.sh --show-all ...` to compare unresolved vs handled state.
 4. Resolve remaining threads, then re-run `scripts/final_gate.sh`.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An auditable GitHub PR review-comments workflow skill for AI coding agents.
 
 It is designed to process CR threads one by one, enforce evidence-first replies,
 and require a final freshness gate before declaring completion.
+For handled threads, replying and resolving are two separate required operations.
 
 By default, the skill stores its PR progress + audit artifacts in a user cache directory
 (override with `GH_ADDRESS_CR_STATE_DIR`). If the cache is purged, the workflow can be rebuilt
@@ -75,6 +76,17 @@ from GitHub thread state; the main downside is potential repeated work.
 npx skills add https://github.com/RbBtSn0w/gh-address-cr-skill --skill gh-address-cr
 ```
 
+## Breaking changes (2026-04-09)
+
+- `scripts/batch_resolve.sh` now requires an approved list format:
+  - one thread per line: `APPROVED <thread_id>`
+  - empty lines and `#` comments are allowed
+  - raw thread-id lines now fail fast
+- `scripts/list_threads.sh` now uses the latest thread comment as primary context and emits:
+  - `comment_source` (`latest|first|none`)
+  - `first_url`, `latest_url`
+  - `url`/`body` remain available, now latest-first with fallback
+
 ## Update model (official `skills` behavior)
 
 `npx skills update` is driven by the lock file and remote folder hash, not by git tag directly.
@@ -128,6 +140,15 @@ scripts/post_reply.sh --repo owner/repo --pr 123 --audit-id run-YYYYMMDD <thread
 scripts/resolve_thread.sh --repo owner/repo --pr 123 --audit-id run-YYYYMMDD <thread_id>
 scripts/final_gate.sh --auto-clean --audit-id run-YYYYMMDD owner/repo 123
 ```
+
+## Troubleshooting final gate failure
+
+If `scripts/final_gate.sh` fails:
+
+1. Read the pending table in terminal output and the printed audit summary path.
+2. For each pending thread, verify both operations were completed: `post_reply` and `resolve_thread`.
+3. Re-run `scripts/run_once.sh --show-all ...` to compare unresolved vs handled state.
+4. Resolve remaining threads, then re-run `scripts/final_gate.sh`.
 
 ## CI semantic release (tag + changelog)
 

--- a/gh-address-cr/SKILL.md
+++ b/gh-address-cr/SKILL.md
@@ -22,7 +22,7 @@ Use this skill in strict incremental mode to minimize token usage while keeping 
    - `scripts/run_once.sh [--audit-id <id>] <owner/repo> <pr_number>`
 2. Process only unresolved + unhandled threads.
 3. For each thread: `understand -> analyze/decide (Accept/Defer/Clarify) -> act (fix code OR write rationale) -> evidence reply -> resolve`. (Note: You MUST resolve the thread on GitHub after replying to pass the final gate).
-   - `post_reply` and `resolve_thread` are separate atomic operations. Both MUST be executed for handled threads.
+   - `scripts/post_reply.sh` and `scripts/resolve_thread.sh` are separate atomic operations. Both MUST be executed for handled threads.
 4. Use minimal fixes and targeted tests first.
 5. Before completion message, run hard gate (MANDATORY):
    - `scripts/final_gate.sh [--auto-clean|--no-auto-clean] [--audit-id <id>] <owner/repo> <pr_number>`

--- a/gh-address-cr/SKILL.md
+++ b/gh-address-cr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-address-cr
-description: Resolve GitHub PR review comments end-to-end with evidence. Use when asked to process CR comments one by one, verify fixes, reply per thread, fix unresolved issues, produce minimal repair plans, explain why new CRs appear later, and decide whether each CR must be fixed before merge.
+description: Use when resolving GitHub PR review threads that require evidence-first replies, explicit resolve actions, and a mandatory final unresolved-thread gate before completion.
 ---
 
 # gh-address-cr
@@ -22,6 +22,7 @@ Use this skill in strict incremental mode to minimize token usage while keeping 
    - `scripts/run_once.sh [--audit-id <id>] <owner/repo> <pr_number>`
 2. Process only unresolved + unhandled threads.
 3. For each thread: `understand -> analyze/decide (Accept/Defer/Clarify) -> act (fix code OR write rationale) -> evidence reply -> resolve`. (Note: You MUST resolve the thread on GitHub after replying to pass the final gate).
+   - `post_reply` and `resolve_thread` are separate atomic operations. Both MUST be executed for handled threads.
 4. Use minimal fixes and targeted tests first.
 5. Before completion message, run hard gate (MANDATORY):
    - `scripts/final_gate.sh [--auto-clean|--no-auto-clean] [--audit-id <id>] <owner/repo> <pr_number>`
@@ -37,7 +38,7 @@ Before modifying code, you MUST analyze the necessity of the CR suggestion:
 ## Hard Constraints (No Bypass)
 
 - Never declare "done" without `final_gate.sh` pass.
-- Never bypass state tracking with ad-hoc batch scripts.
+- Never bypass state tracking with ad-hoc batch scripts. Only use `scripts/batch_resolve.sh` with an approved list produced after per-thread analysis and evidence drafting.
 - If unresolved exists, keep iterating; do not send completion summary.
 - Each mid-run update must include either a pending list or explicit `Verified: 0 Unresolved Threads found`.
 
@@ -73,12 +74,22 @@ Any final completion message must include:
 - Post reply: `scripts/post_reply.sh [--dry-run] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <thread_id> <reply_file>`
 - Resolve thread: `scripts/resolve_thread.sh [--dry-run] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <thread_id>`
 - Mark handled without resolving: `scripts/mark_handled.sh [--repo <owner/repo> --pr <number>] <thread_id>`
-- Batch resolve from file: `scripts/batch_resolve.sh [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <thread_ids_file>`
+- Batch resolve from approved file: `scripts/batch_resolve.sh [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <approved_threads_file>` (format: `APPROVED <thread_id>`)
 - Generate reply draft: `scripts/generate_reply.sh [--mode fix|clarify|defer] [--severity P1|P2|P3] <output_md> [args...]`
 - Clean local cache: `scripts/clean_state.sh [--repo <owner/repo> --pr <number> | --all] [--clean-tmp]`
 - Audit report: `scripts/audit_report.sh <owner/repo> <pr_number>`
 - Templates: `assets/reply-templates/`
 - Reference checklist: `references/cr-triage-checklist.md`
+
+## Troubleshooting `final_gate` Failure
+
+If `scripts/final_gate.sh` fails:
+
+1. Read the pending table in terminal output and the audit summary file path printed by `final_gate.sh`.
+2. For each pending `thread_id`, verify if reply and resolve were both completed (reply-only is insufficient).
+3. Re-run `scripts/run_once.sh --show-all ...` to compare unresolved and handled state.
+4. Post missing evidence reply and resolve missing threads.
+5. Re-run `scripts/final_gate.sh ...` and only declare completion after `Verified: 0 Unresolved Threads found`.
 
 ## Fast Path
 
@@ -97,4 +108,3 @@ Any final completion message must include:
    - `scripts/final_gate.sh --auto-clean --audit-id run-20260324 github/spec-kit 1906`
 
 State cache lives in a user cache directory by default (override with `GH_ADDRESS_CR_STATE_DIR`) to avoid repeated labor across rounds. If the cache is purged, the workflow can be rebuilt from GitHub thread state; the main downside is potential repeated work.
- by default (override with `GH_ADDRESS_CR_STATE_DIR`) to avoid repeated labor across rounds. If the cache is purged, the workflow can be rebuilt from GitHub thread state; the main downside is potential repeated work.

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -4,7 +4,7 @@ interface:
   short_description: Process PR review comments with evidence-first fixes and replies.
   default_prompt: |
     Resolve PR CR comments one by one with evidence-first replies.
-    1. For each handled thread, execute BOTH `post_reply` and `resolve_thread` (reply-only is incomplete).
-    2. Before any completion statement, run `final_gate.sh`.
+    1. For each handled thread, execute BOTH `scripts/post_reply.sh` and `scripts/resolve_thread.sh` (reply-only is incomplete).
+    2. Before any completion statement, run `scripts/final_gate.sh`.
     3. Require the exact line: "Verified: 0 Unresolved Threads found".
-    4. Completion summary must include gate command, unresolved=0 confirmation, and audit summary sha256.
+    4. Completion summary must include the gate command, unresolved=0 confirmation, audit summary path, and audit summary sha256.

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -6,5 +6,5 @@ interface:
     Resolve PR CR comments one by one with evidence-first replies.
     1. For each handled thread, execute BOTH `scripts/post_reply.sh` and `scripts/resolve_thread.sh` (reply-only is incomplete).
     2. Before any completion statement, run `scripts/final_gate.sh`.
-    3. Require the exact line: "Verified: 0 Unresolved Threads found".
+    3. Require the exact line: Verified: 0 Unresolved Threads found.
     4. Completion summary must include the gate command, unresolved=0 confirmation, audit summary path, and audit summary sha256.

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -2,4 +2,9 @@ version: 1
 interface:
   display_name: GH Address CR
   short_description: Process PR review comments with evidence-first fixes and replies.
-  default_prompt: Resolve PR CR comments one by one, verify with code and tests, reply per thread with evidence, fix unresolved issues, and summarize merge readiness.
+  default_prompt: |
+    Resolve PR CR comments one by one with evidence-first replies.
+    1. For each handled thread, execute BOTH `post_reply` and `resolve_thread` (reply-only is incomplete).
+    2. Before any completion statement, run `final_gate.sh`.
+    3. Require the exact line: "Verified: 0 Unresolved Threads found".
+    4. Completion summary must include gate command, unresolved=0 confirmation, and audit summary sha256.

--- a/gh-address-cr/scripts/batch_resolve.sh
+++ b/gh-address-cr/scripts/batch_resolve.sh
@@ -75,6 +75,7 @@ run_resolve() {
   "${cmd[@]}"
 }
 
+tid=""
 while IFS= read -r tid || [[ -n "$tid" ]]; do
   [[ "$tid" =~ ^[[:space:]]*$ ]] && continue
   [[ "$tid" =~ ^[[:space:]]*# ]] && continue

--- a/gh-address-cr/scripts/batch_resolve.sh
+++ b/gh-address-cr/scripts/batch_resolve.sh
@@ -75,12 +75,12 @@ run_resolve() {
   "${cmd[@]}"
 }
 
-tid=""
-while IFS= read -r tid || [[ -n "$tid" ]]; do
-  [[ "$tid" =~ ^[[:space:]]*$ ]] && continue
-  [[ "$tid" =~ ^[[:space:]]*# ]] && continue
-  if [[ ! "$tid" =~ ^[[:space:]]*APPROVED[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
-    echo "Invalid line in approved list: '$tid'" >&2
+line=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  if [[ ! "$line" =~ ^[[:space:]]*APPROVED[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
+    echo "Invalid line in approved list: '$line'" >&2
     echo "Expected format: APPROVED <thread_id>" >&2
     exit 2
   fi

--- a/gh-address-cr/scripts/batch_resolve.sh
+++ b/gh-address-cr/scripts/batch_resolve.sh
@@ -62,30 +62,27 @@ if [[ "$dry_run" == false && "$yes" == false ]]; then
   exit 1
 fi
 
-while IFS= read -r tid; do
-  [[ -z "$tid" ]] && continue
-  [[ "$tid" =~ ^# ]] && continue
-  if [[ ! "$tid" =~ ^APPROVED[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
+run_resolve() {
+  local tid="$1"
+  local cmd=(bash "$resolve_script")
+  if [[ "$dry_run" == true ]]; then
+    cmd+=(--dry-run)
+  fi
+  if [[ -n "$repo" && -n "$pr_number" ]]; then
+    cmd+=(--repo "$repo" --pr "$pr_number" --audit-id "$audit_id")
+  fi
+  cmd+=("$tid")
+  "${cmd[@]}"
+}
+
+while IFS= read -r tid || [[ -n "$tid" ]]; do
+  [[ "$tid" =~ ^[[:space:]]*$ ]] && continue
+  [[ "$tid" =~ ^[[:space:]]*# ]] && continue
+  if [[ ! "$tid" =~ ^[[:space:]]*APPROVED[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
     echo "Invalid line in approved list: '$tid'" >&2
     echo "Expected format: APPROVED <thread_id>" >&2
     exit 2
   fi
   tid="${BASH_REMATCH[1]}"
-  extra_args=()
-  if [[ -n "$repo" && -n "$pr_number" ]]; then
-    extra_args+=(--repo "$repo" --pr "$pr_number" --audit-id "$audit_id")
-  fi
-  if [[ "$dry_run" == true ]]; then
-    if [[ ${#extra_args[@]} -gt 0 ]]; then
-      bash "$resolve_script" --dry-run "${extra_args[@]}" "$tid"
-    else
-      bash "$resolve_script" --dry-run "$tid"
-    fi
-  else
-    if [[ ${#extra_args[@]} -gt 0 ]]; then
-      bash "$resolve_script" "${extra_args[@]}" "$tid"
-    else
-      bash "$resolve_script" "$tid"
-    fi
-  fi
+  run_resolve "$tid"
 done < "$approved_file"

--- a/gh-address-cr/scripts/batch_resolve.sh
+++ b/gh-address-cr/scripts/batch_resolve.sh
@@ -33,7 +33,11 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help|-h)
-      echo "Usage: $0 [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <thread_ids_file>"
+      echo "Usage: $0 [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <approved_threads_file>"
+      echo
+      echo "Approved list format (breaking change):"
+      echo "  - One approved thread per line: APPROVED <thread_id>"
+      echo "  - Empty lines and # comments are allowed"
       exit 0
       ;;
     *)
@@ -43,13 +47,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <thread_ids_file>" >&2
+  echo "Usage: $0 [--dry-run] [--yes] [--repo <owner/repo> --pr <number>] [--audit-id <id>] <approved_threads_file>" >&2
   exit 1
 fi
 
-thread_file="$1"
-if [[ ! -f "$thread_file" ]]; then
-  echo "Thread id file not found: $thread_file" >&2
+approved_file="$1"
+if [[ ! -f "$approved_file" ]]; then
+  echo "Approved thread file not found: $approved_file" >&2
   exit 1
 fi
 
@@ -61,13 +65,27 @@ fi
 while IFS= read -r tid; do
   [[ -z "$tid" ]] && continue
   [[ "$tid" =~ ^# ]] && continue
+  if [[ ! "$tid" =~ ^APPROVED[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
+    echo "Invalid line in approved list: '$tid'" >&2
+    echo "Expected format: APPROVED <thread_id>" >&2
+    exit 2
+  fi
+  tid="${BASH_REMATCH[1]}"
   extra_args=()
   if [[ -n "$repo" && -n "$pr_number" ]]; then
     extra_args+=(--repo "$repo" --pr "$pr_number" --audit-id "$audit_id")
   fi
   if [[ "$dry_run" == true ]]; then
-    bash "$resolve_script" --dry-run "${extra_args[@]}" "$tid"
+    if [[ ${#extra_args[@]} -gt 0 ]]; then
+      bash "$resolve_script" --dry-run "${extra_args[@]}" "$tid"
+    else
+      bash "$resolve_script" --dry-run "$tid"
+    fi
   else
-    bash "$resolve_script" "${extra_args[@]}" "$tid"
+    if [[ ${#extra_args[@]} -gt 0 ]]; then
+      bash "$resolve_script" "${extra_args[@]}" "$tid"
+    else
+      bash "$resolve_script" "$tid"
+    fi
   fi
-done < "$thread_file"
+done < "$approved_file"

--- a/gh-address-cr/scripts/list_threads.sh
+++ b/gh-address-cr/scripts/list_threads.sh
@@ -28,7 +28,8 @@ query='query($owner:String!,$name:String!,$number:Int!,$after:String){
           isOutdated
           path
           line
-          comments(first:1){ nodes{ url body } }
+          firstComment: comments(first:1){ nodes{ url body } }
+          latestComment: comments(last:1){ nodes{ url body } }
         }
       }
     }
@@ -57,7 +58,18 @@ while true; do
   fi
 
   echo "$response" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[] |
-    {id, isResolved, isOutdated, path, line, url: .comments.nodes[0].url, body: .comments.nodes[0].body}'
+    {
+      id,
+      isResolved,
+      isOutdated,
+      path,
+      line,
+      url: (.latestComment.nodes[0].url // .firstComment.nodes[0].url // null),
+      body: (.latestComment.nodes[0].body // .firstComment.nodes[0].body // null),
+      comment_source: (if (.latestComment.nodes | length) > 0 then "latest" elif (.firstComment.nodes | length) > 0 then "first" else "none" end),
+      first_url: (.firstComment.nodes[0].url // null),
+      latest_url: (.latestComment.nodes[0].url // null)
+    }'
 
   has_next="$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
   if [[ "$has_next" != "true" ]]; then


### PR DESCRIPTION
## Summary
- tighten skill guidance around reply/resolve atomicity and final-gate troubleshooting
- make thread listing latest-comment aware and emit comment provenance fields
- harden batch resolve input parsing and document the breaking contract

## Test Plan
- `bash -n gh-address-cr/scripts/list_threads.sh gh-address-cr/scripts/batch_resolve.sh`
- `ruby -e 'require "yaml"; YAML.load_file("gh-address-cr/agents/openai.yaml"); puts "yaml-ok"'`
- `tmpf=$(mktemp); printf 'APPROVED THREAD123   \\n' > "$tmpf"; gh-address-cr/scripts/batch_resolve.sh --dry-run --yes "$tmpf"; rc=$?; rm -f "$tmpf"; exit $rc`
- `tmpf=$(mktemp); printf 'APPROVED    \\n' > "$tmpf"; gh-address-cr/scripts/batch_resolve.sh --dry-run --yes "$tmpf"; rc=$?; rm -f "$tmpf"; exit $rc`