### PR TITLE
fix: preserve agent workflow publish contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Stable machine summary fields:
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
+The `threads` command may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
 
 ## Multi-Agent Coordination
 
@@ -231,6 +232,7 @@ Role split:
 - `gatekeeper`: deterministic final-gate role
 
 Parallel work is lease-based. Independent items may be claimed concurrently, but overlapping file, item, thread, or GitHub side-effect conflict keys are rejected. AI agents must not post replies or resolve GitHub threads directly; accepted evidence is published by the runtime.
+After `agent submit` returns `ACTION_ACCEPTED`, follow the returned `next_action`; GitHub-thread fixes publish through `agent publish`.
 
 Main entrypoint examples:
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -75,6 +75,7 @@ High-level commands emit structured JSON by default. Agents MUST consume these f
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
+The `threads` command may also include a `threads` array with actionable GitHub thread context (`thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence).
 
 ## Multi-Agent Protocol
 
@@ -86,6 +87,7 @@ Use the runtime as the coordinator:
   - claims one eligible item and writes an `ActionRequest`
 - `gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>`
   - validates an `ActionResponse`, lease ownership, and required evidence
+  - when it returns `ACTION_ACCEPTED`, run the returned `next_action`; accepted GitHub-thread fixes publish through `agent publish`
 - `gh-address-cr agent leases <owner/repo> <pr_number>`
   - inspects active and terminal claims
 - `gh-address-cr agent reclaim <owner/repo> <pr_number>`

--- a/skill/references/status-action-map.md
+++ b/skill/references/status-action-map.md
@@ -7,6 +7,9 @@ This document maps the `gh-address-cr` runtime `status` fields to the next safe 
 If `status` is `WAITING_FOR_ACTION`:
 - **Action**: Inspect the `item_id` and `item_kind`. Use `gh-address-cr agent next` and `gh-address-cr agent submit` to claim the item and submit your work.
 
+If `status` is `ACTION_ACCEPTED`:
+- **Action**: Run the returned `next_action` exactly. For accepted GitHub-thread fixes, this publishes through `gh-address-cr agent publish`.
+
 If `status` is `BLOCKED`:
 - **Action**: Inspect the `reason_code` and `waiting_on`. Handle the blocked item by applying a resolution (`fix`, `clarify`, `defer`, `reject`).
 

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -816,7 +816,7 @@ def _native_summary(
     item: dict | None = None,
 ) -> dict:
     metrics = session.get("metrics") if isinstance(session.get("metrics"), dict) else {}
-    return {
+    summary = {
         "status": status,
         "repo": repo,
         "pr_number": str(pr_number),
@@ -834,6 +834,38 @@ def _native_summary(
         "next_action": next_action,
         "exit_code": exit_code,
     }
+    if command == "threads":
+        summary["threads"] = _native_thread_rows(session)
+    return summary
+
+
+def _native_thread_rows(session: dict) -> list[dict]:
+    items = session.get("items") if isinstance(session.get("items"), dict) else {}
+    rows = []
+    for item_id, item in sorted(items.items()):
+        if not isinstance(item, dict) or item.get("item_kind") != "github_thread":
+            continue
+        status = str(item.get("status") or "")
+        state = str(item.get("state") or "")
+        thread_id = item.get("thread_id") or item.get("origin_ref") or str(item_id).removeprefix("github-thread:")
+        reply_evidence = item.get("reply_evidence") if isinstance(item.get("reply_evidence"), dict) else None
+        rows.append(
+            {
+                "item_id": str(item.get("item_id") or item_id),
+                "thread_id": thread_id,
+                "path": item.get("path"),
+                "line": item.get("line"),
+                "body": item.get("body"),
+                "url": item.get("url"),
+                "state": state or None,
+                "status": status or None,
+                "is_resolved": status.upper() == "CLOSED" or state.lower() in {"closed", "resolved"},
+                "is_outdated": bool(item.get("is_outdated") or item.get("isOutdated") or status.upper() == "STALE"),
+                "reply_evidence": reply_evidence,
+                "accepted_response_present": isinstance(item.get("accepted_response"), dict),
+            }
+        )
+    return rows
 
 
 def _parse_native_high_level_args(command: str, args: list[str]) -> argparse.Namespace:
@@ -1314,6 +1346,7 @@ def handle_final_gate(repo: str | None, pr_number: str | None, passthrough: list
         print(f"Final gate failed to evaluate: {exc}", file=sys.stderr)
         return 5
 
+    _write_native_final_gate_artifacts(parsed.repo, parsed.pr_number, parsed.audit_id, result)
     _emit_final_gate_result(result)
     if not result.passed:
         print(f"\nGate FAILED: {_final_gate_failure_message(result)}. Do not send completion summary.", file=sys.stderr)
@@ -1343,6 +1376,64 @@ def _emit_final_gate_result(result: core_gate.GateResult) -> None:
         print(f"{key}={result.counts[key]}")
     print(f"reason_code={result.reason_code or 'PASSED'}")
     print(f"exit_code={result.exit_code}")
+
+
+def _write_native_final_gate_artifacts(
+    repo: str,
+    pr_number: str,
+    audit_id: str,
+    result: core_gate.GateResult,
+) -> None:
+    workspace = session_store.workspace_dir(repo, pr_number)
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    run_id = audit_id or "final-gate"
+    summary_path = workspace / core_paths.audit_summary_file(repo, pr_number).name
+    audit_path = workspace / core_paths.audit_log_file(repo, pr_number).name
+    trace_path = workspace / "trace.jsonl"
+    status = "ok" if result.passed else "failed"
+    summary_lines = [
+        "# Audit Summary",
+        "",
+        f"- repo: {repo}",
+        f"- pr: {pr_number}",
+        f"- run_id: {run_id}",
+        f"- final_gate_status: {status}",
+        f"- reason_code: {result.reason_code or 'PASSED'}",
+    ]
+    summary_lines.extend(f"- {key}: {result.counts[key]}" for key in core_gate.COUNT_KEYS)
+    if result.failure_codes:
+        summary_lines.extend(["", "## Failure Codes", *[f"- {code}" for code in result.failure_codes]])
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    summary_sha256 = hashlib.sha256(summary_path.read_bytes()).hexdigest()
+    audit_entry = {
+        "ts": timestamp,
+        "run_id": run_id,
+        "audit_id": run_id,
+        "repo": repo,
+        "pr": str(pr_number),
+        "action": "final-gate",
+        "status": status,
+        "message": "Evaluated native final gate",
+        "details": {
+            "counts": dict(result.counts),
+            "failure_codes": list(result.failure_codes),
+            "summary_file": str(summary_path),
+            "summary_sha256": summary_sha256,
+        },
+    }
+    trace_entry = {
+        "ts": timestamp,
+        "run_id": run_id,
+        "repo": repo,
+        "pr": str(pr_number),
+        "event": "final_gate",
+        "status": status,
+        "reason_code": result.reason_code or "PASSED",
+        "counts": dict(result.counts),
+    }
+    for path, entry in ((audit_path, audit_entry), (trace_path, trace_entry)):
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
 
 
 def _final_gate_failure_message(result: core_gate.GateResult) -> str:

--- a/src/gh_address_cr/core/gate.py
+++ b/src/gh_address_cr/core/gate.py
@@ -292,7 +292,9 @@ def _session_with_remote_threads(
 
 
 def _has_publish_ready_evidence(item: Mapping[str, Any]) -> bool:
-    return str(item.get("state") or "").lower() == "publish_ready" and isinstance(item.get("accepted_response"), Mapping)
+    if isinstance(item.get("accepted_response"), Mapping):
+        return True
+    return _has_content(item.get("publish_resolution"))
 
 
 def _session_items(session: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/gh_address_cr/core/gate.py
+++ b/src/gh_address_cr/core/gate.py
@@ -117,7 +117,11 @@ class Gatekeeper:
         *,
         snapshot_path: str | Path | None = None,
     ) -> GateResult:
-        session = self._load_session(repo, pr_number)
+        manager = SessionManager(repo, str(pr_number))
+        try:
+            session = manager.load()
+        except SessionError:
+            session = manager.create(status="WAITING_FOR_GATE")
         current_login = self.github_client.viewer_login()
         remote_threads = (
             _load_thread_snapshot(snapshot_path)
@@ -126,20 +130,24 @@ class Gatekeeper:
         )
         pending_reviews = self.github_client.list_pending_reviews(repo, str(pr_number), current_login)
         merged_session = _session_with_remote_threads(session, remote_threads, current_login=current_login)
-        return evaluate_final_gate(
+        result = evaluate_final_gate(
             merged_session,
             remote_threads=remote_threads,
             pending_reviews=pending_reviews,
             current_login=current_login,
         )
-
-    @staticmethod
-    def _load_session(repo: str, pr_number: str) -> dict[str, Any]:
-        manager = SessionManager(repo, str(pr_number))
-        try:
-            return manager.load()
-        except SessionError:
-            return manager.create(status="WAITING_FOR_GATE")
+        metrics = dict(merged_session.get("metrics") or {})
+        metrics.update(
+            {
+                "blocking_items_count": result.counts["blocking_items_count"],
+                "unresolved_github_threads_count": result.counts["unresolved_github_threads_count"],
+                "github_threads_missing_reply_count": result.counts["github_threads_missing_reply_count"],
+                "pending_current_login_review_count": result.counts["pending_current_login_review_count"],
+            }
+        )
+        merged_session["metrics"] = metrics
+        manager.save(merged_session)
+        return result
 
 
 def evaluate_final_gate(
@@ -251,6 +259,7 @@ def _session_with_remote_threads(
         item["body"] = thread.get("body") or item.get("body")
         is_resolved = _thread_is_resolved(thread)
         is_outdated = bool(thread.get("isOutdated", thread.get("is_outdated", False)))
+        item["is_outdated"] = is_outdated
         if is_resolved:
             item["state"] = (
                 item.get("state") if str(item.get("state") or "").lower() in GITHUB_TERMINAL_STATES else "closed"
@@ -258,6 +267,10 @@ def _session_with_remote_threads(
             item["status"] = "CLOSED"
             item["blocking"] = False
             item["handled"] = True
+        elif _has_publish_ready_evidence(item):
+            item["state"] = "publish_ready"
+            item["status"] = item.get("status") or "OPEN"
+            item["blocking"] = True
         elif is_outdated:
             item["state"] = "stale"
             item["status"] = "STALE"
@@ -276,6 +289,10 @@ def _session_with_remote_threads(
         items[item_id] = item
     merged["items"] = items
     return merged
+
+
+def _has_publish_ready_evidence(item: Mapping[str, Any]) -> bool:
+    return str(item.get("state") or "").lower() == "publish_ready" and isinstance(item.get("accepted_response"), Mapping)
 
 
 def _session_items(session: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -15,9 +15,11 @@ from gh_address_cr.core.leases import (
     accept_lease,
     claim_lease,
     expire_leases,
+    release_lease,
     submit_lease,
 )
 from gh_address_cr.core.models import ActionRequest
+from gh_address_cr.core.reply_templates import fix_reply as render_fix_reply
 from gh_address_cr.evidence.ledger import EvidenceLedger, SideEffectAttempt
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.errors import GitHubError
@@ -130,6 +132,15 @@ def record_classification(
     }
     item["decision"] = normalized
     item["updated_at"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    released_lease_id = _release_active_triage_lease(session, item_id, agent_id=agent_id)
+    if released_lease_id:
+        item["state"] = "open"
+        item["status"] = "OPEN"
+        item["blocking"] = True
+        item["claimed_by"] = None
+        item["claimed_at"] = None
+        item["lease_expires_at"] = None
+        item.pop("active_lease_id", None)
     session_store.save_session(repo, pr_number, session)
     return {
         "status": "CLASSIFICATION_RECORDED",
@@ -138,6 +149,7 @@ def record_classification(
         "item_id": item_id,
         "classification": normalized,
         "evidence_record_id": record.record_id,
+        "released_lease_id": released_lease_id,
     }
 
 
@@ -415,7 +427,7 @@ def submit_action_response(
         "lease_id": lease_id,
         "item_id": item_id,
         "evidence_record_id": record.record_id,
-        "next_action": "Run review again to publish accepted evidence.",
+        "next_action": f"Run `gh-address-cr agent publish {repo} {pr_number}` to publish accepted evidence.",
     }
 
 
@@ -670,10 +682,11 @@ def _github_thread_id(item_id: str, item: dict[str, Any]) -> str:
 
 
 def _publish_reply_body(item: dict[str, Any], response: dict[str, Any]) -> tuple[str | None, str | None]:
+    resolution = str(response.get("resolution") or item.get("publish_resolution") or "")
     reply_markdown = response.get("reply_markdown")
-    if isinstance(reply_markdown, str) and reply_markdown.strip():
+    if resolution != "fix" and isinstance(reply_markdown, str) and reply_markdown.strip():
         return reply_markdown, None
-    if str(response.get("resolution") or item.get("publish_resolution") or "") != "fix":
+    if resolution != "fix":
         return None, "MISSING_PUBLISH_REPLY"
     fix_reply = response.get("fix_reply")
     if not isinstance(fix_reply, dict):
@@ -691,20 +704,12 @@ def _publish_reply_body(item: dict[str, Any], response: dict[str, Any]) -> tuple
         return None, "MISSING_FIX_REPLY_TEST_COMMAND"
     if not test_result:
         return None, "MISSING_FIX_REPLY_TEST_RESULT"
-    summary = str(fix_reply.get("summary") or response.get("note") or "Addressed the review thread.").strip()
+    severity = _normalize_fix_reply_severity(fix_reply.get("severity") or item.get("severity") or "P2")
     why = str(fix_reply.get("why") or "Addressed the CR with targeted changes and validation evidence.").strip()
-    body = "\n".join(
-        [
-            summary,
-            "",
-            f"- Commit: `{commit_hash}`",
-            f"- Files: {', '.join(files)}",
-            f"- Validation: `{test_command}` ({test_result})",
-            "",
-            why,
-        ]
-    )
-    return body, None
+    try:
+        return render_fix_reply(severity, [commit_hash, ",".join(files), test_command, test_result, why]), None
+    except SystemExit as exc:
+        return None, str(exc) or "MISSING_PUBLISH_REPLY"
 
 
 def _normalize_string_list(value: Any) -> list[str]:
@@ -727,6 +732,35 @@ def _normalize_validation_commands(value: Any) -> list[str]:
         if command_text:
             commands.append(command_text)
     return commands
+
+
+def _normalize_fix_reply_severity(value: Any) -> str:
+    severity = str(value or "").strip().upper()
+    return severity if severity in {"P1", "P2", "P3"} else "P2"
+
+
+def _release_active_triage_lease(session: dict[str, Any], item_id: str, *, agent_id: str) -> str | None:
+    for lease_id, lease in session.get("leases", {}).items():
+        if not isinstance(lease, dict):
+            continue
+        if lease.get("item_id") != item_id:
+            continue
+        if lease.get("role") != "triage":
+            continue
+        if lease.get("status") not in {"active", "submitted"}:
+            continue
+        release_lease(session, str(lease_id), reason="classification_recorded")
+        _ledger(session).append_event(
+            session_id=str(session["session_id"]),
+            item_id=item_id,
+            lease_id=str(lease_id),
+            agent_id=agent_id,
+            role="triage",
+            event_type="classification_lease_released",
+            payload={"reason": "classification_recorded"},
+        )
+        return str(lease_id)
+    return None
 
 
 def _side_effect_key(session: dict[str, Any], item_id: str, side_effect_type: str) -> str:

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -281,6 +281,11 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         result = self.run_runtime_module("agent", "submit", self.repo, self.pr, "--input", str(response_path))
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["next_action"],
+            f"Run `gh-address-cr agent publish {self.repo} {self.pr}` to publish accepted evidence.",
+        )
         session = self.load_session()
         item = session["items"]["github-thread:abc"]
         self.assertEqual(item["state"], "publish_ready")

--- a/tests/test_native_workflow.py
+++ b/tests/test_native_workflow.py
@@ -61,6 +61,37 @@ class NativeWorkflowTests(unittest.TestCase):
                 self.assertEqual(evidence_rows[0]["event_type"], "classification_recorded")
                 self.assertEqual(evidence_rows[0]["agent_id"], "triage-1")
 
+    def test_record_classification_releases_active_triage_lease_for_fixer(self):
+        from gh_address_cr.core import workflow
+
+        repo = "owner/repo"
+        pr_number = "123"
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                manager = self.write_session(repo, pr_number, open_item())
+
+                triage = workflow.issue_action_request(repo, pr_number, role="triage", agent_id="triage-1")
+                classified = workflow.record_classification(
+                    repo,
+                    pr_number,
+                    item_id="local:1",
+                    classification="fix",
+                    agent_id="triage-1",
+                    note="Real defect.",
+                )
+                fixer = workflow.issue_action_request(repo, pr_number, role="fixer", agent_id="fixer-1")
+
+                session = manager.load()
+                triage_lease = session["leases"][triage["lease_id"]]
+                fixer_lease = session["leases"][fixer["lease_id"]]
+                self.assertEqual(classified["status"], "CLASSIFICATION_RECORDED")
+                self.assertEqual(classified["released_lease_id"], triage["lease_id"])
+                self.assertEqual(triage_lease["status"], "released")
+                self.assertEqual(triage_lease["reason"], "classification_recorded")
+                self.assertEqual(fixer["status"], "ACTION_REQUESTED")
+                self.assertEqual(fixer_lease["role"], "fixer")
+                self.assertEqual(session["items"]["local:1"]["active_lease_id"], fixer["lease_id"])
+
     def test_record_classification_rejects_unknown_item_without_mutation(self):
         from gh_address_cr.core import workflow
 
@@ -165,6 +196,185 @@ class NativeWorkflowTests(unittest.TestCase):
                 self.assertIn("reply_posted", event_types)
                 self.assertIn("thread_resolved", event_types)
                 self.assertIn("response_published", event_types)
+
+    def test_publish_ready_thread_survives_remote_refresh_before_publish(self):
+        from gh_address_cr.core import gate, workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+                self.resolved = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append((repo, pr_number, thread_id, body))
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                self.resolved.append((repo, pr_number, thread_id))
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        remote_threads = [
+            {
+                "id": "THREAD_1",
+                "isResolved": False,
+                "isOutdated": False,
+                "path": "src/example.py",
+                "line": 12,
+                "url": "https://github.test/thread",
+                "body": "Please validate this input.",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                manager = self.write_session(repo, pr_number, item)
+                refreshed = gate.session_with_remote_threads(manager.load(), remote_threads)
+                manager.save(refreshed)
+                client = FakeGitHubClient()
+
+                result = workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                session = manager.load()
+                self.assertEqual(result["status"], "PUBLISH_COMPLETE")
+                self.assertEqual(client.replies[0][2], "THREAD_1")
+                self.assertEqual(client.resolved[0], (repo, pr_number, "THREAD_1"))
+                self.assertEqual(session["items"]["github-thread:THREAD_1"]["state"], "closed")
+
+    def test_publish_github_thread_fix_uses_documented_reply_template(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "severity": "P1",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        expected = (
+            "Fixed in `abc123`.\n"
+            "\n"
+            "Severity: `P1`\n"
+            "\n"
+            "What I changed:\n"
+            "- `src/example.py`: updated per CR scope\n"
+            "\n"
+            "Why this addresses the CR:\n"
+            "- The input is now checked before use.\n"
+            "- High-severity path validated with targeted regression checks.\n"
+            "\n"
+            "Validation:\n"
+            "- `python3 -m unittest tests.test_example`\n"
+            "- Result: passed\n"
+            "\n"
+            "If anything still looks off, I can follow up with a focused patch.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                self.write_session(repo, pr_number, item)
+                client = FakeGitHubClient()
+
+                workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                self.assertEqual(client.replies[0], expected)
+
+    def test_publish_github_thread_fix_ignores_reply_markdown_when_fix_reply_exists(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "severity": "P2",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "reply_markdown": "Legacy handwritten reply must not be used for fix.",
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                self.write_session(repo, pr_number, item)
+                client = FakeGitHubClient()
+
+                workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                self.assertIn("Fixed in `abc123`.", client.replies[0])
+                self.assertNotIn("Legacy handwritten reply", client.replies[0])
 
     def test_publish_github_thread_response_fails_before_side_effect_without_reply_body(self):
         from gh_address_cr.core import workflow

--- a/tests/test_native_workflow.py
+++ b/tests/test_native_workflow.py
@@ -262,6 +262,73 @@ class NativeWorkflowTests(unittest.TestCase):
                 self.assertEqual(client.resolved[0], (repo, pr_number, "THREAD_1"))
                 self.assertEqual(session["items"]["github-thread:THREAD_1"]["state"], "closed")
 
+    def test_remote_refresh_recovers_publish_ready_from_accepted_evidence(self):
+        from gh_address_cr.core import gate, workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+                self.resolved = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append((repo, pr_number, thread_id, body))
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                self.resolved.append((repo, pr_number, thread_id))
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "state": "open",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        remote_threads = [
+            {
+                "id": "THREAD_1",
+                "isResolved": False,
+                "isOutdated": False,
+                "path": "src/example.py",
+                "line": 12,
+                "url": "https://github.test/thread",
+                "body": "Please validate this input.",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                manager = self.write_session(repo, pr_number, item)
+                refreshed = gate.session_with_remote_threads(manager.load(), remote_threads)
+                manager.save(refreshed)
+
+                self.assertEqual(refreshed["items"]["github-thread:THREAD_1"]["state"], "publish_ready")
+
+                client = FakeGitHubClient()
+                result = workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                session = manager.load()
+                self.assertEqual(result["status"], "PUBLISH_COMPLETE")
+                self.assertEqual(client.replies[0][2], "THREAD_1")
+                self.assertEqual(client.resolved[0], (repo, pr_number, "THREAD_1"))
+                self.assertEqual(session["items"]["github-thread:THREAD_1"]["state"], "closed")
+
     def test_publish_github_thread_fix_uses_documented_reply_template(self):
         from gh_address_cr.core import workflow
 

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -705,6 +705,66 @@ else:
         self.assertEqual(summary["reason_code"], "PASSED")
         self.assertIsNone(summary["waiting_on"])
 
+    def test_cli_threads_machine_includes_actionable_thread_rows(self):
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+if sys.argv[1:3] == ['api', 'graphql']:
+    print(json.dumps({
+        'data': {
+            'repository': {
+                'pullRequest': {
+                    'reviewThreads': {
+                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        'nodes': [{
+                            'id': 'THREAD_ACTIONABLE',
+                            'isResolved': False,
+                            'isOutdated': False,
+                            'path': 'src/thread.py',
+                            'line': 12,
+                            'comments': {'nodes': [
+                                {'url': 'https://example.test/thread/actionable', 'body': 'Please fix this.', 'author': {'login': 'reviewer'}},
+                            ]},
+                            'firstComment': {'nodes': [{'url': 'https://example.test/thread/actionable', 'body': 'Please fix this.'}]},
+                            'latestComment': {'nodes': [{'url': 'https://example.test/thread/actionable', 'body': 'Please fix this.'}]},
+                        }]
+                    }
+                }
+            }
+        }
+    }))
+elif sys.argv[1:3] == ['api', 'user']:
+    print(json.dumps({'login': 'agent-login'}))
+elif sys.argv[1:3] == ['api', 'repos/octo/example/pulls/77/reviews?per_page=100&page=1']:
+    print('[]')
+else:
+    raise SystemExit(f'unhandled gh args: {sys.argv[1:]}')
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "--machine", "threads", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["threads"][0]["item_id"], "github-thread:THREAD_ACTIONABLE")
+        self.assertEqual(summary["threads"][0]["thread_id"], "THREAD_ACTIONABLE")
+        self.assertEqual(summary["threads"][0]["path"], "src/thread.py")
+        self.assertEqual(summary["threads"][0]["line"], 12)
+        self.assertEqual(summary["threads"][0]["body"], "Please fix this.")
+        self.assertEqual(summary["threads"][0]["url"], "https://example.test/thread/actionable")
+        self.assertEqual(summary["threads"][0]["state"], "open")
+        self.assertEqual(summary["threads"][0]["status"], "OPEN")
+        self.assertFalse(summary["threads"][0]["is_resolved"])
+        self.assertFalse(summary["threads"][0]["is_outdated"])
+        self.assertFalse(summary["threads"][0]["accepted_response_present"])
+        self.assertIsNone(summary["threads"][0]["reply_evidence"])
+
     def test_cli_findings_defaults_to_structured_summary(self):
         payload_file = Path(self.temp_dir.name) / "findings.json"
         payload_file.write_text(
@@ -2148,6 +2208,53 @@ else:
         self.assertNotEqual(result.returncode, 0, result.stderr)
         self.assertIn("github_threads_missing_reply_count=1", result.stdout)
         self.assertIn("missing reply evidence", result.stderr)
+
+    def test_cli_final_gate_no_auto_clean_preserves_audit_report_artifacts(self):
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+
+if args[:2] == ['api', 'graphql']:
+    print(json.dumps({
+        'data': {
+            'repository': {
+                'pullRequest': {
+                    'reviewThreads': {
+                        'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                        'nodes': []
+                    }
+                }
+            }
+        }
+    }))
+elif args[:2] == ['api', 'user']:
+    print(json.dumps({'login': 'agent-login'}))
+elif args[:2] == ['api', 'repos/octo/example/pulls/77/reviews?per_page=100&page=1']:
+    print('[]')
+else:
+    raise SystemExit(f'unhandled gh args: {args}')
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd(
+            [sys.executable, str(CLI_PY), "final-gate", "--no-auto-clean", "--audit-id", "native-run", self.repo, self.pr]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        report = self.run_cmd([sys.executable, str(AUDIT_REPORT_PY), "--run-id", "native-run", self.repo, self.pr])
+
+        self.assertEqual(report.returncode, 0, report.stderr)
+        self.assertNotIn("No audit log found.", report.stdout)
+        self.assertNotIn("No trace log found.", report.stdout)
+        self.assertNotIn("No audit summary found.", report.stdout)
+        self.assertIn('"run_id": "native-run"', report.stdout)
+        self.assertIn("== Audit Summary SHA256 ==", report.stdout)
 
     def test_final_gate_python_fails_when_current_login_has_pending_reviews(self):
         gh = self.bin_dir / "gh"


### PR DESCRIPTION
## Summary

Fixes the Issue #16 P1/P2 agent workflow contract bugs in one PR. This covers accepted GitHub-thread evidence preservation, triage lease release after classification, documented publish reply rendering, retained final-gate audit evidence, and actionable `threads` machine output.

Fixes #17
Fixes #18
Fixes #19
Fixes #20
Fixes #21
Refs #16

#22-#24 are intentionally out of scope for this PR.

## Changes

- Preserve `publish_ready`, `accepted_response`, and publish resolution when remote review threads are refreshed before publish.
- Release active triage leases after `agent classify`, clearing claim fields so fixer agents can claim without overlap conflicts.
- Render GitHub fix replies through the shared documented template (`Fixed in`, `Severity`, `What I changed`, `Why this addresses the CR`, `Validation`).
- Retain native `final-gate --no-auto-clean` audit artifacts for `audit-report` without changing auto-clean archive behavior.
- Add actionable thread rows to `threads --machine` output while keeping existing summary fields.
- Update runtime/skill docs for the changed agent-facing contracts.

## Validation

- `ruff check src tests`
- `/opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `/opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `/opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
- `git diff --check`

## Notes

This PR does not add lightweight address mode, batch evidence schema, auth/env diagnostics, normalized findings contract changes, or a new `address` command.
