### PR TITLE
feat: add agent feedback issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-agent-feedback.md
+++ b/.github/ISSUE_TEMPLATE/ai-agent-feedback.md
@@ -1,0 +1,37 @@
+---
+name: AI Agent Feedback
+about: Report skill-level friction, missing automation, contradictory instructions, or tooling failures for gh-address-cr.
+title: "[AI Feedback] "
+---
+
+## Summary
+
+<!-- One short paragraph describing the problem. -->
+
+## Category
+
+<!-- workflow-gap | tooling-bug | docs-gap | integration-gap | other -->
+
+## Expected Workflow
+
+<!-- What should the skill have made possible? -->
+
+## Actual Behavior
+
+<!-- What actually blocked or confused the agent? -->
+
+## Reproduction Context
+
+<!-- Include the agent name, skill command, repo/PR under review, and any useful environment details. -->
+
+## Technical Diagnostics
+
+<!-- Prefer safe technical signals such as failing command, exit code, status, reason_code, waiting_on, run_id, skill version, head SHA, and session metrics. -->
+
+## Artifacts
+
+<!-- Link relevant logs, artifacts, or sanitized file paths. -->
+
+## Additional Notes
+
+<!-- Optional follow-up context or a concrete improvement idea. Do not include usernames, emails, tokens, machine names, or absolute local paths. Matching feedback may be deduplicated automatically. -->

--- a/README.md
+++ b/README.md
@@ -746,8 +746,7 @@ npx skills update
 - Mandatory final gate (`python3 gh-address-cr/scripts/cli.py final-gate`) before completion
 - Session-scoped state tracking to avoid duplicate work
 - Audit log + trace log + audit summary + summary hash output
-- Audit summaries include labeled total, new in this run, unresolved, and handled in this run counts, not just final zero-state gate metrics
-- `python3 gh-address-cr/scripts/cli.py final-gate` also prints the same current-run snapshot in human-readable form before the raw machine diagnostics
+- Audit summaries and `final-gate` output preserve machine-readable gate counts and summary hashes for evidence
 - Python-first implementation with a single CLI entrypoint
 - Module-split automated tests for session, wrappers, and helper scripts
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,12 @@ If you omit the producer where it is required:
 - External fixer commands must read a JSON payload from stdin and return JSON:
   - `resolution`: `fix`, `clarify`, or `defer`
   - `note`
-  - `reply_markdown` for GitHub thread items
+  - for GitHub thread `fix`: `fix_reply`
+    - `commit_hash`
+    - `files`
+    - optional `severity`, `why`, `test_command`, `test_result`
+    - `validation_commands` may be used as default validation evidence when `test_command` / `test_result` are omitted
+  - for GitHub thread `clarify` or `defer`: `reply_markdown`
   - optional `validation_commands`
 - `adapter` producer is re-run on each iteration.
 - `json` and `code-review` producers are treated as one-shot inputs for the current review run.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,49 @@ Ready-to-use prompt variants:
 继续处理 session、GitHub threads、fix、reply/resolve 和 final-gate，直到通过。
 ```
 
+## AI Agent Feedback
+
+When the skill itself blocks progress, file a feedback issue in this repository instead of silently dropping the problem.
+
+- Use feedback issues for skill-level problems such as contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures that are not caused by the repository under review.
+- Do not file feedback issues for normal PR findings, target-repository bugs, or expected wait states such as `WAITING_FOR_EXTERNAL_REVIEW`.
+- Do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues.
+- Prefer safe technical diagnostics such as failing command, exit code, status, `reason_code`, `waiting_on`, `run_id`, and skill version.
+- When `--using-repo` and `--using-pr` are provided, the helper auto-collects the latest local evidence from the PR workspace when available:
+  - `last-machine-summary.json`
+  - `session.json`
+  - `audit_summary.md`
+  - cached PR head SHA from `github_pr_cache.json`
+- The helper deduplicates repeated reports by fingerprint and skips creating a new issue when the same feedback issue is already open or was closed recently within the cooldown window.
+- The repository issue format lives in `.github/ISSUE_TEMPLATE/ai-agent-feedback.md`.
+- Repository-root helper command:
+
+```bash
+python3 gh-address-cr/scripts/submit_feedback.py \
+  --category workflow-gap \
+  --title "blocked without a recovery step" \
+  --summary "review stopped in a blocked state without enough operator guidance." \
+  --expected "the skill should identify the next command or artifact to inspect." \
+  --actual "the workflow stopped and the next action was ambiguous." \
+  --source-command "python3 gh-address-cr/scripts/cli.py review owner/repo 123" \
+  --failing-command "python3 gh-address-cr/scripts/cli.py final-gate owner/repo 123" \
+  --exit-code 5 \
+  --status BLOCKED \
+  --reason-code WAITING_FOR_FIX \
+  --waiting-on human_fix \
+  --run-id cr-loop-20260417T120000Z \
+  --skill-version 1.2.0 \
+  --using-repo owner/repo \
+  --using-pr 123 \
+  --artifact /tmp/loop-request.json
+```
+
+- Unified CLI passthrough:
+
+```bash
+python3 gh-address-cr/scripts/cli.py submit-feedback --category workflow-gap --title "..." --summary "..." --expected "..." --actual "..."
+```
+
 ## Choosing Fixes
 
 `gh-address-cr` is not "fix every comment immediately". The intended workflow is:

--- a/gh-address-cr/SKILL.md
+++ b/gh-address-cr/SKILL.md
@@ -162,12 +162,7 @@ Advanced producer and dispatch details live in:
   - output includes `Verified: 0 Unresolved Threads found`, and
   - output includes `Verified: 0 Pending Reviews found`, and
   - session blocking item count is zero.
-- Completion summaries must lead with a readable current-run handling summary from the same gate run, not just the final zero counts:
-  - GitHub threads: total, new in this run, unresolved, handled in this run
-  - local findings: total, new in this run, unresolved, handled in this run
-  - prefer labeled phrasing such as `GitHub threads: total 2; new in this run 0; unresolved 0; handled in this run 0`
-  - prefer the human-readable `Current Run Snapshot` block printed by `python3 scripts/cli.py final-gate ...`; use raw machine count lines only as fallback evidence
-  - use `audit_summary.md` or the machine-readable count lines printed by `final-gate`
+- Use `audit_summary.md` or the machine-readable count lines printed by `final-gate` when run-scoped diagnostics are needed.
 - If gate fails, continue iteration; completion summary is forbidden.
 
 ## Core Rules
@@ -341,15 +336,11 @@ Prefer `NEEDS_HUMAN` over speculative fixes when:
 Final output must include:
 
 1. `final_gate` command used
-2. readable current-run handling summary from the same gate run:
-   - GitHub threads total, new in this run, unresolved, handled in this run
-   - local findings total, new in this run, unresolved, handled in this run
-   - prefer labeled phrasing such as `GitHub threads: total 2; new in this run 0; unresolved 0; handled in this run 0`
-3. `Verified: 0 Unresolved Threads found`
-4. `Verified: 0 Pending Reviews found`
-5. unresolved GitHub threads = 0
-6. session blocking items = 0
-7. audit summary path + sha256
+2. `Verified: 0 Unresolved Threads found`
+3. `Verified: 0 Pending Reviews found`
+4. unresolved GitHub threads = 0
+5. session blocking items = 0
+6. audit summary path + sha256
 
 For run-scoped diagnostics, use:
 

--- a/gh-address-cr/SKILL.md
+++ b/gh-address-cr/SKILL.md
@@ -190,7 +190,12 @@ The default review entrypoint runs repeated intake, item selection, action execu
 - External fixer commands must read a JSON payload from stdin and return a JSON object containing:
   - `resolution`: `fix`, `clarify`, or `defer`
   - `note`
-  - `reply_markdown` for GitHub thread items
+  - for GitHub thread `fix`: `fix_reply`
+    - `commit_hash`
+    - `files`
+    - optional `severity`, `why`, `test_command`, `test_result`
+    - `validation_commands` may be used as the default validation evidence when `test_command` / `test_result` are omitted
+  - for GitHub thread `clarify` or `defer`: `reply_markdown`
   - optional `validation_commands`
 - `code-review` and `json` producers are consumed once per review run.
 - `adapter` producer is re-run on each iteration.
@@ -302,13 +307,13 @@ Prefer `NEEDS_HUMAN` over speculative fixes when:
 
 ## Agent Feedback
 
-- when the skill itself blocks progress, file a feedback issue against the skill repository before giving up.
-- use feedback issues for skill-level problems such as contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures that are not caused by the repository under review.
-- do not file feedback issues for normal PR findings, code bugs in the target repository, or expected wait states such as `WAITING_FOR_EXTERNAL_REVIEW`.
-- do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues.
-- prefer safe technical diagnostics such as failing command, exit code, status, `reason_code`, `waiting_on`, `run_id`, and skill version.
-- when `--using-repo` and `--using-pr` are present, `submit_feedback.py` auto-collects local PR-workspace evidence from `last-machine-summary.json`, `session.json`, `audit_summary.md`, and cached PR head SHA when those files exist.
-- repeated feedback is deduplicated by fingerprint; if the same feedback issue is already open, or was closed recently inside the cooldown window, the helper returns the existing issue instead of creating a new one.
+- When the skill itself blocks progress, file a feedback issue against the skill repository before giving up.
+- Use feedback issues for skill-level problems such as contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures that are not caused by the repository under review.
+- Do not file feedback issues for normal PR findings, code bugs in the target repository, or expected wait states such as `WAITING_FOR_EXTERNAL_REVIEW`.
+- Do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues.
+- Prefer safe technical diagnostics such as failing command, exit code, status, `reason_code`, `waiting_on`, `run_id`, and skill version.
+- When `--using-repo` and `--using-pr` are present, `submit_feedback.py` auto-collects local PR-workspace evidence from `last-machine-summary.json`, `session.json`, `audit_summary.md`, and cached PR head SHA when those files exist.
+- Repeated feedback is deduplicated by fingerprint; if the same feedback issue is already open, or was closed recently inside the cooldown window, the helper returns the existing issue instead of creating a new one.
 - Use `python3 scripts/submit_feedback.py` with explicit fields so the body matches the repository issue format:
   - `--category`
   - `--title`

--- a/gh-address-cr/SKILL.md
+++ b/gh-address-cr/SKILL.md
@@ -305,6 +305,26 @@ Prefer `NEEDS_HUMAN` over speculative fixes when:
 
 `gh-address-cr` should stop iteration and escalate rather than forcing an implementation under uncertainty.
 
+## Agent Feedback
+
+- when the skill itself blocks progress, file a feedback issue against the skill repository before giving up.
+- use feedback issues for skill-level problems such as contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures that are not caused by the repository under review.
+- do not file feedback issues for normal PR findings, code bugs in the target repository, or expected wait states such as `WAITING_FOR_EXTERNAL_REVIEW`.
+- do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues.
+- prefer safe technical diagnostics such as failing command, exit code, status, `reason_code`, `waiting_on`, `run_id`, and skill version.
+- when `--using-repo` and `--using-pr` are present, `submit_feedback.py` auto-collects local PR-workspace evidence from `last-machine-summary.json`, `session.json`, `audit_summary.md`, and cached PR head SHA when those files exist.
+- repeated feedback is deduplicated by fingerprint; if the same feedback issue is already open, or was closed recently inside the cooldown window, the helper returns the existing issue instead of creating a new one.
+- Use `python3 scripts/submit_feedback.py` with explicit fields so the body matches the repository issue format:
+  - `--category`
+  - `--title`
+  - `--summary`
+  - `--expected`
+  - `--actual`
+  - optional `--source-command`, `--failing-command`, `--exit-code`, `--status`, `--reason-code`, `--waiting-on`, `--run-id`, `--skill-version`, `--using-repo`, `--using-pr`, `--artifact`, and `--notes`
+- Example:
+  - `python3 scripts/submit_feedback.py --category workflow-gap --title "blocked without a recovery step" --summary "review stopped in a blocked state without enough operator guidance." --expected "the skill should identify the next command or artifact to inspect." --actual "the workflow stopped and the next action was ambiguous." --source-command "python3 scripts/cli.py review owner/repo 123" --failing-command "python3 scripts/cli.py final-gate owner/repo 123" --exit-code 5 --status BLOCKED --reason-code WAITING_FOR_FIX --waiting-on human_fix --run-id cr-loop-20260417T120000Z --skill-version 1.2.0 --using-repo owner/repo --using-pr 123 --artifact /tmp/loop-request.json`
+  - `python3 scripts/cli.py submit-feedback --category workflow-gap --title "blocked without a recovery step" --summary "review stopped in a blocked state without enough operator guidance." --expected "the skill should identify the next command or artifact to inspect." --actual "the workflow stopped and the next action was ambiguous."`
+
 ## Required Evidence
 
 - Accepted GitHub thread:
@@ -360,6 +380,7 @@ For run-scoped diagnostics, use:
 - checklist: `references/cr-triage-checklist.md`
 - stable operator surface: `python3 scripts/cli.py`
 - preferred automation surface: `python3 scripts/cli.py ...`
+- AI agent feedback helper: `python3 scripts/submit_feedback.py`
 - code-review bridge prompt: `python3 scripts/cli.py prepare-code-review <local|mixed> <owner/repo> <pr_number>`
 - Markdown-to-findings converter: `python3 scripts/cli.py review-to-findings <owner/repo> <pr_number> --input -`
 - code-review adapter backend: `python3 scripts/cli.py code-review-adapter --input -`

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -10,7 +10,7 @@ interface:
     4. Prefer the default internal fixer path for loop execution; use `--fixer-cmd` only for advanced external integrations.
     5. GitHub review threads require both reply and resolve.
     6. Local findings require valid terminal notes.
-    7. Before any completion statement, run `python3 scripts/cli.py final-gate ...` and summarize the current-run queue counts in natural language. Include total, new in this run, unresolved, and handled in this run for both GitHub threads and local findings; prefer the human-readable `Current Run Snapshot` block and use raw machine count lines only as fallback evidence.
+    7. Before any completion statement, run `python3 scripts/cli.py final-gate ...` and report the gate evidence directly from that run. Include `Verified: 0 Unresolved Threads found`, `Verified: 0 Pending Reviews found`, session blocking item count, and the audit summary path + sha256. Use the machine-readable count lines only when extra run-scoped diagnostics are needed.
     8. If skill usage is blocked by contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures, run `python3 scripts/submit_feedback.py` before giving up. Do not file feedback issues for normal PR findings or codebase bugs.
     9. Do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues. Prefer safe technical diagnostics such as failing command, exit code, status, reason_code, waiting_on, run_id, and skill version.
     10. When possible, provide `--using-repo` and `--using-pr` so feedback can auto-collect the latest local machine summary, session metrics, audit summary hash, and cached PR head SHA. Repeated feedback is deduplicated by fingerprint.

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -11,3 +11,6 @@ interface:
     5. GitHub review threads require both reply and resolve.
     6. Local findings require valid terminal notes.
     7. Before any completion statement, run `python3 scripts/cli.py final-gate ...` and summarize the current-run queue counts in natural language. Include total, new in this run, unresolved, and handled in this run for both GitHub threads and local findings; prefer the human-readable `Current Run Snapshot` block and use raw machine count lines only as fallback evidence.
+    8. If skill usage is blocked by contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures, run `python3 scripts/submit_feedback.py` before giving up. Do not file feedback issues for normal PR findings or codebase bugs.
+    9. Do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues. Prefer safe technical diagnostics such as failing command, exit code, status, reason_code, waiting_on, run_id, and skill version.
+    10. When possible, provide `--using-repo` and `--using-pr` so feedback can auto-collect the latest local machine summary, session metrics, audit summary hash, and cached PR head SHA. Repeated feedback is deduplicated by fingerprint.

--- a/gh-address-cr/agents/openai.yaml
+++ b/gh-address-cr/agents/openai.yaml
@@ -11,6 +11,6 @@ interface:
     5. GitHub review threads require both reply and resolve.
     6. Local findings require valid terminal notes.
     7. Before any completion statement, run `python3 scripts/cli.py final-gate ...` and report the gate evidence directly from that run. Include `Verified: 0 Unresolved Threads found`, `Verified: 0 Pending Reviews found`, session blocking item count, and the audit summary path + sha256. Use the machine-readable count lines only when extra run-scoped diagnostics are needed.
-    8. If skill usage is blocked by contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures, run `python3 scripts/submit_feedback.py` before giving up. Do not file feedback issues for normal PR findings or codebase bugs.
+    8. If skill usage is blocked by contradictory instructions, missing automation, documentation gaps, or repeatable tooling failures, run `python3 scripts/submit_feedback.py` before giving up. Do not file feedback issues for normal PR findings, codebase bugs, or expected wait states such as `WAITING_FOR_EXTERNAL_REVIEW`.
     9. Do not include usernames, emails, tokens, machine names, or absolute local paths in feedback issues. Prefer safe technical diagnostics such as failing command, exit code, status, reason_code, waiting_on, run_id, and skill version.
     10. When possible, provide `--using-repo` and `--using-pr` so feedback can auto-collect the latest local machine summary, session metrics, audit summary hash, and cached PR head SHA. Repeated feedback is deduplicated by fingerprint.

--- a/gh-address-cr/scripts/cli.py
+++ b/gh-address-cr/scripts/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from ingest_findings import normalize_finding, parse_records
 from review_to_findings import parse_findings
 from python_common import incoming_findings_json_file, incoming_findings_markdown_file, normalized_handoff_findings_file
-from python_common import producer_request_file, workspace_dir
+from python_common import last_machine_summary_file, producer_request_file, workspace_dir
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -39,6 +39,7 @@ COMMAND_TO_SCRIPT = {
     "batch-resolve": "batch_resolve.py",
     "clean-state": "clean_state.py",
     "session-engine": "session_engine.py",
+    "submit-feedback": "submit_feedback.py",
 }
 
 HIGH_LEVEL_COMMANDS = {"review", "threads", "findings", "adapter"}
@@ -144,6 +145,11 @@ def alias_help(command: str) -> str:
 
 def workspace_root(repo: str, pr_number: str) -> Path:
     return workspace_dir(repo, pr_number)
+
+
+def persist_machine_summary(repo: str, pr_number: str, payload: dict) -> None:
+    path = last_machine_summary_file(repo, pr_number)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def external_review_command(repo: str, pr_number: str) -> str:
@@ -417,6 +423,7 @@ def output_preflight_error(
             next_action=next_action,
             artifact_path=artifact_path,
         )
+        persist_machine_summary(repo, pr_number, summary)
         sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
     print(message, file=sys.stderr)
     return exit_code
@@ -521,7 +528,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "command",
-        metavar="{review,threads,findings,adapter,review-to-findings}",
+        metavar="{review,threads,findings,adapter,review-to-findings,submit-feedback}",
         help=(
             "High-level commands:\n"
             "  cli.py review owner/repo 123 [--human]\n"
@@ -534,6 +541,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  For `adapter`, flags after <adapter_cmd...> are passed through to the adapter command.\n"
             "Utility commands:\n"
             "  cli.py review-to-findings owner/repo 123 --input finding-blocks.md\n"
+            "  cli.py submit-feedback --category workflow-gap --title ... --summary ... --expected ... --actual ...\n"
             "  review-to-findings accepts fixed finding blocks only, not arbitrary Markdown.\n"
         ),
     )
@@ -569,6 +577,7 @@ def main(argv: list[str] | None = None) -> int:
     result = subprocess.run([sys.executable, str(target), *rewritten_args], text=True, capture_output=True)
     if args.command in HIGH_LEVEL_COMMANDS and not args.human:
         summary = build_machine_summary(args.command, args.args[0], args.args[1], result)
+        persist_machine_summary(args.args[0], args.args[1], summary)
         sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
     else:
         if result.stdout:

--- a/gh-address-cr/scripts/cr_loop.py
+++ b/gh-address-cr/scripts/cr_loop.py
@@ -445,7 +445,8 @@ def build_github_fix_reply(action: dict, item: dict, validation_commands: object
     severity = str(fix_reply.get("severity") or item.get("severity") or "P2").strip().upper()
     why = str(fix_reply.get("why") or "Addressed the CR with minimal targeted changes and regression coverage.").strip()
     test_command = str(fix_reply.get("test_command") or " && ".join(normalized_validation_commands)).strip()
-    test_result = str(fix_reply.get("test_result") or ("passed" if test_command else "")).strip()
+    derived_test_result = "passed" if normalized_validation_commands else ""
+    test_result = str(fix_reply.get("test_result") or derived_test_result).strip()
     if not test_command:
         return None, "GitHub fix actions require fix_reply.test_command or validation_commands."
     if not test_result:

--- a/gh-address-cr/scripts/cr_loop.py
+++ b/gh-address-cr/scripts/cr_loop.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+from generate_reply import fix_reply as render_fix_reply
 import session_engine as engine
 from python_common import findings_file, loop_artifact_file, reply_file, run_cmd as common_run_cmd, snapshot_file, trace_event, validation_file, parse_dispatch, shield_adapter_passthrough, VALID_MODES, VALID_PRODUCERS
 
@@ -393,13 +394,53 @@ def write_internal_fixer_request(repo: str, pr_number: str, *, run_id: str, iter
             "Review the selected item using the current PR context.",
             "Decide one resolution: fix, clarify, or defer.",
             "Produce note text for terminal handling.",
-            "If the item is a GitHub thread, also produce reply_markdown.",
+            "If the item is a GitHub thread and resolution=fix, return fix_reply instead of handwritten reply_markdown.",
+            "fix_reply must include commit_hash and files, and should include why; test_command/test_result may be omitted when validation_commands are provided.",
+            "If the item is a GitHub thread and resolution=clarify or defer, produce reply_markdown.",
             "Write any generated reply markdown inside the PR artifacts directory, not the project workspace.",
         ],
         **payload,
     }
     request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return request_path
+
+
+def build_github_fix_reply(action: dict, item: dict, validation_commands: list[str]) -> tuple[str | None, str]:
+    fix_reply = action.get("fix_reply")
+    if not isinstance(fix_reply, dict):
+        return None, "GitHub fix actions require fix_reply. Raw reply_markdown is not allowed for fix."
+
+    commit_hash = str(fix_reply.get("commit_hash") or "").strip()
+    if not commit_hash:
+        return None, "GitHub fix actions require fix_reply.commit_hash."
+
+    files_value = fix_reply.get("files")
+    if isinstance(files_value, str):
+        files = [part.strip() for part in files_value.split(",") if part.strip()]
+    elif isinstance(files_value, list):
+        files = [str(part).strip() for part in files_value if str(part).strip()]
+    else:
+        files = []
+    if not files:
+        return None, "GitHub fix actions require fix_reply.files."
+
+    severity = str(fix_reply.get("severity") or item.get("severity") or "P2").strip().upper()
+    why = str(fix_reply.get("why") or "Addressed the CR with minimal targeted changes and regression coverage.").strip()
+    test_command = str(fix_reply.get("test_command") or " && ".join(validation_commands)).strip()
+    test_result = str(fix_reply.get("test_result") or ("passed" if test_command else "")).strip()
+    if not test_command:
+        return None, "GitHub fix actions require fix_reply.test_command or validation_commands."
+    if not test_result:
+        return None, "GitHub fix actions require fix_reply.test_result or a derivable validation result."
+
+    try:
+        reply_markdown = render_fix_reply(
+            severity,
+            [commit_hash, ",".join(files), test_command, test_result, why],
+        )
+    except SystemExit as exc:
+        return None, str(exc) or "Invalid fix_reply payload."
+    return reply_markdown, ""
 
 
 def run_validation(commands: list[str]) -> tuple[bool, str]:
@@ -587,9 +628,13 @@ def handle_batch(args: argparse.Namespace, repo: str, pr_number: str, batch_item
                 continue  # Skip this item for now, retry next wave
 
         if item["item_kind"] == "github_thread":
-            reply_markdown = action.get("reply_markdown")
+            if resolution == "fix":
+                reply_markdown, error = build_github_fix_reply(action, item, validation_commands)
+            else:
+                reply_markdown = action.get("reply_markdown")
+                error = ""
             if not reply_markdown:
-                error = "GitHub thread actions require reply_markdown."
+                error = error or "GitHub thread actions require reply_markdown."
                 record_auto_attempt(
                     repo,
                     pr_number,

--- a/gh-address-cr/scripts/cr_loop.py
+++ b/gh-address-cr/scripts/cr_loop.py
@@ -405,7 +405,24 @@ def write_internal_fixer_request(repo: str, pr_number: str, *, run_id: str, iter
     return request_path
 
 
-def build_github_fix_reply(action: dict, item: dict, validation_commands: list[str]) -> tuple[str | None, str]:
+def normalize_validation_commands(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        command = value.strip()
+        return [command] if command else []
+    if isinstance(value, (list, tuple)):
+        commands = []
+        for entry in value:
+            command = str(entry or "").strip()
+            if command:
+                commands.append(command)
+        return commands
+    command = str(value).strip()
+    return [command] if command else []
+
+
+def build_github_fix_reply(action: dict, item: dict, validation_commands: object) -> tuple[str | None, str]:
     fix_reply = action.get("fix_reply")
     if not isinstance(fix_reply, dict):
         return None, "GitHub fix actions require fix_reply. Raw reply_markdown is not allowed for fix."
@@ -424,9 +441,10 @@ def build_github_fix_reply(action: dict, item: dict, validation_commands: list[s
     if not files:
         return None, "GitHub fix actions require fix_reply.files."
 
+    normalized_validation_commands = normalize_validation_commands(validation_commands)
     severity = str(fix_reply.get("severity") or item.get("severity") or "P2").strip().upper()
     why = str(fix_reply.get("why") or "Addressed the CR with minimal targeted changes and regression coverage.").strip()
-    test_command = str(fix_reply.get("test_command") or " && ".join(validation_commands)).strip()
+    test_command = str(fix_reply.get("test_command") or " && ".join(normalized_validation_commands)).strip()
     test_result = str(fix_reply.get("test_result") or ("passed" if test_command else "")).strip()
     if not test_command:
         return None, "GitHub fix actions require fix_reply.test_command or validation_commands."
@@ -597,7 +615,7 @@ def handle_batch(args: argparse.Namespace, repo: str, pr_number: str, batch_item
             persist=True,
         )
 
-        validation_commands = list(action.get("validation_commands") or []) + list(args.validation_cmd or [])
+        validation_commands = normalize_validation_commands(action.get("validation_commands")) + normalize_validation_commands(args.validation_cmd)
         if resolution == "fix" and validation_commands:
             ok, validation_error = run_validation(validation_commands)
             write_validation_record(repo, pr_number, run_id=run_id, iteration=iteration, item_id=item["item_id"], commands=validation_commands, ok=ok, error=validation_error)

--- a/gh-address-cr/scripts/final_gate.py
+++ b/gh-address-cr/scripts/final_gate.py
@@ -25,25 +25,6 @@ def metric_count(data: dict[str, str], key: str) -> int:
     return int(data.get(key, "0"))
 
 
-def print_current_run_snapshot(data: dict[str, str]) -> None:
-    print()
-    print("== Current Run Snapshot ==")
-    print(
-        "GitHub threads: "
-        f"total {metric_count(data, 'github_threads_total_count')}; "
-        f"new in this run {metric_count(data, 'github_threads_new_count')}; "
-        f"unresolved {metric_count(data, 'github_threads_unresolved_count')}; "
-        f"handled in this run {metric_count(data, 'github_threads_handled_this_run_count')}"
-    )
-    print(
-        "Local findings: "
-        f"total {metric_count(data, 'local_findings_total_count')}; "
-        f"new in this run {metric_count(data, 'local_findings_new_count')}; "
-        f"unresolved {metric_count(data, 'local_findings_unresolved_count')}; "
-        f"handled in this run {metric_count(data, 'local_findings_handled_this_run_count')}"
-    )
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the final PR/session gate.")
     auto_group = parser.add_mutually_exclusive_group()
@@ -116,7 +97,6 @@ def main() -> int:
             summary.write_text(Path(summary_from_engine).read_text(encoding="utf-8"), encoding="utf-8")
         if not summary_hash and summary.exists():
             summary_hash = sha256_of_file(summary)
-        print_current_run_snapshot(data)
         print()
         print("== Machine Gate Diagnostics ==")
         print(gate_output.rstrip())
@@ -143,7 +123,6 @@ def main() -> int:
         print(f"\nGate FAILED: {failure_message}. Do not send completion summary.", file=sys.stderr)
         return 3
 
-    print_current_run_snapshot(data)
     print()
     print("== Gate Result ==")
     print("Verified: 0 Unresolved Threads found")

--- a/gh-address-cr/scripts/python_common.py
+++ b/gh-address-cr/scripts/python_common.py
@@ -100,6 +100,10 @@ def normalized_handoff_findings_file(repo: str, pr_number: str) -> Path:
     return findings_file(repo, pr_number, "incoming-findings.normalized.json")
 
 
+def last_machine_summary_file(repo: str, pr_number: str) -> Path:
+    return workspace_dir(repo, pr_number) / "last-machine-summary.json"
+
+
 def reply_file(repo: str, pr_number: str, name: str) -> Path:
     return workspace_dir(repo, pr_number) / name
 

--- a/gh-address-cr/scripts/session_engine.py
+++ b/gh-address-cr/scripts/session_engine.py
@@ -1023,20 +1023,6 @@ def cmd_gate(args):
         f"- unresolved_github_threads_count: {len(unresolved_threads)}",
         f"- invalid_local_items_count: {len(invalid_local_items)}",
         f"- loop_warning_items_count: {len(loop_warning_items)}",
-        "",
-        "## Current Run Snapshot",
-        (
-            f"- GitHub threads: total {progress['github_threads_total_count']}; "
-            f"new in this run {progress['github_threads_new_count']}; "
-            f"unresolved {progress['github_threads_unresolved_count']}; "
-            f"handled in this run {progress['github_threads_handled_this_run_count']}"
-        ),
-        (
-            f"- Local findings: total {progress['local_findings_total_count']}; "
-            f"new in this run {progress['local_findings_new_count']}; "
-            f"unresolved {progress['local_findings_unresolved_count']}; "
-            f"handled in this run {progress['local_findings_handled_this_run_count']}"
-        ),
     ]
     if blocking:
         lines.extend(["", "## Blocking Items"])

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -36,6 +36,7 @@ VALID_CATEGORIES = (
 )
 POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?P<prefix>^|[\s([{\"'<=,`])(?P<path>/[^\s`\"')\]}>;,]+)")
 WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?P<prefix>^|[\s([{\"'<=,`])(?P<path>[A-Za-z]:\\[^\s`\"')\]}>;,]+)")
+FILE_URI_RE = re.compile(r"(?P<prefix>^|[\s([{\"'<=,`])(?P<scheme>file://)(?P<path>/[^\s`\"')\]}>;,]+)")
 EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 TOKEN_PATTERNS = (
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -100,6 +101,10 @@ def compact_absolute_path(value: str) -> str:
         parts = parts[2:]
     elif len(parts) >= 3 and parts[:2] == ["var", "home"]:
         parts = parts[3:]
+    elif len(parts) >= 4 and parts[0] == "mnt" and re.match(r"^[A-Za-z]$", parts[1]) and parts[2] in {"Users", "home"}:
+        parts = parts[4:]
+    elif len(parts) >= 5 and parts[0] == "mnt" and re.match(r"^[A-Za-z]$", parts[1]) and parts[2:4] == ["var", "home"]:
+        parts = parts[5:]
     if not parts:
         return "..."
     return f".../{'/'.join(parts[-3:])}"
@@ -117,6 +122,10 @@ def redact_secret_token(value: str) -> str:
 
 def sanitize_text(value: str) -> str:
     sanitized = redact_secret_token(value)
+    sanitized = FILE_URI_RE.sub(
+        lambda match: f"{match.group('prefix')}{match.group('scheme')}{compact_absolute_path(match.group('path'))}",
+        sanitized,
+    )
     sanitized = POSIX_ABSOLUTE_PATH_RE.sub(
         lambda match: f"{match.group('prefix')}{compact_absolute_path(match.group('path'))}",
         sanitized,

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -138,9 +138,7 @@ def sanitize_text(value: str) -> str:
 
 
 def sanitize_token(token: str) -> str:
-    if token.startswith("/") or is_windows_absolute_path(token):
-        return compact_absolute_path(token)
-    return redact_secret_token(token)
+    return sanitize_text(token)
 
 
 def sanitize_command(value: str | None) -> str | None:
@@ -168,7 +166,7 @@ def sanitize_command(value: str | None) -> str | None:
             if key.lower() in SENSITIVE_VALUE_FLAGS:
                 sanitized_tokens.append(f"{key}=[redacted]")
                 continue
-            sanitized_tokens.append(f"{key}={sanitize_token(raw_value)}")
+            sanitized_tokens.append(sanitize_text(token))
             continue
         sanitized_tokens.append(sanitize_token(token))
     return " ".join(sanitized_tokens)
@@ -429,7 +427,7 @@ def build_issue_body(args: argparse.Namespace, context: dict, fingerprint: str) 
         "",
         "## Reproduction Context",
         "",
-        f"- Agent: `{args.agent}`",
+        f"- Agent: `{sanitize_text(args.agent)}`",
         f"- Skill command: {source_command}",
         f"- Repository under review: {repo_context}",
         f"- Pull request under review: {pr_context}",

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -599,11 +599,22 @@ def main(argv: list[str] | None = None) -> int:
         return emit_result(payload, 0)
 
     request_payload = {"title": args.title, "body": body}
-    result = gh_write_cmd(
-        ["gh", "api", f"repos/{args.target_repo}/issues", "--method", "POST", "--input", "-"],
-        input_text=json.dumps(request_payload),
-        check=False,
-    )
+    try:
+        result = gh_write_cmd(
+            ["gh", "api", f"repos/{args.target_repo}/issues", "--method", "POST", "--input", "-"],
+            input_text=json.dumps(request_payload),
+            check=False,
+        )
+    except SystemExit as exc:
+        payload["error"] = sanitize_error_message(str(exc), "submit feedback failed")
+        write_feedback_audit(
+            args,
+            "failed",
+            "Feedback issue submission failed",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint, "error": payload["error"]},
+        )
+        return emit_result(payload, 1, error_message=payload["error"])
+
     if result.returncode != 0:
         payload["error"] = sanitize_error_message(result.stderr or result.stdout, "submit feedback failed")
         write_feedback_audit(

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -45,9 +45,9 @@ TOKEN_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
     re.compile(r"\bBearer\s+[A-Za-z0-9._-]{16,}\b", re.IGNORECASE),
 )
-SECRET_ASSIGNMENT_RE = re.compile(r"(?i)\b(token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;]+)")
+SECRET_ASSIGNMENT_RE = re.compile(r"(?i)\b(token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;&]+)")
 PRIVATE_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b(username|user|email|hostname|host|machine|machine_name|computer|computer_name)\b([=: ]+)([^\s,;]+)"
+    r"(?i)\b(username|user|email|hostname|host|machine|machine_name|computer|computer_name)\b([=: ]+)([^\s,;&]+)"
 )
 VERSION_RE = re.compile(r"^## \[(?P<version>[^\]]+)\]", re.MULTILINE)
 SENSITIVE_VALUE_FLAGS = {
@@ -72,9 +72,9 @@ def normalize_title(value: str) -> str:
     title = value.strip()
     if not title:
         raise SystemExit("--title must not be empty.")
-    if title.startswith("[AI Feedback] "):
-        return title
-    return f"[AI Feedback] {title}"
+    if not title.startswith("[AI Feedback] "):
+        title = f"[AI Feedback] {title}"
+    return sanitize_text(title)
 
 
 def normalize_text(value: str, *, field_name: str) -> str:
@@ -283,7 +283,6 @@ def load_feedback_context(repo: str | None, pr_number: str | None) -> dict:
 
 def merge_context(args: argparse.Namespace, context: dict) -> None:
     machine_summary = context.get("machine_summary") if isinstance(context.get("machine_summary"), dict) else {}
-    session_payload = context.get("session") if isinstance(context.get("session"), dict) else {}
 
     args.status = args.status or machine_summary.get("status") or context.get("loop_status")
     args.reason_code = args.reason_code or machine_summary.get("reason_code")
@@ -294,8 +293,6 @@ def merge_context(args: argparse.Namespace, context: dict) -> None:
 
     artifact_values = [*args.artifact, *context.get("artifacts", [])]
     args.artifact = unique_preserving_order(artifact_values)
-
-    _ = session_payload
 
 
 def bullet_or_default(items: list[str], *, empty_value: str = "- Not provided.") -> list[str]:
@@ -443,7 +440,7 @@ def build_issue_body(args: argparse.Namespace, context: dict, fingerprint: str) 
         "",
         "## Artifacts",
         "",
-        *bullet_or_default([compact_absolute_path(item) for item in args.artifact]),
+        *bullet_or_default([sanitize_text(item) for item in args.artifact]),
         "",
         "## Additional Notes",
         "",
@@ -470,6 +467,13 @@ def format_lookup_error(exc: Exception) -> str:
     if not detail:
         detail = exc.__class__.__name__
     return sanitize_text(f"feedback issue dedupe lookup failed: {detail}")
+
+
+def sanitize_error_message(value: str | None, fallback: str) -> str:
+    sanitized = sanitize_text(value or "").strip()
+    if not sanitized:
+        return fallback
+    return sanitized[:2000]
 
 
 def audit_scope(args: argparse.Namespace) -> tuple[str, str]:
@@ -584,7 +588,7 @@ def main(argv: list[str] | None = None) -> int:
         check=False,
     )
     if result.returncode != 0:
-        payload["error"] = result.stderr or "submit feedback failed"
+        payload["error"] = sanitize_error_message(result.stderr or result.stdout, "submit feedback failed")
         write_feedback_audit(
             args,
             "failed",

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import quote_plus
 
 from python_common import (
     audit_event,
@@ -25,6 +26,7 @@ from python_common import (
 DEFAULT_TARGET_REPO = "RbBtSn0w/gh-address-cr-skill"
 DEFAULT_COOLDOWN_HOURS = 24
 DEFAULT_FEEDBACK_PR = "feedback"
+DEFAULT_FEEDBACK_SEARCH_PAGE_SIZE = 10
 FINGERPRINT_MARKER_PREFIX = "gh-address-cr-feedback-fingerprint:"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VALID_CATEGORIES = (
@@ -371,25 +373,22 @@ def parse_github_time(value: str | None) -> datetime | None:
         return None
 
 
-def list_existing_feedback_issues(target_repo: str) -> list[dict]:
-    issues: list[dict] = []
-    page = 1
-    while True:
-        response = gh_read_json(["api", f"repos/{target_repo}/issues?state=all&per_page=100&page={page}"])
-        if not response:
-            break
-        if not isinstance(response, list):
-            raise SystemExit("Expected a JSON array when listing existing feedback issues.")
-        issues.extend([issue for issue in response if isinstance(issue, dict) and "pull_request" not in issue])
-        page += 1
-    return issues
+def search_existing_feedback_issues(target_repo: str, fingerprint: str) -> list[dict]:
+    query = f"repo:{target_repo} is:issue {fingerprint} in:body"
+    response = gh_read_json(["api", f"search/issues?q={quote_plus(query)}&per_page={DEFAULT_FEEDBACK_SEARCH_PAGE_SIZE}"])
+    if not isinstance(response, dict):
+        raise SystemExit("Expected a JSON object when searching existing feedback issues.")
+    items = response.get("items")
+    if not isinstance(items, list):
+        raise SystemExit("Expected an `items` array when searching existing feedback issues.")
+    return [issue for issue in items if isinstance(issue, dict) and "pull_request" not in issue]
 
 
 def find_existing_feedback_issue(target_repo: str, fingerprint: str, cooldown_hours: int) -> tuple[str | None, dict | None]:
     now = datetime.now(timezone.utc)
     cooldown_cutoff = now - timedelta(hours=cooldown_hours)
     recent_closed_match: dict | None = None
-    for issue in list_existing_feedback_issues(target_repo):
+    for issue in search_existing_feedback_issues(target_repo, fingerprint):
         issue_fingerprint = extract_feedback_fingerprint(str(issue.get("body") or ""))
         if issue_fingerprint != fingerprint:
             continue
@@ -404,9 +403,9 @@ def find_existing_feedback_issue(target_repo: str, fingerprint: str, cooldown_ho
 
 
 def build_issue_body(args: argparse.Namespace, context: dict, fingerprint: str) -> str:
-    repo_context = f"`{args.using_repo}`" if args.using_repo else "Not provided."
-    pr_context = f"`{args.using_pr}`" if args.using_pr else "Not provided."
-    source_command = f"`{args.source_command}`" if args.source_command else "Not provided."
+    repo_context = f"`{sanitize_text(args.using_repo)}`" if args.using_repo else "Not provided."
+    pr_context = f"`{sanitize_text(args.using_pr)}`" if args.using_pr else "Not provided."
+    source_command = f"`{sanitize_text(args.source_command)}`" if args.source_command else "Not provided."
 
     lines = [
         "## Summary",

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -474,6 +474,24 @@ def sanitize_error_message(value: str | None, fallback: str) -> str:
     return sanitized[:2000]
 
 
+def validate_created_issue_response(response: object) -> tuple[int | None, str | None, str | None]:
+    if not isinstance(response, dict):
+        return None, None, "feedback issue response did not contain a JSON object"
+
+    invalid_fields: list[str] = []
+    issue_number = response.get("number")
+    if not isinstance(issue_number, int) or isinstance(issue_number, bool) or issue_number <= 0:
+        invalid_fields.append("number")
+
+    issue_url = response.get("html_url")
+    if not isinstance(issue_url, str) or not issue_url.strip():
+        invalid_fields.append("html_url")
+
+    if invalid_fields:
+        return None, None, f"feedback issue response missing valid {', '.join(invalid_fields)}"
+    return issue_number, issue_url, None
+
+
 def audit_scope(args: argparse.Namespace) -> tuple[str, str]:
     return args.using_repo or args.target_repo, args.using_pr or DEFAULT_FEEDBACK_PR
 
@@ -607,9 +625,20 @@ def main(argv: list[str] | None = None) -> int:
         )
         return emit_result(payload, 1, error_message=payload["error"])
 
+    issue_number, issue_url, response_error = validate_created_issue_response(response)
+    if response_error:
+        payload["error"] = response_error
+        write_feedback_audit(
+            args,
+            "failed",
+            "Feedback issue response missing required fields",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint, "error": payload["error"]},
+        )
+        return emit_result(payload, 1, error_message=payload["error"])
+
     payload["status"] = "succeeded"
-    payload["issue_number"] = response.get("number")
-    payload["issue_url"] = response.get("html_url")
+    payload["issue_number"] = issue_number
+    payload["issue_url"] = issue_url
     write_feedback_audit(
         args,
         "ok",
@@ -617,8 +646,8 @@ def main(argv: list[str] | None = None) -> int:
         {
             "target_repo": args.target_repo,
             "fingerprint": fingerprint,
-            "issue_number": response.get("number"),
-            "issue_url": response.get("html_url"),
+            "issue_number": issue_number,
+            "issue_url": issue_url,
         },
     )
     return emit_result(payload, 0)

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -47,7 +47,9 @@ TOKEN_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
     re.compile(r"\bBearer\s+[A-Za-z0-9._-]{16,}\b", re.IGNORECASE),
 )
-SECRET_ASSIGNMENT_RE = re.compile(r"(?i)\b(token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;&]+)")
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:[A-Za-z0-9]+[_-])*token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;&]+)"
+)
 PRIVATE_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(username|user|email|hostname|host|machine|machine_name|computer|computer_name)\b([=: ]+)([^\s,;&]+)"
 )

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import re
 import shlex
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -33,8 +34,8 @@ VALID_CATEGORIES = (
     "integration-gap",
     "other",
 )
-POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?P<path>(?<!:)(?<!/)/(?:[^\s`]+))")
-WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?P<path>[A-Za-z]:\\[^\s`]+)")
+POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?P<prefix>^|[\s([{\"'<=,`])(?P<path>/[^\s`\"')\]}>;,]+)")
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?P<prefix>^|[\s([{\"'<=,`])(?P<path>[A-Za-z]:\\[^\s`\"')\]}>;,]+)")
 EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 TOKEN_PATTERNS = (
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -95,6 +96,10 @@ def compact_absolute_path(value: str) -> str:
     parts = [part for part in normalized.split("/") if part]
     if parts and re.match(r"^[A-Za-z]:$", parts[0]):
         parts = parts[1:]
+    if len(parts) >= 2 and parts[0] in {"Users", "home"}:
+        parts = parts[2:]
+    elif len(parts) >= 3 and parts[:2] == ["var", "home"]:
+        parts = parts[3:]
     if not parts:
         return "..."
     return f".../{'/'.join(parts[-3:])}"
@@ -112,8 +117,14 @@ def redact_secret_token(value: str) -> str:
 
 def sanitize_text(value: str) -> str:
     sanitized = redact_secret_token(value)
-    sanitized = POSIX_ABSOLUTE_PATH_RE.sub(lambda match: compact_absolute_path(match.group("path")), sanitized)
-    sanitized = WINDOWS_ABSOLUTE_PATH_RE.sub(lambda match: compact_absolute_path(match.group("path")), sanitized)
+    sanitized = POSIX_ABSOLUTE_PATH_RE.sub(
+        lambda match: f"{match.group('prefix')}{compact_absolute_path(match.group('path'))}",
+        sanitized,
+    )
+    sanitized = WINDOWS_ABSOLUTE_PATH_RE.sub(
+        lambda match: f"{match.group('prefix')}{compact_absolute_path(match.group('path'))}",
+        sanitized,
+    )
     return sanitized
 
 
@@ -442,6 +453,16 @@ def emit_result(payload: dict, exit_code: int, *, error_message: str | None = No
     return exit_code
 
 
+def format_lookup_error(exc: Exception) -> str:
+    if isinstance(exc, subprocess.CalledProcessError):
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+    else:
+        detail = str(exc).strip()
+    if not detail:
+        detail = exc.__class__.__name__
+    return sanitize_text(f"feedback issue dedupe lookup failed: {detail}")
+
+
 def audit_scope(args: argparse.Namespace) -> tuple[str, str]:
     return args.using_repo or args.target_repo, args.using_pr or DEFAULT_FEEDBACK_PR
 
@@ -518,7 +539,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return emit_result(payload, 0)
 
-    dedupe_status, existing_issue = find_existing_feedback_issue(args.target_repo, fingerprint, args.cooldown_hours)
+    try:
+        dedupe_status, existing_issue = find_existing_feedback_issue(args.target_repo, fingerprint, args.cooldown_hours)
+    except (json.JSONDecodeError, subprocess.CalledProcessError, SystemExit) as exc:
+        payload["error"] = format_lookup_error(exc)
+        write_feedback_audit(
+            args,
+            "failed",
+            "Feedback issue dedupe lookup failed",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint, "error": payload["error"]},
+        )
+        return emit_result(payload, 1, error_message=payload["error"])
+
     if existing_issue is not None and dedupe_status is not None:
         payload["status"] = dedupe_status
         payload["issue_number"] = existing_issue.get("number")

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import re
+import shlex
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from python_common import (
+    audit_event,
+    audit_summary_file,
+    gh_read_json,
+    gh_write_cmd,
+    github_pr_cache_file,
+    last_machine_summary_file,
+    session_file,
+    sha256_of_file,
+)
+
+
+DEFAULT_TARGET_REPO = "RbBtSn0w/gh-address-cr-skill"
+DEFAULT_COOLDOWN_HOURS = 24
+DEFAULT_FEEDBACK_PR = "feedback"
+FINGERPRINT_MARKER_PREFIX = "gh-address-cr-feedback-fingerprint:"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALID_CATEGORIES = (
+    "workflow-gap",
+    "tooling-bug",
+    "docs-gap",
+    "integration-gap",
+    "other",
+)
+POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?P<path>(?<!:)(?<!/)/(?:[^\s`]+))")
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?P<path>[A-Za-z]:\\[^\s`]+)")
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+TOKEN_PATTERNS = (
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]{16,}\b", re.IGNORECASE),
+)
+SECRET_ASSIGNMENT_RE = re.compile(r"(?i)\b(token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;]+)")
+PRIVATE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(username|user|email|hostname|host|machine|machine_name|computer|computer_name)\b([=: ]+)([^\s,;]+)"
+)
+VERSION_RE = re.compile(r"^## \[(?P<version>[^\]]+)\]", re.MULTILINE)
+SENSITIVE_VALUE_FLAGS = {
+    "--token",
+    "--secret",
+    "--password",
+    "--api-key",
+    "--api_key",
+    "--email",
+    "--user",
+    "--username",
+    "--host",
+    "--hostname",
+    "--machine",
+    "--machine-name",
+    "--computer",
+    "--computer-name",
+}
+
+
+def normalize_title(value: str) -> str:
+    title = value.strip()
+    if not title:
+        raise SystemExit("--title must not be empty.")
+    if title.startswith("[AI Feedback] "):
+        return title
+    return f"[AI Feedback] {title}"
+
+
+def normalize_text(value: str, *, field_name: str) -> str:
+    text = value.strip()
+    if not text:
+        raise SystemExit(f"{field_name} must not be empty.")
+    return text
+
+
+def is_windows_absolute_path(value: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:[\\/]", value))
+
+
+def compact_absolute_path(value: str) -> str:
+    if not value:
+        return value
+    if not (value.startswith("/") or is_windows_absolute_path(value)):
+        return value
+    normalized = value.replace("\\", "/")
+    parts = [part for part in normalized.split("/") if part]
+    if parts and re.match(r"^[A-Za-z]:$", parts[0]):
+        parts = parts[1:]
+    if not parts:
+        return "..."
+    return f".../{'/'.join(parts[-3:])}"
+
+
+def redact_secret_token(value: str) -> str:
+    redacted = value
+    redacted = EMAIL_RE.sub("[redacted-email]", redacted)
+    for pattern in TOKEN_PATTERNS:
+        redacted = pattern.sub("[redacted-token]", redacted)
+    redacted = SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}[redacted-token]", redacted)
+    redacted = PRIVATE_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}[redacted]", redacted)
+    return redacted
+
+
+def sanitize_text(value: str) -> str:
+    sanitized = redact_secret_token(value)
+    sanitized = POSIX_ABSOLUTE_PATH_RE.sub(lambda match: compact_absolute_path(match.group("path")), sanitized)
+    sanitized = WINDOWS_ABSOLUTE_PATH_RE.sub(lambda match: compact_absolute_path(match.group("path")), sanitized)
+    return sanitized
+
+
+def sanitize_token(token: str) -> str:
+    if token.startswith("/") or is_windows_absolute_path(token):
+        return compact_absolute_path(token)
+    return redact_secret_token(token)
+
+
+def sanitize_command(value: str | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        tokens = shlex.split(value)
+    except ValueError:
+        return sanitize_text(value)
+
+    sanitized_tokens: list[str] = []
+    expects_sensitive_value = False
+    for token in tokens:
+        lower_token = token.lower()
+        if expects_sensitive_value:
+            sanitized_tokens.append("[redacted]")
+            expects_sensitive_value = False
+            continue
+        if lower_token in SENSITIVE_VALUE_FLAGS:
+            sanitized_tokens.append(token)
+            expects_sensitive_value = True
+            continue
+        if "=" in token:
+            key, raw_value = token.split("=", 1)
+            if key.lower() in SENSITIVE_VALUE_FLAGS:
+                sanitized_tokens.append(f"{key}=[redacted]")
+                continue
+            sanitized_tokens.append(f"{key}={sanitize_token(raw_value)}")
+            continue
+        sanitized_tokens.append(sanitize_token(token))
+    return " ".join(sanitized_tokens)
+
+
+def unique_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def load_json_file(path: Path, errors: list[str], *, label: str) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label} was not valid JSON: {exc}")
+        return {}
+    if not isinstance(payload, dict):
+        errors.append(f"{label} did not contain a JSON object.")
+        return {}
+    return payload
+
+
+def extract_artifact_path(last_error: str) -> str | None:
+    prefix = "Internal fixer action required:"
+    if prefix in last_error:
+        candidate = last_error.split(prefix, 1)[1].strip()
+        if candidate:
+            return candidate
+    match = re.search(r"((?<!:)(?<!/)/(?:\S+\.json)|[A-Za-z]:\\\S+\.json)", last_error)
+    if match:
+        return match.group(1)
+    return None
+
+
+def detect_skill_version() -> str | None:
+    changelog = REPO_ROOT / "CHANGELOG.md"
+    if not changelog.exists():
+        return None
+    match = VERSION_RE.search(changelog.read_text(encoding="utf-8"))
+    if not match:
+        return None
+    return match.group("version")
+
+
+def load_feedback_context(repo: str | None, pr_number: str | None) -> dict:
+    context = {
+        "errors": [],
+        "artifacts": [],
+        "head_sha": None,
+        "current_item_id": None,
+        "session_status": None,
+        "loop_status": None,
+        "blocking_items_count": None,
+        "open_local_findings_count": None,
+        "unresolved_github_threads_count": None,
+        "needs_human_items_count": None,
+        "audit_summary_sha256": None,
+    }
+    if not repo or not pr_number:
+        return context
+
+    summary_path = last_machine_summary_file(repo, pr_number)
+    summary_payload = load_json_file(summary_path, context["errors"], label="last-machine-summary.json")
+    context["machine_summary"] = summary_payload
+    if summary_payload.get("artifact_path"):
+        context["artifacts"].append(str(summary_payload["artifact_path"]))
+    if summary_payload.get("item_id"):
+        context["current_item_id"] = str(summary_payload["item_id"])
+
+    session_path = session_file(repo, pr_number)
+    session_payload = load_json_file(session_path, context["errors"], label="session.json")
+    context["session"] = session_payload
+    if session_payload:
+        context["session_status"] = session_payload.get("status")
+        metrics = session_payload.get("metrics")
+        if isinstance(metrics, dict):
+            context["blocking_items_count"] = metrics.get("blocking_items_count")
+            context["open_local_findings_count"] = metrics.get("open_local_findings_count")
+            context["unresolved_github_threads_count"] = metrics.get("unresolved_github_threads_count")
+            context["needs_human_items_count"] = metrics.get("needs_human_items_count")
+        loop_state = session_payload.get("loop_state")
+        if isinstance(loop_state, dict):
+            context["loop_status"] = loop_state.get("status")
+            context["run_id"] = loop_state.get("run_id")
+            if not context["current_item_id"]:
+                context["current_item_id"] = loop_state.get("current_item_id")
+            last_error = str(loop_state.get("last_error") or "")
+            artifact_path = extract_artifact_path(last_error)
+            if artifact_path:
+                context["artifacts"].append(artifact_path)
+
+    cache_path = github_pr_cache_file(repo, pr_number)
+    cache_payload = load_json_file(cache_path, context["errors"], label="github_pr_cache.json")
+    context["head_sha"] = cache_payload.get("head_sha")
+
+    audit_path = audit_summary_file(repo, pr_number)
+    if audit_path.exists():
+        context["audit_summary_sha256"] = sha256_of_file(audit_path)
+        context["artifacts"].append(str(audit_path))
+
+    context["artifacts"] = unique_preserving_order(context["artifacts"])
+    return context
+
+
+def merge_context(args: argparse.Namespace, context: dict) -> None:
+    machine_summary = context.get("machine_summary") if isinstance(context.get("machine_summary"), dict) else {}
+    session_payload = context.get("session") if isinstance(context.get("session"), dict) else {}
+
+    args.status = args.status or machine_summary.get("status") or context.get("loop_status")
+    args.reason_code = args.reason_code or machine_summary.get("reason_code")
+    args.waiting_on = args.waiting_on or machine_summary.get("waiting_on")
+    args.exit_code = args.exit_code if args.exit_code is not None else machine_summary.get("exit_code")
+    args.run_id = args.run_id or context.get("run_id")
+    args.skill_version = args.skill_version or detect_skill_version()
+
+    artifact_values = [*args.artifact, *context.get("artifacts", [])]
+    args.artifact = unique_preserving_order(artifact_values)
+
+    _ = session_payload
+
+
+def bullet_or_default(items: list[str], *, empty_value: str = "- Not provided.") -> list[str]:
+    if not items:
+        return [empty_value]
+    return [f"- `{item}`" for item in items]
+
+
+def technical_diagnostics(args: argparse.Namespace, context: dict) -> list[str]:
+    values = []
+    if args.failing_command:
+        values.append(f"- Failing command: `{args.failing_command}`")
+    if args.exit_code is not None:
+        values.append(f"- Exit code: `{args.exit_code}`")
+    if args.status:
+        values.append(f"- Status: `{args.status}`")
+    if args.reason_code:
+        values.append(f"- Reason code: `{args.reason_code}`")
+    if args.waiting_on:
+        values.append(f"- Waiting on: `{args.waiting_on}`")
+    if args.run_id:
+        values.append(f"- Run ID: `{args.run_id}`")
+    if args.skill_version:
+        values.append(f"- Skill version: `{args.skill_version}`")
+    if context.get("head_sha"):
+        values.append(f"- Head SHA: `{context['head_sha']}`")
+    if context.get("current_item_id"):
+        values.append(f"- Current item ID: `{context['current_item_id']}`")
+    if context.get("session_status"):
+        values.append(f"- Session status: `{context['session_status']}`")
+    if context.get("loop_status"):
+        values.append(f"- Loop status: `{context['loop_status']}`")
+    if context.get("blocking_items_count") is not None:
+        values.append(f"- Session blocking items: `{context['blocking_items_count']}`")
+    if context.get("open_local_findings_count") is not None:
+        values.append(f"- Open local findings: `{context['open_local_findings_count']}`")
+    if context.get("unresolved_github_threads_count") is not None:
+        values.append(f"- Unresolved GitHub threads: `{context['unresolved_github_threads_count']}`")
+    if context.get("needs_human_items_count") is not None:
+        values.append(f"- Needs-human items: `{context['needs_human_items_count']}`")
+    if context.get("audit_summary_sha256"):
+        values.append(f"- Audit summary SHA256: `{context['audit_summary_sha256']}`")
+    for error in context.get("errors", []):
+        values.append(f"- Context load warning: {sanitize_text(error)}")
+    return values or ["- Not provided."]
+
+
+def build_fingerprint_payload(args: argparse.Namespace) -> dict:
+    return {
+        "category": args.category,
+        "title": args.title,
+        "summary": sanitize_text(args.summary),
+        "expected": sanitize_text(args.expected),
+        "actual": sanitize_text(args.actual),
+        "source_command": args.source_command or "",
+        "failing_command": args.failing_command or "",
+    }
+
+
+def compute_feedback_fingerprint(args: argparse.Namespace) -> str:
+    payload = build_fingerprint_payload(args)
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def extract_feedback_fingerprint(body: str) -> str | None:
+    marker = re.search(rf"{re.escape(FINGERPRINT_MARKER_PREFIX)}\s*([0-9a-f]{{64}})", body or "")
+    if not marker:
+        return None
+    return marker.group(1)
+
+
+def parse_github_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def list_existing_feedback_issues(target_repo: str) -> list[dict]:
+    issues: list[dict] = []
+    page = 1
+    while True:
+        response = gh_read_json(["api", f"repos/{target_repo}/issues?state=all&per_page=100&page={page}"])
+        if not response:
+            break
+        if not isinstance(response, list):
+            raise SystemExit("Expected a JSON array when listing existing feedback issues.")
+        issues.extend([issue for issue in response if isinstance(issue, dict) and "pull_request" not in issue])
+        page += 1
+    return issues
+
+
+def find_existing_feedback_issue(target_repo: str, fingerprint: str, cooldown_hours: int) -> tuple[str | None, dict | None]:
+    now = datetime.now(timezone.utc)
+    cooldown_cutoff = now - timedelta(hours=cooldown_hours)
+    recent_closed_match: dict | None = None
+    for issue in list_existing_feedback_issues(target_repo):
+        issue_fingerprint = extract_feedback_fingerprint(str(issue.get("body") or ""))
+        if issue_fingerprint != fingerprint:
+            continue
+        if issue.get("state") == "open":
+            return "duplicate", issue
+        closed_at = parse_github_time(issue.get("closed_at") or issue.get("updated_at"))
+        if closed_at and closed_at >= cooldown_cutoff:
+            recent_closed_match = issue
+    if recent_closed_match is not None:
+        return "cooldown", recent_closed_match
+    return None, None
+
+
+def build_issue_body(args: argparse.Namespace, context: dict, fingerprint: str) -> str:
+    repo_context = f"`{args.using_repo}`" if args.using_repo else "Not provided."
+    pr_context = f"`{args.using_pr}`" if args.using_pr else "Not provided."
+    source_command = f"`{args.source_command}`" if args.source_command else "Not provided."
+
+    lines = [
+        "## Summary",
+        "",
+        sanitize_text(args.summary),
+        "",
+        "## Category",
+        "",
+        f"- {args.category}",
+        "",
+        "## Expected Workflow",
+        "",
+        sanitize_text(args.expected),
+        "",
+        "## Actual Behavior",
+        "",
+        sanitize_text(args.actual),
+        "",
+        "## Reproduction Context",
+        "",
+        f"- Agent: `{args.agent}`",
+        f"- Skill command: {source_command}",
+        f"- Repository under review: {repo_context}",
+        f"- Pull request under review: {pr_context}",
+        "",
+        "## Technical Diagnostics",
+        "",
+        *technical_diagnostics(args, context),
+        "",
+        "## Artifacts",
+        "",
+        *bullet_or_default([compact_absolute_path(item) for item in args.artifact]),
+        "",
+        "## Additional Notes",
+        "",
+        sanitize_text(args.notes) if args.notes else "None.",
+        "",
+        f"<!-- {FINGERPRINT_MARKER_PREFIX} {fingerprint} -->",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def emit_result(payload: dict, exit_code: int, *, error_message: str | None = None) -> int:
+    sys.stdout.write(json.dumps(payload))
+    if error_message:
+        print(error_message, file=sys.stderr)
+    return exit_code
+
+
+def audit_scope(args: argparse.Namespace) -> tuple[str, str]:
+    return args.using_repo or args.target_repo, args.using_pr or DEFAULT_FEEDBACK_PR
+
+
+def write_feedback_audit(args: argparse.Namespace, status: str, message: str, details: dict) -> None:
+    repo, pr_number = audit_scope(args)
+    audit_event("submit_feedback", status, repo, pr_number, args.audit_id, message, details)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a structured AI-agent feedback issue for gh-address-cr-skill.")
+    parser.add_argument("--target-repo", default=DEFAULT_TARGET_REPO)
+    parser.add_argument("--agent", default="ai-agent")
+    parser.add_argument("--audit-id", default="default")
+    parser.add_argument("--cooldown-hours", type=int, default=DEFAULT_COOLDOWN_HOURS)
+    parser.add_argument("--category", required=True, choices=VALID_CATEGORIES)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--expected", required=True)
+    parser.add_argument("--actual", required=True)
+    parser.add_argument("--source-command")
+    parser.add_argument("--failing-command")
+    parser.add_argument("--exit-code", type=int)
+    parser.add_argument("--status")
+    parser.add_argument("--reason-code")
+    parser.add_argument("--waiting-on")
+    parser.add_argument("--run-id")
+    parser.add_argument("--skill-version")
+    parser.add_argument("--using-repo")
+    parser.add_argument("--using-pr")
+    parser.add_argument("--artifact", action="append", default=[])
+    parser.add_argument("--notes")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    if args.using_pr and not args.using_repo:
+        parser.error("--using-pr requires --using-repo.")
+    if args.cooldown_hours < 0:
+        parser.error("--cooldown-hours must be >= 0.")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    args.title = normalize_title(args.title)
+    args.summary = normalize_text(args.summary, field_name="--summary")
+    args.expected = normalize_text(args.expected, field_name="--expected")
+    args.actual = normalize_text(args.actual, field_name="--actual")
+    args.source_command = sanitize_command(args.source_command)
+    args.failing_command = sanitize_command(args.failing_command)
+
+    context = load_feedback_context(args.using_repo, args.using_pr)
+    merge_context(args, context)
+    fingerprint = compute_feedback_fingerprint(args)
+    body = build_issue_body(args, context, fingerprint)
+
+    payload = {
+        "status": "failed",
+        "target_repo": args.target_repo,
+        "issue_number": None,
+        "issue_url": None,
+        "title": args.title,
+        "body": body,
+        "fingerprint": fingerprint,
+        "error": None,
+    }
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_feedback_audit(
+            args,
+            "dry-run",
+            "Previewed feedback issue submission",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint},
+        )
+        return emit_result(payload, 0)
+
+    dedupe_status, existing_issue = find_existing_feedback_issue(args.target_repo, fingerprint, args.cooldown_hours)
+    if existing_issue is not None and dedupe_status is not None:
+        payload["status"] = dedupe_status
+        payload["issue_number"] = existing_issue.get("number")
+        payload["issue_url"] = existing_issue.get("html_url")
+        write_feedback_audit(
+            args,
+            dedupe_status,
+            "Skipped feedback issue creation because a matching issue already exists",
+            {
+                "target_repo": args.target_repo,
+                "fingerprint": fingerprint,
+                "existing_issue_number": existing_issue.get("number"),
+                "existing_issue_url": existing_issue.get("html_url"),
+            },
+        )
+        return emit_result(payload, 0)
+
+    request_payload = {"title": args.title, "body": body}
+    result = gh_write_cmd(
+        ["gh", "api", f"repos/{args.target_repo}/issues", "--method", "POST", "--input", "-"],
+        input_text=json.dumps(request_payload),
+        check=False,
+    )
+    if result.returncode != 0:
+        payload["error"] = result.stderr or "submit feedback failed"
+        write_feedback_audit(
+            args,
+            "failed",
+            "Feedback issue submission failed",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint, "error": payload["error"]},
+        )
+        return emit_result(payload, 1, error_message=payload["error"])
+
+    try:
+        response = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        payload["error"] = "feedback issue response was not valid JSON"
+        write_feedback_audit(
+            args,
+            "failed",
+            "Feedback issue response was not valid JSON",
+            {"target_repo": args.target_repo, "fingerprint": fingerprint, "error": payload["error"]},
+        )
+        return emit_result(payload, 1, error_message=payload["error"])
+
+    payload["status"] = "succeeded"
+    payload["issue_number"] = response.get("number")
+    payload["issue_url"] = response.get("html_url")
+    write_feedback_audit(
+        args,
+        "ok",
+        "Created feedback issue",
+        {
+            "target_repo": args.target_repo,
+            "fingerprint": fingerprint,
+            "issue_number": response.get("number"),
+            "issue_url": response.get("html_url"),
+        },
+    )
+    return emit_result(payload, 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gh-address-cr/scripts/submit_feedback.py
+++ b/gh-address-cr/scripts/submit_feedback.py
@@ -166,7 +166,7 @@ def sanitize_command(value: str | None) -> str | None:
             expects_sensitive_value = True
             continue
         if "=" in token:
-            key, raw_value = token.split("=", 1)
+            key, _ = token.split("=", 1)
             if key.lower() in SENSITIVE_VALUE_FLAGS:
                 sanitized_tokens.append(f"{key}=[redacted]")
                 continue

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,7 @@ PREPARE_CODE_REVIEW_PY = SCRIPTS_DIR / "prepare_code_review.py"
 CODE_REVIEW_ADAPTER_PY = SCRIPTS_DIR / "code_review_adapter.py"
 REVIEW_TO_FINDINGS_PY = SCRIPTS_DIR / "review_to_findings.py"
 PYTHON_COMMON_PY = SCRIPTS_DIR / "python_common.py"
+SUBMIT_FEEDBACK_PY = SCRIPTS_DIR / "submit_feedback.py"
 
 
 class SessionEngineTestCase(unittest.TestCase):

--- a/tests/test_aux_scripts.py
+++ b/tests/test_aux_scripts.py
@@ -210,6 +210,33 @@ class AuxiliaryScriptsTest(PythonScriptTestCase):
         self.assertIn("https://example.com/log?token=[redacted-token]&owner=[redacted-email]", payload["body"])
         self.assertIn("`.../gh-address-cr-skill/tmp/state.json`", payload["body"])
 
+    def test_submit_feedback_sanitizes_agent_name_in_dry_run(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--dry-run",
+                "--category",
+                "tooling-bug",
+                "--agent",
+                "/Users/snow/private ghp_abcdefghijklmnopqrstuvwxyz12 alice@example.com",
+                "--title",
+                "agent redaction",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIn("- Agent: `.../private [redacted-token] [redacted-email]`", payload["body"])
+        self.assertNotIn("/Users/snow/private", payload["body"])
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", payload["body"])
+        self.assertNotIn("alice@example.com", payload["body"])
+
     def test_submit_feedback_posts_issue_via_github_api(self):
         gh = self.bin_dir / "gh"
         request_path = Path(self.temp_dir.name) / "issue_request.json"

--- a/tests/test_aux_scripts.py
+++ b/tests/test_aux_scripts.py
@@ -176,6 +176,40 @@ class AuxiliaryScriptsTest(PythonScriptTestCase):
         self.assertNotIn("/Users/snow", payload["body"])
         self.assertIn("## Additional Notes", payload["body"])
 
+    def test_submit_feedback_sanitizes_title_and_artifacts_in_dry_run(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--dry-run",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "/Users/snow/private ghp_abcdefghijklmnopqrstuvwxyz12 alice@example.com",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+                "--artifact",
+                "https://example.com/log?token=ghp_abcdefghijklmnopqrstuvwxyz12&owner=alice@example.com",
+                "--artifact",
+                "/Users/snow/Documents/GitHub/gh-address-cr-skill/tmp/state.json",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "dry-run")
+        self.assertTrue(payload["title"].startswith("[AI Feedback] "))
+        self.assertNotIn("/Users/snow/private", payload["title"])
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", payload["title"])
+        self.assertNotIn("alice@example.com", payload["title"])
+        self.assertIn("[redacted-token]", payload["title"])
+        self.assertIn("[redacted-email]", payload["title"])
+        self.assertIn("https://example.com/log?token=[redacted-token]&owner=[redacted-email]", payload["body"])
+        self.assertIn("`.../gh-address-cr-skill/tmp/state.json`", payload["body"])
+
     def test_submit_feedback_posts_issue_via_github_api(self):
         gh = self.bin_dir / "gh"
         request_path = Path(self.temp_dir.name) / "issue_request.json"

--- a/tests/test_aux_scripts.py
+++ b/tests/test_aux_scripts.py
@@ -237,6 +237,36 @@ class AuxiliaryScriptsTest(PythonScriptTestCase):
         self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", payload["body"])
         self.assertNotIn("alice@example.com", payload["body"])
 
+    def test_submit_feedback_sanitizes_review_context_fields_in_dry_run(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--dry-run",
+                "--category",
+                "workflow-gap",
+                "--title",
+                "review context redaction",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+                "--using-repo",
+                "/Users/snow/private ghp_abcdefghijklmnopqrstuvwxyz12",
+                "--using-pr",
+                "alice@example.com",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIn("- Repository under review: `.../private [redacted-token]`", payload["body"])
+        self.assertIn("- Pull request under review: `[redacted-email]`", payload["body"])
+        self.assertNotIn("/Users/snow/private", payload["body"])
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", payload["body"])
+        self.assertNotIn("alice@example.com", payload["body"])
+
     def test_submit_feedback_posts_issue_via_github_api(self):
         gh = self.bin_dir / "gh"
         request_path = Path(self.temp_dir.name) / "issue_request.json"
@@ -248,8 +278,8 @@ from pathlib import Path
 
 request_path = Path({str(request_path)!r})
 args = sys.argv[1:]
-if args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
-    print('[]')
+if len(args) >= 2 and args[0] == 'api' and args[1].startswith('search/issues?q=repo%3ARbBtSn0w%2Fgh-address-cr-skill+') and args[1].endswith('&per_page=10'):
+    print(json.dumps({{'items': []}}))
 elif args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
     payload = json.load(sys.stdin)
     request_path.write_text(json.dumps(payload), encoding='utf-8')
@@ -401,10 +431,8 @@ fingerprint_payload = {{
     'failing_command': '',
 }}
 fingerprint = hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True, separators=(',', ':')).encode('utf-8')).hexdigest()
-if args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
-    print(json.dumps([{{'number': 88, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/88', 'state': 'open', 'body': f'<!-- gh-address-cr-feedback-fingerprint: {{fingerprint}} -->'}}]))
-elif args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=2']:
-    print('[]')
+if len(args) >= 2 and args[0] == 'api' and args[1] == f'search/issues?q=repo%3ARbBtSn0w%2Fgh-address-cr-skill+is%3Aissue+{{fingerprint}}+in%3Abody&per_page=10':
+    print(json.dumps({{'items': [{{'number': 88, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/88', 'state': 'open', 'body': f'<!-- gh-address-cr-feedback-fingerprint: {{fingerprint}} -->'}}]}}))
 elif args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
     raise SystemExit('create should not be called')
 else:
@@ -436,6 +464,7 @@ else:
         self.assertEqual(payload["issue_number"], 88)
         calls = json.loads(calls_path.read_text(encoding="utf-8"))
         self.assertFalse(any(call[:4] == ["api", "repos/RbBtSn0w/gh-address-cr-skill/issues", "--method", "POST"] for call in calls))
+        self.assertTrue(any(call[:2] == ["api", f"search/issues?q=repo%3ARbBtSn0w%2Fgh-address-cr-skill+is%3Aissue+{payload['fingerprint']}+in%3Abody&per_page=10"] for call in calls))
 
     def test_submit_feedback_writes_local_audit_event(self):
         gh = self.bin_dir / "gh"
@@ -447,8 +476,8 @@ import sys
 args = sys.argv[1:]
 if args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
     print(json.dumps({'number': 322, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/322'}))
-elif args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
-    print('[]')
+elif len(args) >= 2 and args[0] == 'api' and args[1].startswith('search/issues?q=repo%3ARbBtSn0w%2Fgh-address-cr-skill+') and args[1].endswith('&per_page=10'):
+    print(json.dumps({'items': []}))
 else:
     raise SystemExit(f'unhandled gh args: {args}')
 """,

--- a/tests/test_aux_scripts.py
+++ b/tests/test_aux_scripts.py
@@ -4,7 +4,15 @@ import os
 import sys
 from pathlib import Path
 
-from tests.helpers import BATCH_RESOLVE_PY, CLEAN_STATE_PY, GENERATE_REPLY_PY, PYTHON_COMMON_PY, PythonScriptTestCase, RUN_ONCE_PY
+from tests.helpers import (
+    BATCH_RESOLVE_PY,
+    CLEAN_STATE_PY,
+    GENERATE_REPLY_PY,
+    PYTHON_COMMON_PY,
+    PythonScriptTestCase,
+    RUN_ONCE_PY,
+    SUBMIT_FEEDBACK_PY,
+)
 
 
 class AuxiliaryScriptsTest(PythonScriptTestCase):
@@ -101,6 +109,321 @@ class AuxiliaryScriptsTest(PythonScriptTestCase):
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Invalid severity", result.stderr)
+
+    def test_submit_feedback_dry_run_outputs_canonical_issue_body(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--dry-run",
+                "--category",
+                "workflow-gap",
+                "--title",
+                "review command left an ambiguous blocked state",
+                "--summary",
+                "The skill did not explain which step should happen next.",
+                "--expected",
+                "The skill should tell the agent which command or artifact to inspect next.",
+                "--actual",
+                "The run stopped with a blocked status and no actionable recovery path.",
+                "--source-command",
+                "python3 /Users/snow/Documents/GitHub/gh-address-cr-skill/gh-address-cr/scripts/cli.py review octo/example 77",
+                "--failing-command",
+                "python3 /Users/snow/Documents/GitHub/gh-address-cr-skill/gh-address-cr/scripts/final_gate.py octo/example 77",
+                "--exit-code",
+                "5",
+                "--status",
+                "BLOCKED",
+                "--reason-code",
+                "WAITING_FOR_FIX",
+                "--waiting-on",
+                "human_fix",
+                "--run-id",
+                "cr-loop-20260417T120000Z",
+                "--skill-version",
+                "1.2.0",
+                "--using-repo",
+                "octo/example",
+                "--using-pr",
+                "77",
+                "--artifact",
+                "/Users/snow/Documents/GitHub/gh-address-cr-skill/tmp/pr-77/blocker.json",
+                "--notes",
+                "Happened after the second retry.",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "dry-run")
+        self.assertEqual(payload["target_repo"], "RbBtSn0w/gh-address-cr-skill")
+        self.assertTrue(payload["title"].startswith("[AI Feedback] "))
+        self.assertIn("## Summary", payload["body"])
+        self.assertIn("## Category", payload["body"])
+        self.assertIn("workflow-gap", payload["body"])
+        self.assertIn("## Expected Workflow", payload["body"])
+        self.assertIn("## Actual Behavior", payload["body"])
+        self.assertIn("## Reproduction Context", payload["body"])
+        self.assertIn("## Technical Diagnostics", payload["body"])
+        self.assertIn("`python3 .../gh-address-cr/scripts/cli.py review octo/example 77`", payload["body"])
+        self.assertIn("`python3 .../gh-address-cr/scripts/final_gate.py octo/example 77`", payload["body"])
+        self.assertIn("- Exit code: `5`", payload["body"])
+        self.assertIn("- Status: `BLOCKED`", payload["body"])
+        self.assertIn("- Reason code: `WAITING_FOR_FIX`", payload["body"])
+        self.assertIn("- Waiting on: `human_fix`", payload["body"])
+        self.assertIn("- Run ID: `cr-loop-20260417T120000Z`", payload["body"])
+        self.assertIn("- Skill version: `1.2.0`", payload["body"])
+        self.assertIn("`.../tmp/pr-77/blocker.json`", payload["body"])
+        self.assertNotIn("/Users/snow", payload["body"])
+        self.assertIn("## Additional Notes", payload["body"])
+
+    def test_submit_feedback_posts_issue_via_github_api(self):
+        gh = self.bin_dir / "gh"
+        request_path = Path(self.temp_dir.name) / "issue_request.json"
+        gh.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+request_path = Path({str(request_path)!r})
+args = sys.argv[1:]
+if args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
+    print('[]')
+elif args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
+    payload = json.load(sys.stdin)
+    request_path.write_text(json.dumps(payload), encoding='utf-8')
+    print(json.dumps({{'number': 321, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/321'}}))
+else:
+    raise SystemExit(f'unhandled gh args: {{args}}')
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--category",
+                "tooling-bug",
+                "--title",
+                "submit feedback should create a GitHub issue",
+                "--summary",
+                "Need a structured feedback issue for the skill.",
+                "--expected",
+                "A new issue should be created in the skill repo.",
+                "--actual",
+                "The agent had no standardized place to report the problem.",
+                "--failing-command",
+                "python3 /Users/snow/Documents/GitHub/gh-address-cr-skill/gh-address-cr/scripts/control_plane.py mixed json octo/example 77",
+                "--exit-code",
+                "2",
+                "--status",
+                "FAILED",
+                "--reason-code",
+                "INVALID_PRODUCER_OUTPUT",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "succeeded")
+        self.assertEqual(payload["issue_number"], 321)
+        self.assertEqual(
+            payload["issue_url"],
+            "https://github.com/RbBtSn0w/gh-address-cr-skill/issues/321",
+        )
+        issue_request = json.loads(request_path.read_text(encoding="utf-8"))
+        self.assertTrue(issue_request["title"].startswith("[AI Feedback] "))
+        self.assertIn("## Summary", issue_request["body"])
+        self.assertIn("## Actual Behavior", issue_request["body"])
+        self.assertIn("## Technical Diagnostics", issue_request["body"])
+        self.assertIn("INVALID_PRODUCER_OUTPUT", issue_request["body"])
+        self.assertIn("tooling-bug", issue_request["body"])
+        self.assertNotIn("/Users/snow", issue_request["body"])
+
+    def test_submit_feedback_auto_collects_workspace_evidence_without_user_paths(self):
+        workspace = self.workspace_dir()
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / "last-machine-summary.json").write_text(
+            json.dumps(
+                {
+                    "status": "BLOCKED",
+                    "reason_code": "WAITING_FOR_FIX",
+                    "waiting_on": "human_fix",
+                    "exit_code": 5,
+                    "item_id": "github-thread:THREAD_9",
+                    "artifact_path": "/Users/snow/Documents/GitHub/gh-address-cr-skill/tmp/loop-request.json",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (workspace / "session.json").write_text(
+            json.dumps(
+                {
+                    "status": "ACTIVE",
+                    "metrics": {
+                        "blocking_items_count": 2,
+                        "open_local_findings_count": 1,
+                        "unresolved_github_threads_count": 1,
+                        "needs_human_items_count": 1,
+                    },
+                    "loop_state": {
+                        "run_id": "run-777",
+                        "status": "BLOCKED",
+                        "current_item_id": "github-thread:THREAD_9",
+                        "last_error": "Internal fixer action required: /Users/snow/Documents/GitHub/gh-address-cr-skill/tmp/loop-request.json",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (workspace / "audit_summary.md").write_text("summary", encoding="utf-8")
+        (workspace / "github_pr_cache.json").write_text(json.dumps({"head_sha": "cafebabe"}), encoding="utf-8")
+
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--dry-run",
+                "--category",
+                "workflow-gap",
+                "--title",
+                "auto evidence should be collected",
+                "--summary",
+                "The script should absorb recent technical context automatically.",
+                "--expected",
+                "Feedback should include recent run evidence.",
+                "--actual",
+                "Operators currently have to add every diagnostic field manually.",
+                "--using-repo",
+                self.repo,
+                "--using-pr",
+                self.pr,
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIn("- Exit code: `5`", payload["body"])
+        self.assertIn("- Status: `BLOCKED`", payload["body"])
+        self.assertIn("- Reason code: `WAITING_FOR_FIX`", payload["body"])
+        self.assertIn("- Waiting on: `human_fix`", payload["body"])
+        self.assertIn("- Run ID: `run-777`", payload["body"])
+        self.assertIn("- Head SHA: `cafebabe`", payload["body"])
+        self.assertIn("- Current item ID: `github-thread:THREAD_9`", payload["body"])
+        self.assertIn("- Session blocking items: `2`", payload["body"])
+        self.assertIn("- Audit summary SHA256:", payload["body"])
+        self.assertIn("loop-request.json", payload["body"])
+        self.assertNotIn("/Users/snow", payload["body"])
+
+    def test_submit_feedback_reuses_existing_open_issue_for_same_fingerprint(self):
+        gh = self.bin_dir / "gh"
+        calls_path = Path(self.temp_dir.name) / "gh_calls.json"
+        gh.write_text(
+            f"""#!/usr/bin/env python3
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+calls_path = Path({str(calls_path)!r})
+calls = json.loads(calls_path.read_text(encoding='utf-8')) if calls_path.exists() else []
+args = sys.argv[1:]
+calls.append(args)
+calls_path.write_text(json.dumps(calls), encoding='utf-8')
+fingerprint_payload = {{
+    'category': 'workflow-gap',
+    'title': '[AI Feedback] duplicate feedback',
+    'summary': 'Same summary',
+    'expected': 'Same expected',
+    'actual': 'Same actual',
+    'source_command': '',
+    'failing_command': '',
+}}
+fingerprint = hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True, separators=(',', ':')).encode('utf-8')).hexdigest()
+if args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
+    print(json.dumps([{{'number': 88, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/88', 'state': 'open', 'body': f'<!-- gh-address-cr-feedback-fingerprint: {{fingerprint}} -->'}}]))
+elif args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=2']:
+    print('[]')
+elif args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
+    raise SystemExit('create should not be called')
+else:
+    raise SystemExit(f'unhandled gh args: {{args}}')
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--category",
+                "workflow-gap",
+                "--title",
+                "duplicate feedback",
+                "--summary",
+                "Same summary",
+                "--expected",
+                "Same expected",
+                "--actual",
+                "Same actual",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "duplicate")
+        self.assertEqual(payload["issue_number"], 88)
+        calls = json.loads(calls_path.read_text(encoding="utf-8"))
+        self.assertFalse(any(call[:4] == ["api", "repos/RbBtSn0w/gh-address-cr-skill/issues", "--method", "POST"] for call in calls))
+
+    def test_submit_feedback_writes_local_audit_event(self):
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+if args[:4] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues', '--method', 'POST']:
+    print(json.dumps({'number': 322, 'html_url': 'https://github.com/RbBtSn0w/gh-address-cr-skill/issues/322'}))
+elif args[:2] == ['api', 'repos/RbBtSn0w/gh-address-cr-skill/issues?state=all&per_page=100&page=1']:
+    print('[]')
+else:
+    raise SystemExit(f'unhandled gh args: {args}')
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(SUBMIT_FEEDBACK_PY),
+                "--category",
+                "tooling-bug",
+                "--title",
+                "audit feedback submission",
+                "--summary",
+                "Need an audit trail for feedback submissions.",
+                "--expected",
+                "A local audit event should be written.",
+                "--actual",
+                "Feedback submission currently has no local audit record.",
+                "--using-repo",
+                self.repo,
+                "--using-pr",
+                self.pr,
+                "--audit-id",
+                "feedback-audit-1",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        audit_rows = [json.loads(line) for line in self.audit_log_file().read_text(encoding="utf-8").splitlines() if line.strip()]
+        self.assertTrue(audit_rows)
+        last = audit_rows[-1]
+        self.assertEqual(last["action"], "submit_feedback")
+        self.assertEqual(last["status"], "ok")
+        self.assertEqual(last["audit_id"], "feedback-audit-1")
 
     def test_batch_resolve_python_processes_approved_lines(self):
         approved = Path(self.temp_dir.name) / "approved.txt"

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -833,6 +833,94 @@ else:
         self.assertEqual(captured["commands"], ["python3 -m unittest tests.test_cr_loop", "123"])
         self.assertIn("`python3 -m unittest tests.test_cr_loop && 123`", captured["reply_body"])
 
+    def test_handle_batch_github_fix_requires_test_result_when_only_test_command_is_provided(self):
+        module = self.load_module()
+        item_id = "github-thread:THREAD_FIX_MISSING_TEST_RESULT"
+        session = {
+            "schema_version": 1,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "items": {
+                item_id: {
+                    "item_id": item_id,
+                    "item_kind": "github_thread",
+                    "origin_ref": "THREAD_FIX_MISSING_TEST_RESULT",
+                    "title": "Require explicit test_result",
+                    "body": "The fixer should not infer a passing result from a raw test command string alone.",
+                    "path": "src/missing_test_result.py",
+                    "line": 31,
+                    "severity": "P2",
+                    "status": "OPEN",
+                    "decision": None,
+                    "blocking": True,
+                    "handled": False,
+                    "handled_at": None,
+                    "resolution_note": None,
+                    "published": True,
+                    "published_ref": "https://example.test/thread/missing-test-result",
+                    "url": "https://example.test/thread/missing-test-result",
+                    "first_url": "https://example.test/thread/missing-test-result",
+                    "latest_url": "https://example.test/thread/missing-test-result",
+                    "is_outdated": False,
+                    "scan_id": None,
+                    "introduced_in_sha": None,
+                    "last_seen_in_sha": None,
+                    "claimed_by": None,
+                    "claimed_at": None,
+                    "lease_expires_at": None,
+                    "repeat_count": 0,
+                    "reopen_count": 0,
+                    "evidence": [],
+                    "history": [],
+                    "auto_attempt_count": 0,
+                    "last_auto_action": None,
+                    "last_auto_failure": None,
+                    "needs_human": False,
+                    "reply_posted": False,
+                    "reply_url": None,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        self.session_file().parent.mkdir(parents=True, exist_ok=True)
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+
+        def fake_run_fixer(_cmd: str, _payload: dict):
+            return (
+                {
+                    "resolution": "fix",
+                    "note": "Updated the code path.",
+                    "fix_reply": {
+                        "commit_hash": "feed123",
+                        "files": ["src/missing_test_result.py"],
+                        "test_command": "python3 -m unittest tests.test_cr_loop",
+                    },
+                    "validation_commands": [],
+                },
+                "",
+            )
+
+        module.run_fixer = fake_run_fixer
+        module.emit = lambda _result: None
+        args = types.SimpleNamespace(fixer_cmd="fixer", validation_cmd=[], max_iterations=3)
+
+        with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": str(self.state_dir)}):
+            status, error = module.handle_batch(
+                args,
+                self.repo,
+                self.pr,
+                [session["items"][item_id]],
+                run_id="batch-missing-test-result",
+                iteration=1,
+            )
+
+        self.assertEqual(status, "needs_human")
+        self.assertIn("test_result", error)
+        updated = json.loads(self.session_file().read_text(encoding="utf-8"))["items"][item_id]
+        self.assertTrue(updated["needs_human"])
+        self.assertFalse(updated["reply_posted"])
+
     def test_cr_loop_local_json_fix_passes_gate(self):
         findings_file = Path(self.temp_dir.name) / "findings.json"
         findings_file.write_text(

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -383,6 +383,228 @@ else:
         self.assertEqual(updated["reply_url"], "https://example.test/reply/retryable")
         self.assertEqual(updated["last_auto_failure"], "graphql failed")
 
+    def test_handle_batch_github_fix_generates_reply_from_structured_fix_payload(self):
+        module = self.load_module()
+        item_id = "github-thread:THREAD_FIX_TEMPLATE"
+        session = {
+            "schema_version": 1,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "items": {
+                item_id: {
+                    "item_id": item_id,
+                    "item_kind": "github_thread",
+                    "origin_ref": "THREAD_FIX_TEMPLATE",
+                    "title": "Use template",
+                    "body": "Fix replies must use the canonical template.",
+                    "path": "src/template_fix.py",
+                    "line": 21,
+                    "severity": "P2",
+                    "status": "OPEN",
+                    "decision": None,
+                    "blocking": True,
+                    "handled": False,
+                    "handled_at": None,
+                    "resolution_note": None,
+                    "published": True,
+                    "published_ref": "https://example.test/thread/template-fix",
+                    "url": "https://example.test/thread/template-fix",
+                    "first_url": "https://example.test/thread/template-fix",
+                    "latest_url": "https://example.test/thread/template-fix",
+                    "is_outdated": False,
+                    "scan_id": None,
+                    "introduced_in_sha": None,
+                    "last_seen_in_sha": None,
+                    "claimed_by": None,
+                    "claimed_at": None,
+                    "lease_expires_at": None,
+                    "repeat_count": 0,
+                    "reopen_count": 0,
+                    "evidence": [],
+                    "history": [],
+                    "auto_attempt_count": 0,
+                    "last_auto_action": None,
+                    "last_auto_failure": None,
+                    "needs_human": False,
+                    "reply_posted": False,
+                    "reply_url": None,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        self.session_file().parent.mkdir(parents=True, exist_ok=True)
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+
+        captured = {}
+
+        def fake_run_fixer(_cmd: str, _payload: dict):
+            return (
+                {
+                    "resolution": "fix",
+                    "note": "Applied the focused fix.",
+                    "fix_reply": {
+                        "commit_hash": "abc123",
+                        "files": ["src/template_fix.py", "tests/test_template_fix.py"],
+                        "why": "Aligned the reply flow with the canonical fix template.",
+                    },
+                    "validation_commands": ["python3 -m unittest tests.test_cr_loop"],
+                },
+                "",
+            )
+
+        def fake_run_validation(commands: list[str]):
+            self.assertEqual(commands, ["python3 -m unittest tests.test_cr_loop"])
+            return True, ""
+
+        def fake_run_cmd(cmd, *, stdin=None):
+            if Path(cmd[1]).name == "batch_github_execute.py":
+                payload = json.loads(stdin or "[]")
+                self.assertEqual(len(payload), 1)
+                captured["reply_body"] = payload[0]["reply_body"]
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    json.dumps(
+                        {
+                            item_id: {
+                                "status": "succeeded",
+                                "reply_url": "https://example.test/reply/template-fix",
+                            }
+                        }
+                    ),
+                    "",
+                )
+            if Path(cmd[1]).name == "session_engine.py" and cmd[2] == "update-items-batch":
+                updates = json.loads(stdin or "[]")
+                session_data = json.loads(self.session_file().read_text(encoding="utf-8"))
+                for update in updates:
+                    session_data["items"][update["item_id"]].update(update)
+                self.session_file().write_text(json.dumps(session_data), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        module.run_fixer = fake_run_fixer
+        module.run_validation = fake_run_validation
+        module.run_cmd = fake_run_cmd
+        module.emit = lambda _result: None
+
+        args = types.SimpleNamespace(
+            fixer_cmd="fixer",
+            validation_cmd=[],
+            max_iterations=10,
+        )
+
+        with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": str(self.state_dir)}):
+            status, error = module.handle_batch(
+                args,
+                self.repo,
+                self.pr,
+                [session["items"][item_id]],
+                run_id="batch-fix-template",
+                iteration=1,
+            )
+
+        self.assertEqual(status, "done")
+        self.assertEqual(error, "")
+        self.assertIn("Fixed in `abc123`.", captured["reply_body"])
+        self.assertIn("Severity: `P2`", captured["reply_body"])
+        self.assertIn("What I changed:", captured["reply_body"])
+        self.assertIn("- `src/template_fix.py`: updated per CR scope", captured["reply_body"])
+        self.assertIn("Why this addresses the CR:", captured["reply_body"])
+        self.assertIn("Validation:", captured["reply_body"])
+        self.assertIn("`python3 -m unittest tests.test_cr_loop`", captured["reply_body"])
+        self.assertIn("Result: passed", captured["reply_body"])
+
+        updated = json.loads(self.session_file().read_text(encoding="utf-8"))["items"][item_id]
+        self.assertEqual(updated["status"], "CLOSED")
+        self.assertTrue(updated["handled"])
+        self.assertTrue(updated["reply_posted"])
+
+    def test_handle_batch_github_fix_rejects_raw_reply_markdown_without_fix_template_payload(self):
+        module = self.load_module()
+        item_id = "github-thread:THREAD_RAW_FIX_REPLY"
+        session = {
+            "schema_version": 1,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "items": {
+                item_id: {
+                    "item_id": item_id,
+                    "item_kind": "github_thread",
+                    "origin_ref": "THREAD_RAW_FIX_REPLY",
+                    "title": "Reject raw fix reply",
+                    "body": "Raw fix replies should not bypass the template.",
+                    "path": "src/raw_fix_reply.py",
+                    "line": 8,
+                    "severity": "P2",
+                    "status": "OPEN",
+                    "decision": None,
+                    "blocking": True,
+                    "handled": False,
+                    "handled_at": None,
+                    "resolution_note": None,
+                    "published": True,
+                    "published_ref": "https://example.test/thread/raw-fix",
+                    "url": "https://example.test/thread/raw-fix",
+                    "first_url": "https://example.test/thread/raw-fix",
+                    "latest_url": "https://example.test/thread/raw-fix",
+                    "is_outdated": False,
+                    "scan_id": None,
+                    "introduced_in_sha": None,
+                    "last_seen_in_sha": None,
+                    "claimed_by": None,
+                    "claimed_at": None,
+                    "lease_expires_at": None,
+                    "repeat_count": 0,
+                    "reopen_count": 0,
+                    "evidence": [],
+                    "history": [],
+                    "auto_attempt_count": 0,
+                    "last_auto_action": None,
+                    "last_auto_failure": None,
+                    "needs_human": False,
+                    "reply_posted": False,
+                    "reply_url": None,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        self.session_file().parent.mkdir(parents=True, exist_ok=True)
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+
+        def fake_run_fixer(_cmd: str, _payload: dict):
+            return (
+                {
+                    "resolution": "fix",
+                    "note": "Fixed it.",
+                    "reply_markdown": "Custom reply that bypasses the template.",
+                    "validation_commands": [],
+                },
+                "",
+            )
+
+        module.run_fixer = fake_run_fixer
+        module.emit = lambda _result: None
+        args = types.SimpleNamespace(fixer_cmd="fixer", validation_cmd=[], max_iterations=3)
+
+        with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": str(self.state_dir)}):
+            status, error = module.handle_batch(
+                args,
+                self.repo,
+                self.pr,
+                [session["items"][item_id]],
+                run_id="batch-raw-fix-reply",
+                iteration=1,
+            )
+
+        self.assertEqual(status, "needs_human")
+        self.assertIn("fix_reply", error)
+        updated = json.loads(self.session_file().read_text(encoding="utf-8"))["items"][item_id]
+        self.assertTrue(updated["needs_human"])
+        self.assertFalse(updated["reply_posted"])
+
     def test_cr_loop_local_json_fix_passes_gate(self):
         findings_file = Path(self.temp_dir.name) / "findings.json"
         findings_file.write_text(

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -605,6 +605,234 @@ else:
         self.assertTrue(updated["needs_human"])
         self.assertFalse(updated["reply_posted"])
 
+    def test_handle_batch_github_fix_normalizes_string_validation_command(self):
+        module = self.load_module()
+        item_id = "github-thread:THREAD_FIX_STRING_VALIDATION"
+        session = {
+            "schema_version": 1,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "items": {
+                item_id: {
+                    "item_id": item_id,
+                    "item_kind": "github_thread",
+                    "origin_ref": "THREAD_FIX_STRING_VALIDATION",
+                    "title": "Normalize string validation command",
+                    "body": "String validation commands should not be split into characters.",
+                    "path": "src/string_validation.py",
+                    "line": 17,
+                    "severity": "P2",
+                    "status": "OPEN",
+                    "decision": None,
+                    "blocking": True,
+                    "handled": False,
+                    "handled_at": None,
+                    "resolution_note": None,
+                    "published": True,
+                    "published_ref": "https://example.test/thread/string-validation",
+                    "url": "https://example.test/thread/string-validation",
+                    "first_url": "https://example.test/thread/string-validation",
+                    "latest_url": "https://example.test/thread/string-validation",
+                    "is_outdated": False,
+                    "scan_id": None,
+                    "introduced_in_sha": None,
+                    "last_seen_in_sha": None,
+                    "claimed_by": None,
+                    "claimed_at": None,
+                    "lease_expires_at": None,
+                    "repeat_count": 0,
+                    "reopen_count": 0,
+                    "evidence": [],
+                    "history": [],
+                    "auto_attempt_count": 0,
+                    "last_auto_action": None,
+                    "last_auto_failure": None,
+                    "needs_human": False,
+                    "reply_posted": False,
+                    "reply_url": None,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        self.session_file().parent.mkdir(parents=True, exist_ok=True)
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+
+        captured = {}
+
+        def fake_run_fixer(_cmd: str, _payload: dict):
+            return (
+                {
+                    "resolution": "fix",
+                    "note": "Normalized string validation commands.",
+                    "fix_reply": {
+                        "commit_hash": "abc123",
+                        "files": ["src/string_validation.py"],
+                    },
+                    "validation_commands": "python3 -m unittest tests.test_cr_loop",
+                },
+                "",
+            )
+
+        def fake_run_validation(commands: list[str]):
+            captured["commands"] = commands
+            return True, ""
+
+        def fake_run_cmd(cmd, *, stdin=None):
+            if Path(cmd[1]).name == "batch_github_execute.py":
+                payload = json.loads(stdin or "[]")
+                captured["reply_body"] = payload[0]["reply_body"]
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    json.dumps({item_id: {"status": "succeeded", "reply_url": "https://example.test/reply/string-validation"}}),
+                    "",
+                )
+            if Path(cmd[1]).name == "session_engine.py" and cmd[2] == "update-items-batch":
+                updates = json.loads(stdin or "[]")
+                session_data = json.loads(self.session_file().read_text(encoding="utf-8"))
+                for update in updates:
+                    session_data["items"][update["item_id"]].update(update)
+                self.session_file().write_text(json.dumps(session_data), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        module.run_fixer = fake_run_fixer
+        module.run_validation = fake_run_validation
+        module.run_cmd = fake_run_cmd
+        module.emit = lambda _result: None
+
+        args = types.SimpleNamespace(fixer_cmd="fixer", validation_cmd=[], max_iterations=10)
+
+        with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": str(self.state_dir)}):
+            status, error = module.handle_batch(
+                args,
+                self.repo,
+                self.pr,
+                [session["items"][item_id]],
+                run_id="batch-string-validation",
+                iteration=1,
+            )
+
+        self.assertEqual(status, "done")
+        self.assertEqual(error, "")
+        self.assertEqual(captured["commands"], ["python3 -m unittest tests.test_cr_loop"])
+        self.assertIn("`python3 -m unittest tests.test_cr_loop`", captured["reply_body"])
+
+    def test_handle_batch_github_fix_normalizes_mixed_validation_command_list(self):
+        module = self.load_module()
+        item_id = "github-thread:THREAD_FIX_MIXED_VALIDATION"
+        session = {
+            "schema_version": 1,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "items": {
+                item_id: {
+                    "item_id": item_id,
+                    "item_kind": "github_thread",
+                    "origin_ref": "THREAD_FIX_MIXED_VALIDATION",
+                    "title": "Normalize mixed validation command list",
+                    "body": "Validation commands should coerce list elements to strings and drop empties.",
+                    "path": "src/mixed_validation.py",
+                    "line": 23,
+                    "severity": "P2",
+                    "status": "OPEN",
+                    "decision": None,
+                    "blocking": True,
+                    "handled": False,
+                    "handled_at": None,
+                    "resolution_note": None,
+                    "published": True,
+                    "published_ref": "https://example.test/thread/mixed-validation",
+                    "url": "https://example.test/thread/mixed-validation",
+                    "first_url": "https://example.test/thread/mixed-validation",
+                    "latest_url": "https://example.test/thread/mixed-validation",
+                    "is_outdated": False,
+                    "scan_id": None,
+                    "introduced_in_sha": None,
+                    "last_seen_in_sha": None,
+                    "claimed_by": None,
+                    "claimed_at": None,
+                    "lease_expires_at": None,
+                    "repeat_count": 0,
+                    "reopen_count": 0,
+                    "evidence": [],
+                    "history": [],
+                    "auto_attempt_count": 0,
+                    "last_auto_action": None,
+                    "last_auto_failure": None,
+                    "needs_human": False,
+                    "reply_posted": False,
+                    "reply_url": None,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        self.session_file().parent.mkdir(parents=True, exist_ok=True)
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+
+        captured = {}
+
+        def fake_run_fixer(_cmd: str, _payload: dict):
+            return (
+                {
+                    "resolution": "fix",
+                    "note": "Normalized mixed validation commands.",
+                    "fix_reply": {
+                        "commit_hash": "def456",
+                        "files": ["src/mixed_validation.py"],
+                    },
+                    "validation_commands": ["python3 -m unittest tests.test_cr_loop", 123, "  ", None],
+                },
+                "",
+            )
+
+        def fake_run_validation(commands: list[str]):
+            captured["commands"] = commands
+            return True, ""
+
+        def fake_run_cmd(cmd, *, stdin=None):
+            if Path(cmd[1]).name == "batch_github_execute.py":
+                payload = json.loads(stdin or "[]")
+                captured["reply_body"] = payload[0]["reply_body"]
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    json.dumps({item_id: {"status": "succeeded", "reply_url": "https://example.test/reply/mixed-validation"}}),
+                    "",
+                )
+            if Path(cmd[1]).name == "session_engine.py" and cmd[2] == "update-items-batch":
+                updates = json.loads(stdin or "[]")
+                session_data = json.loads(self.session_file().read_text(encoding="utf-8"))
+                for update in updates:
+                    session_data["items"][update["item_id"]].update(update)
+                self.session_file().write_text(json.dumps(session_data), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        module.run_fixer = fake_run_fixer
+        module.run_validation = fake_run_validation
+        module.run_cmd = fake_run_cmd
+        module.emit = lambda _result: None
+
+        args = types.SimpleNamespace(fixer_cmd="fixer", validation_cmd=[], max_iterations=10)
+
+        with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": str(self.state_dir)}):
+            status, error = module.handle_batch(
+                args,
+                self.repo,
+                self.pr,
+                [session["items"][item_id]],
+                run_id="batch-mixed-validation",
+                iteration=1,
+            )
+
+        self.assertEqual(status, "done")
+        self.assertEqual(error, "")
+        self.assertEqual(captured["commands"], ["python3 -m unittest tests.test_cr_loop", "123"])
+        self.assertIn("`python3 -m unittest tests.test_cr_loop && 123`", captured["reply_body"])
+
     def test_cr_loop_local_json_fix_passes_gate(self):
         findings_file = Path(self.temp_dir.name) / "findings.json"
         findings_file.write_text(

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -338,6 +338,22 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertIn("https://example.com/file:///docs", sanitized)
         self.assertNotIn("file:///Users/snow/workspace", sanitized)
 
+    def test_submit_feedback_sanitize_command_redacts_key_value_tokens_and_file_uri_args(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_command_under_test")
+
+        sanitized = module.sanitize_command(
+            "python3 tool.py token=supersecret password=hunter2 "
+            "file:///Users/snow/private/state.json https://example.com/file:///docs"
+        )
+
+        self.assertIn("token=[redacted-token]", sanitized)
+        self.assertIn("password=[redacted-token]", sanitized)
+        self.assertIn("file://.../private/state.json", sanitized)
+        self.assertIn("https://example.com/file:///docs", sanitized)
+        self.assertNotIn("token=supersecret", sanitized)
+        self.assertNotIn("password=hunter2", sanitized)
+        self.assertNotIn("file:///Users/snow/private/state.json", sanitized)
+
     def test_submit_feedback_write_failure_sanitizes_error_and_audit_details(self):
         module = self.load_module("submit_feedback.py", "submit_feedback_write_failure_under_test")
 

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -377,6 +377,23 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertIn("https://example.com/file:///docs", sanitized)
         self.assertNotIn("file:///Users/snow/workspace", sanitized)
 
+    def test_submit_feedback_sanitize_text_redacts_common_token_assignment_variants(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_text_token_variants_under_test")
+
+        sanitized = module.sanitize_text(
+            "access_token=supersecret auth-token=hunter2 refresh_token=abc123 "
+            "session token=value should all be redacted."
+        )
+
+        self.assertIn("access_token=[redacted-token]", sanitized)
+        self.assertIn("auth-token=[redacted-token]", sanitized)
+        self.assertIn("refresh_token=[redacted-token]", sanitized)
+        self.assertIn("token=[redacted-token]", sanitized)
+        self.assertNotIn("access_token=supersecret", sanitized)
+        self.assertNotIn("auth-token=hunter2", sanitized)
+        self.assertNotIn("refresh_token=abc123", sanitized)
+        self.assertNotIn("token=value", sanitized)
+
     def test_submit_feedback_sanitize_command_redacts_key_value_tokens_and_file_uri_args(self):
         module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_command_under_test")
 

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -257,6 +257,45 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertTrue(audits)
         self.assertIn("feedback issue response was not valid JSON", stderr.getvalue())
 
+    def test_submit_feedback_rejects_success_response_missing_required_fields(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_missing_fields_under_test")
+
+        audits = []
+        module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
+        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            0,
+            json.dumps({"id": 321}),
+            "",
+        )
+
+        with patched_argv(
+            [
+                "submit_feedback.py",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "bad response",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        ), patch("sys.stdout", new=io.StringIO()) as stdout, patch("sys.stderr", new=io.StringIO()) as stderr:
+            rc = module.main()
+            payload = json.loads(stdout.getvalue())
+
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIsNone(payload["issue_number"])
+        self.assertIsNone(payload["issue_url"])
+        self.assertEqual(payload["error"], "feedback issue response missing valid number, html_url")
+        self.assertTrue(audits)
+        self.assertIn("feedback issue response missing valid number, html_url", stderr.getvalue())
+
     def test_submit_feedback_audits_lookup_failure_with_structured_output(self):
         module = self.load_module("submit_feedback.py", "submit_feedback_lookup_failure_under_test")
 

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -230,7 +230,7 @@ class NetworkWriteContractTest(PythonScriptTestCase):
 
         audits = []
         module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
-        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_read_json = lambda *args, **kwargs: {"items": []}
         module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "not-json", "")
 
         with patched_argv(
@@ -262,7 +262,7 @@ class NetworkWriteContractTest(PythonScriptTestCase):
 
         audits = []
         module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
-        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_read_json = lambda *args, **kwargs: {"items": []}
         module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(
             args[0],
             0,
@@ -398,7 +398,7 @@ class NetworkWriteContractTest(PythonScriptTestCase):
 
         audits = []
         module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
-        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_read_json = lambda *args, **kwargs: {"items": []}
         module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(
             args[0],
             1,

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -312,3 +312,28 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertIn(".../workspace/notes.txt", sanitized)
         self.assertNotIn("/Users/snow/workspace", sanitized)
         self.assertNotIn("C:\\Users\\snow\\workspace\\notes.txt", sanitized)
+
+    def test_submit_feedback_sanitize_text_redacts_mounted_home_paths(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_text_mounted_path_under_test")
+
+        sanitized = module.sanitize_text(
+            "Mounted path file is /mnt/c/Users/snow/workspace/gh-address-cr/scripts/cli.py "
+            "and build cache is /mnt/c/var/home/snow/tmp/state.json."
+        )
+
+        self.assertIn(".../gh-address-cr/scripts/cli.py", sanitized)
+        self.assertIn(".../tmp/state.json", sanitized)
+        self.assertNotIn("/mnt/c/Users/snow", sanitized)
+        self.assertNotIn("/mnt/c/var/home/snow", sanitized)
+
+    def test_submit_feedback_sanitize_text_redacts_file_uri_paths(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_text_file_uri_under_test")
+
+        sanitized = module.sanitize_text(
+            "Local file URI file:///Users/snow/workspace/gh-address-cr/scripts/cli.py "
+            "should be redacted while https://example.com/file:///docs stays intact."
+        )
+
+        self.assertIn("file://.../gh-address-cr/scripts/cli.py", sanitized)
+        self.assertIn("https://example.com/file:///docs", sanitized)
+        self.assertNotIn("file:///Users/snow/workspace", sanitized)

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -337,3 +337,48 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertIn("file://.../gh-address-cr/scripts/cli.py", sanitized)
         self.assertIn("https://example.com/file:///docs", sanitized)
         self.assertNotIn("file:///Users/snow/workspace", sanitized)
+
+    def test_submit_feedback_write_failure_sanitizes_error_and_audit_details(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_write_failure_under_test")
+
+        audits = []
+        module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
+        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            1,
+            "",
+            "token=ghp_abcdefghijklmnopqrstuvwxyz12 path=/Users/snow/private/state.json email=alice@example.com",
+        )
+
+        with patched_argv(
+            [
+                "submit_feedback.py",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "bad response",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        ), patch("sys.stdout", new=io.StringIO()) as stdout, patch("sys.stderr", new=io.StringIO()):
+            rc = module.main()
+            payload = json.loads(stdout.getvalue())
+
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIn("[redacted-token]", payload["error"])
+        self.assertIn("email=[redacted]", payload["error"])
+        self.assertIn(".../private/state.json", payload["error"])
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", payload["error"])
+        self.assertNotIn("alice@example.com", payload["error"])
+        self.assertNotIn("/Users/snow/private", payload["error"])
+        self.assertTrue(audits)
+        audit_args, _audit_kwargs = audits[-1]
+        self.assertIn("[redacted-token]", audit_args[6]["error"])
+        self.assertIn("email=[redacted]", audit_args[6]["error"])
+        self.assertIn(".../private/state.json", audit_args[6]["error"])

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -257,6 +257,47 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertTrue(audits)
         self.assertIn("feedback issue response was not valid JSON", stderr.getvalue())
 
+    def test_submit_feedback_create_system_exit_returns_structured_failure(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_create_system_exit_under_test")
+
+        audits = []
+        module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
+        module.gh_read_json = lambda *args, **kwargs: {"items": []}
+
+        def failing_gh_write_cmd(*args, **kwargs):
+            raise SystemExit("gh missing at /Users/snow/private/bin/gh token=ghp_secretvalue user=snow@example.com")
+
+        module.gh_write_cmd = failing_gh_write_cmd
+
+        with patched_argv(
+            [
+                "submit_feedback.py",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "create system exit",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        ), patch("sys.stdout", new=io.StringIO()) as stdout, patch("sys.stderr", new=io.StringIO()) as stderr:
+            rc = module.main()
+            payload = json.loads(stdout.getvalue())
+
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIsNone(payload["issue_number"])
+        self.assertIsNone(payload["issue_url"])
+        self.assertIn("gh missing", payload["error"])
+        self.assertNotIn("/Users/snow/private", payload["error"])
+        self.assertNotIn("ghp_secretvalue", payload["error"])
+        self.assertNotIn("snow@example.com", payload["error"])
+        self.assertTrue(audits)
+        self.assertIn("gh missing", stderr.getvalue())
+
     def test_submit_feedback_rejects_success_response_missing_required_fields(self):
         module = self.load_module("submit_feedback.py", "submit_feedback_missing_fields_under_test")
 

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -224,3 +224,35 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertEqual(payload["error"], "publish response was not valid JSON")
         self.assertTrue(audits)
         self.assertIn("publish response was not valid JSON", stderr.getvalue())
+
+    def test_submit_feedback_audits_invalid_json_response(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_under_test")
+
+        audits = []
+        module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
+        module.gh_read_json = lambda *args, **kwargs: []
+        module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "not-json", "")
+
+        with patched_argv(
+            [
+                "submit_feedback.py",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "bad response",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        ), patch("sys.stdout", new=io.StringIO()) as stdout, patch("sys.stderr", new=io.StringIO()) as stderr:
+            rc = module.main()
+            payload = json.loads(stdout.getvalue())
+
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["error"], "feedback issue response was not valid JSON")
+        self.assertTrue(audits)
+        self.assertIn("feedback issue response was not valid JSON", stderr.getvalue())

--- a/tests/test_network_write_contracts.py
+++ b/tests/test_network_write_contracts.py
@@ -256,3 +256,59 @@ class NetworkWriteContractTest(PythonScriptTestCase):
         self.assertEqual(payload["error"], "feedback issue response was not valid JSON")
         self.assertTrue(audits)
         self.assertIn("feedback issue response was not valid JSON", stderr.getvalue())
+
+    def test_submit_feedback_audits_lookup_failure_with_structured_output(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_lookup_failure_under_test")
+
+        audits = []
+        module.audit_event = lambda *args, **kwargs: audits.append((args, kwargs))
+
+        def failing_gh_read_json(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, args[0], "", "gh auth failed")
+
+        module.gh_read_json = failing_gh_read_json
+        module.gh_write_cmd = lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "{}", "")
+
+        with patched_argv(
+            [
+                "submit_feedback.py",
+                "--category",
+                "tooling-bug",
+                "--title",
+                "dedupe lookup failure",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        ), patch("sys.stdout", new=io.StringIO()) as stdout, patch("sys.stderr", new=io.StringIO()) as stderr:
+            rc = module.main()
+            payload = json.loads(stdout.getvalue())
+
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIsNone(payload["issue_number"])
+        self.assertIsNone(payload["issue_url"])
+        self.assertIn("dedupe lookup failed", payload["error"])
+        self.assertIn("gh auth failed", payload["error"])
+        self.assertTrue(audits)
+        self.assertIn("dedupe lookup failed", stderr.getvalue())
+
+    def test_submit_feedback_sanitize_text_only_redacts_absolute_paths(self):
+        module = self.load_module("submit_feedback.py", "submit_feedback_sanitize_text_under_test")
+
+        sanitized = module.sanitize_text(
+            "Repo octo/example uses tmp/file.json and https://example.com/docs/a "
+            "plus /Users/snow/workspace/gh-address-cr/scripts/cli.py "
+            "and C:\\Users\\snow\\workspace\\notes.txt."
+        )
+
+        self.assertIn("octo/example", sanitized)
+        self.assertIn("tmp/file.json", sanitized)
+        self.assertIn("https://example.com/docs/a", sanitized)
+        self.assertIn(".../gh-address-cr/scripts/cli.py", sanitized)
+        self.assertIn(".../workspace/notes.txt", sanitized)
+        self.assertNotIn("/Users/snow/workspace", sanitized)
+        self.assertNotIn("C:\\Users\\snow\\workspace\\notes.txt", sanitized)

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -2050,15 +2050,9 @@ else:
 
         result = self.run_cmd([sys.executable, str(FINAL_GATE_PY), "--no-auto-clean", "--audit-id", "gate-test", self.repo, self.pr])
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("== Current Run Snapshot ==", result.stdout)
-        self.assertIn(
-            "GitHub threads: total 1; new in this run 1; unresolved 0; handled in this run 1",
-            result.stdout,
-        )
-        self.assertIn(
-            "Local findings: total 0; new in this run 0; unresolved 0; handled in this run 0",
-            result.stdout,
-        )
+        self.assertNotIn("== Current Run Snapshot ==", result.stdout)
+        self.assertNotIn("GitHub threads: total 1;", result.stdout)
+        self.assertNotIn("Local findings: total 0;", result.stdout)
         self.assertIn("== Gate Result ==", result.stdout)
         self.assertIn("Verified: 0 Unresolved Threads found", result.stdout)
         self.assertIn("Verified: 0 Pending Reviews found", result.stdout)

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -66,7 +66,32 @@ class PythonWrapperCLITest(PythonScriptTestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("review-to-findings owner/repo 123 --input finding-blocks.md", result.stdout)
         self.assertIn("fixed finding blocks only", result.stdout)
+        self.assertIn("submit-feedback --category", result.stdout)
         self.assertNotIn("review-to-findings owner/repo 123 --input review.md", result.stdout)
+
+    def test_cli_submit_feedback_passthrough_dry_run(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(CLI_PY),
+                "submit-feedback",
+                "--dry-run",
+                "--category",
+                "workflow-gap",
+                "--title",
+                "cli passthrough",
+                "--summary",
+                "summary",
+                "--expected",
+                "expected",
+                "--actual",
+                "actual",
+            ]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "dry-run")
+        self.assertTrue(payload["title"].startswith("[AI Feedback] "))
 
     def test_cli_review_defaults_to_structured_summary(self):
         gh = self.bin_dir / "gh"
@@ -249,6 +274,11 @@ else:
         self.assertTrue((self.workspace_dir() / "incoming-findings.json").exists())
         self.assertTrue((self.workspace_dir() / "incoming-findings.md").exists())
         self.assertIn("external review producer", result.stderr)
+        summary_path = self.workspace_dir() / "last-machine-summary.json"
+        self.assertTrue(summary_path.exists())
+        persisted = json.loads(summary_path.read_text(encoding="utf-8"))
+        self.assertEqual(persisted["status"], "WAITING_FOR_EXTERNAL_REVIEW")
+        self.assertEqual(persisted["reason_code"], "WAITING_FOR_EXTERNAL_REVIEW")
 
     def test_cli_findings_help_mentions_source_required_for_sync(self):
         result = self.run_cmd([sys.executable, str(CLI_PY), "findings", "--help"])

--- a/tests/test_session_engine_cli.py
+++ b/tests/test_session_engine_cli.py
@@ -529,11 +529,11 @@ class SessionEngineCLITest(SessionEngineTestCase):
         self.assertIn("local_findings_unresolved_count=0", gated.stdout)
 
         summary = (self.workspace_dir() / "audit_summary.md").read_text(encoding="utf-8")
-        self.assertIn("## Current Run Snapshot", summary)
-        self.assertIn("- GitHub threads: total 2; new in this run 0; unresolved 0; handled in this run 0", summary)
-        self.assertIn("- Local findings: total 0; new in this run 0; unresolved 0; handled in this run 0", summary)
+        self.assertNotIn("## Current Run Snapshot", summary)
+        self.assertNotIn("- GitHub threads: total 2;", summary)
+        self.assertNotIn("- Local findings: total 0;", summary)
 
-    def test_gate_summary_reports_new_and_handled_counts_for_current_run(self):
+    def test_gate_summary_omits_current_run_progress_block(self):
         self.run_engine("init", self.repo, self.pr, check=True)
         gh_seed_payload = json.dumps(
             [
@@ -614,8 +614,8 @@ class SessionEngineCLITest(SessionEngineTestCase):
         self.assertIn("local_findings_unresolved_count=0", gated.stdout)
 
         summary = (self.workspace_dir() / "audit_summary.md").read_text(encoding="utf-8")
-        self.assertIn("- GitHub threads: total 2; new in this run 1; unresolved 0; handled in this run 2", summary)
-        self.assertIn("- Local findings: total 1; new in this run 0; unresolved 0; handled in this run 1", summary)
+        self.assertNotIn("- GitHub threads: total 2;", summary)
+        self.assertNotIn("- Local findings: total 1;", summary)
 
     def test_close_item_marks_local_finding_closed_and_handled(self):
         self.run_engine("init", self.repo, self.pr, check=True)

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -68,19 +68,16 @@ class SkillDocumentationContractTest(unittest.TestCase):
         self.assertIn("python3 scripts/cli.py final-gate <owner/repo> <pr_number>", text)
         self.assertNotIn("README.md", text)
 
-    def test_skill_completion_contract_prefers_labeled_current_run_summary(self):
+    def test_skill_completion_contract_does_not_require_current_run_summary(self):
         text = SKILL_MD.read_text(encoding="utf-8")
-        self.assertIn("readable current-run handling summary", text)
-        self.assertIn(
-            "GitHub threads: total 2; new in this run 0; unresolved 0; handled in this run 0",
-            text,
-        )
-        self.assertIn("prefer the human-readable `Current Run Snapshot` block", text)
+        self.assertNotIn("readable current-run handling summary", text)
+        self.assertNotIn("GitHub threads: total 2; new in this run 0; unresolved 0; handled in this run 0", text)
+        self.assertNotIn("prefer the human-readable `Current Run Snapshot` block", text)
 
-    def test_openai_hint_prefers_natural_language_current_run_counts(self):
+    def test_openai_hint_does_not_require_natural_language_current_run_counts(self):
         text = OPENAI_HINT_YAML.read_text(encoding="utf-8")
-        self.assertIn("summarize the current-run queue counts in natural language", text)
-        self.assertIn("prefer the human-readable `Current Run Snapshot` block", text)
+        self.assertNotIn("summarize the current-run queue counts in natural language", text)
+        self.assertNotIn("prefer the human-readable `Current Run Snapshot` block", text)
 
     def test_skill_documents_agent_feedback_command_and_trigger(self):
         text = SKILL_MD.read_text(encoding="utf-8")

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -82,8 +82,19 @@ class SkillDocumentationContractTest(unittest.TestCase):
     def test_skill_documents_agent_feedback_command_and_trigger(self):
         text = SKILL_MD.read_text(encoding="utf-8")
         self.assertIn("python3 scripts/submit_feedback.py", text)
-        self.assertIn("when the skill itself blocks progress", text)
-        self.assertIn("do not file feedback issues for normal PR findings", text)
+        self.assertIn("When the skill itself blocks progress", text)
+        self.assertIn("Do not file feedback issues for normal PR findings", text)
+        self.assertNotIn("- when the skill itself blocks progress", text)
+
+    def test_skill_documents_structured_fix_reply_contract_for_github_threads(self):
+        skill_text = SKILL_MD.read_text(encoding="utf-8")
+        readme_text = README_MD.read_text(encoding="utf-8")
+        self.assertIn("for GitHub thread `fix`: `fix_reply`", skill_text)
+        self.assertIn("`commit_hash`", skill_text)
+        self.assertIn("`files`", skill_text)
+        self.assertIn("for GitHub thread `clarify` or `defer`: `reply_markdown`", skill_text)
+        self.assertIn("for GitHub thread `fix`: `fix_reply`", readme_text)
+        self.assertIn("for GitHub thread `clarify` or `defer`: `reply_markdown`", readme_text)
 
     def test_openai_hint_requires_feedback_issue_when_skill_usage_is_blocked(self):
         text = OPENAI_HINT_YAML.read_text(encoding="utf-8")

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -90,6 +90,8 @@ class SkillDocumentationContractTest(unittest.TestCase):
         self.assertIn("run `python3 scripts/submit_feedback.py`", text)
         self.assertIn("contradictory instructions", text)
         self.assertIn("missing automation", text)
+        self.assertIn("WAITING_FOR_EXTERNAL_REVIEW", text)
+        self.assertIn("expected wait states", text)
         self.assertIn("Do not include usernames, emails, tokens, machine names, or absolute local paths", text)
 
     def test_repo_issue_template_documents_ai_agent_feedback_fields(self):

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -8,6 +8,7 @@ README_MD = ROOT / "README.md"
 MODE_PRODUCER_MATRIX_MD = ROOT / "gh-address-cr" / "references" / "mode-producer-matrix.md"
 LOCAL_REVIEW_ADAPTER_MD = ROOT / "gh-address-cr" / "references" / "local-review-adapter.md"
 OPENAI_HINT_YAML = ROOT / "gh-address-cr" / "agents" / "openai.yaml"
+AGENT_FEEDBACK_ISSUE_TEMPLATE = ROOT / ".github" / "ISSUE_TEMPLATE" / "ai-agent-feedback.md"
 
 
 class SkillDocumentationContractTest(unittest.TestCase):
@@ -81,6 +82,31 @@ class SkillDocumentationContractTest(unittest.TestCase):
         self.assertIn("summarize the current-run queue counts in natural language", text)
         self.assertIn("prefer the human-readable `Current Run Snapshot` block", text)
 
+    def test_skill_documents_agent_feedback_command_and_trigger(self):
+        text = SKILL_MD.read_text(encoding="utf-8")
+        self.assertIn("python3 scripts/submit_feedback.py", text)
+        self.assertIn("when the skill itself blocks progress", text)
+        self.assertIn("do not file feedback issues for normal PR findings", text)
+
+    def test_openai_hint_requires_feedback_issue_when_skill_usage_is_blocked(self):
+        text = OPENAI_HINT_YAML.read_text(encoding="utf-8")
+        self.assertIn("run `python3 scripts/submit_feedback.py`", text)
+        self.assertIn("contradictory instructions", text)
+        self.assertIn("missing automation", text)
+        self.assertIn("Do not include usernames, emails, tokens, machine names, or absolute local paths", text)
+
+    def test_repo_issue_template_documents_ai_agent_feedback_fields(self):
+        text = AGENT_FEEDBACK_ISSUE_TEMPLATE.read_text(encoding="utf-8")
+        self.assertIn("name: AI Agent Feedback", text)
+        self.assertIn("## Summary", text)
+        self.assertIn("## Category", text)
+        self.assertIn("## Expected Workflow", text)
+        self.assertIn("## Actual Behavior", text)
+        self.assertIn("## Reproduction Context", text)
+        self.assertIn("## Technical Diagnostics", text)
+        self.assertIn("## Additional Notes", text)
+        self.assertIn("Do not include usernames, emails, tokens, machine names, or absolute local paths", text)
+
     def test_skill_owned_references_and_agent_hints_use_skill_relative_paths(self):
         for path in (MODE_PRODUCER_MATRIX_MD, LOCAL_REVIEW_ADAPTER_MD, OPENAI_HINT_YAML):
             text = path.read_text(encoding="utf-8")
@@ -91,6 +117,7 @@ class SkillDocumentationContractTest(unittest.TestCase):
     def test_referenced_skill_owned_docs_exist(self):
         for path in (MODE_PRODUCER_MATRIX_MD, LOCAL_REVIEW_ADAPTER_MD, OPENAI_HINT_YAML):
             self.assertTrue(path.exists(), msg=str(path))
+        self.assertTrue(AGENT_FEEDBACK_ISSUE_TEMPLATE.exists(), msg=str(AGENT_FEEDBACK_ISSUE_TEMPLATE))
 
     def test_readme_examples_use_single_review_main_entrypoint(self):
         text = README_MD.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add structured AI-agent feedback issue reporting for gh-address-cr, including the new `submit_feedback.py` helper, `cli.py submit-feedback`, audit integration, dedupe, cooldown, and workspace evidence collection
- add the packaged and repo-level contracts for agent feedback reporting in `gh-address-cr/SKILL.md`, `gh-address-cr/agents/openai.yaml`, `README.md`, and `.github/ISSUE_TEMPLATE/ai-agent-feedback.md`
- fix the follow-up review regressions so dedupe lookup failures now return structured failure JSON with audit records, and path redaction only compacts real absolute local paths without corrupting repo slugs, relative paths, or URLs

## Test Plan
- `ruff check gh-address-cr tests`
- `python3 -m unittest discover -s tests`
- `python3 gh-address-cr/scripts/cli.py --help`
- `python3 gh-address-cr/scripts/cli.py cr-loop --help`
- `python3 gh-address-cr/scripts/submit_feedback.py --help`
