### PR TITLE
feat: add lightweight address flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ Native runtime ownership is now split by responsibility:
 - `src/gh_address_cr/legacy_scripts/`: compatibility shims for packaged runtime script paths
 
 The native packages under `core/`, `github/`, and `intake/` must not import `legacy_scripts`.
-Public high-level commands (`review`, `threads`, `findings`, and `adapter`) are routed through the native runtime package. Core script entrypoints such as `session_engine.py`, `cr_loop.py`, and `control_plane.py` now delegate to native modules; the remaining `legacy_scripts` files are compatibility surfaces for older direct script invocations.
+Public high-level commands (`review`, `address`, `threads`, `findings`, and `adapter`) are routed through the native runtime package. Core script entrypoints such as `session_engine.py`, `cr_loop.py`, and `control_plane.py` now delegate to native modules; the remaining `legacy_scripts` files are compatibility surfaces for older direct script invocations.
 
 ## Public Interface
 
-`gh-address-cr` should be understood first as a PR-scoped workflow orchestrator with one public main entrypoint:
+`gh-address-cr` should be understood first as a PR-scoped workflow orchestrator with one public main entrypoint plus a lightweight thread-only shortcut:
 
 - `review`
+- `address`
 
 Advanced/internal integration entrypoints:
 
@@ -183,6 +184,7 @@ Minimal invocation model:
 
 ```text
 /gh-address-cr review <owner/repo> <pr_number>
+/gh-address-cr address <owner/repo> <pr_number>
 ```
 
 Advanced/internal integrations are documented later in this README.
@@ -203,7 +205,7 @@ Stable machine summary fields:
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
-The `threads` command may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
+The `threads` command and lightweight address states may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
 
 ## Multi-Agent Coordination
 
@@ -246,8 +248,13 @@ High-level entrypoints:
   - public main entrypoint
   - runs the full PR review workflow automatically
   - waits for external producer handoff when findings are absent
+  - supports `--auto-simple` for the lightweight GitHub thread-only path
   - handles both local findings and GitHub review threads in one run
   - emits a machine-readable JSON summary by default
+- `address`
+  - lightweight GitHub thread-only entrypoint for simple PRs
+  - does not wait for external review findings or ingest local findings
+  - emits `WAITING_FOR_SIMPLE_ADDRESS` with an actionable request artifact when threads need agent evidence
 - `threads`
   - advanced/internal: GitHub review threads only
   - emits a machine-readable JSON summary by default
@@ -462,6 +469,7 @@ For explicit automation or repository-root invocation, the main command is:
 
 ```bash
 python3 skill/scripts/cli.py review <owner/repo> <pr_number> [--input <path>|-] [--human]
+python3 skill/scripts/cli.py address <owner/repo> <pr_number> [--human]
 ```
 
 For `producer=code-review`, generate the standardized bridge prompt with:
@@ -483,6 +491,8 @@ The converter writes the standardized findings JSON to the cache-backed PR works
 Advanced CLI examples:
 
 ```text
+$gh-address-cr address <PR_URL>
+$gh-address-cr review --auto-simple <PR_URL>
 $gh-address-cr threads <PR_URL>
 $gh-address-cr findings <PR_URL> --input findings.json
 $gh-address-cr findings <PR_URL> --input - --sync

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gh-address-cr
 description: Use when a GitHub Pull Request needs review-thread reply and resolve handling, findings ingestion, and a mandatory final gate in one PR-scoped session.
-argument-hint: "<review|threads|findings|adapter> ..."
+argument-hint: "<review|address|threads|findings|adapter> ..."
 ---
 
 # gh-address-cr
@@ -13,6 +13,7 @@ The runtime owns session state, intake routing, GitHub side effects, leases, and
 
 ```text
 /gh-address-cr review <owner/repo> <pr_number>
+/gh-address-cr address <owner/repo> <pr_number>
 /gh-address-cr threads <owner/repo> <pr_number>
 /gh-address-cr findings <owner/repo> <pr_number> --input <path>|-
 /gh-address-cr adapter <owner/repo> <pr_number> <adapter_cmd...>
@@ -44,7 +45,7 @@ If the runtime is missing or incompatible, the shim must fail loudly before sess
 
 Read this skill in this order when you are an AI agent:
 
-1. Start from the public main entrypoint: `review <owner/repo> <pr_number>`.
+1. Start from the public main entrypoint: `review <owner/repo> <pr_number>`, or `address <owner/repo> <pr_number>` for simple GitHub-thread-only PRs.
 2. Inspect the JSON machine summary output from the runtime.
 3. Consult `references/status-action-map.md` to map the runtime `status`, `reason_code`, and `next_action` to your next safe step. You MUST branch your execution strictly based on these structured fields. Never parse or infer state from human prose or logs.
 4. For multi-agent execution, use `agent orchestrate start`, `agent orchestrate step`, `agent orchestrate submit`, `agent orchestrate status`, and `agent orchestrate stop` through the runtime CLI.
@@ -52,7 +53,7 @@ Read this skill in this order when you are an AI agent:
 
 Fail-fast rules:
 
-- `review` is the only public main entrypoint.
+- `review` is the full public main entrypoint; `address` is the lightweight GitHub-thread-only shortcut.
 - `review-to-findings` does not accept arbitrary Markdown. It only accepts the fixed `finding` block format. This converter rejects plain narrative Markdown review output.
 - AI agents must not post GitHub replies or resolve threads directly; the runtime records evidence and performs deterministic side effects.
 - If a command outputs a `reason_code` or `next_action`, your next step MUST be determined solely by that code, ignoring all other prose in the `message` field.
@@ -75,7 +76,7 @@ High-level commands emit structured JSON by default. Agents MUST consume these f
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
-The `threads` command may also include a `threads` array with actionable GitHub thread context (`thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence).
+The `threads` command and lightweight address states may also include a `threads` array with actionable GitHub thread context (`thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence).
 
 ## Multi-Agent Protocol
 
@@ -122,6 +123,7 @@ Treat `SKILL.md` as the source of truth for using this skill.
 
 - Start from the high-level dispatcher:
   - `python3 scripts/cli.py review <owner/repo> <pr_number>`
+  - `python3 scripts/cli.py address <owner/repo> <pr_number>`
   - `python3 scripts/cli.py threads <owner/repo> <pr_number>`
   - `python3 scripts/cli.py findings <owner/repo> <pr_number> --input <path>|- [--sync]`
   - `python3 scripts/cli.py adapter <owner/repo> <pr_number> <adapter_cmd...>`
@@ -133,6 +135,7 @@ Treat `SKILL.md` as the source of truth for using this skill.
 These high-level paths are fully operational now:
 
 - `review`
+- `address`
 - `threads`
 - `findings`
 - `adapter`
@@ -292,6 +295,8 @@ Examples:
 
 ```text
 $gh-address-cr review <PR_URL>
+$gh-address-cr address <PR_URL>
+$gh-address-cr review --auto-simple <PR_URL>
 $gh-address-cr threads <PR_URL>
 $gh-address-cr findings <PR_URL> --input findings.json
 $gh-address-cr findings <PR_URL> --input - --sync

--- a/skill/references/status-action-map.md
+++ b/skill/references/status-action-map.md
@@ -13,6 +13,12 @@ If `status` is `ACTION_ACCEPTED`:
 If `status` is `BLOCKED`:
 - **Action**: Inspect the `reason_code` and `waiting_on`. Handle the blocked item by applying a resolution (`fix`, `clarify`, `defer`, `reject`).
 
+If `reason_code` is `WAITING_FOR_SIMPLE_ADDRESS`:
+- **Action**: Inspect the `artifact_path` and `threads` array. Use per-thread `agent classify`, `agent next`, `agent submit`, and `agent publish`; do not invent a batch response.
+
+If `reason_code` is `AUTO_SIMPLE_NOT_ELIGIBLE`:
+- **Action**: Stop the lightweight path and run the normal `review`, `findings`, or `adapter` workflow to handle local findings.
+
 ## External Interactions
 
 If `status` is `WAITING_FOR_EXTERNAL_REVIEW`:

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -819,6 +819,13 @@ def _first_blocking_item(session: dict) -> dict | None:
     return None
 
 
+def _first_local_item(session: dict) -> dict | None:
+    for item in session.get("items", {}).values():
+        if isinstance(item, dict) and item.get("item_kind") == "local_finding":
+            return item
+    return None
+
+
 def _native_summary(
     *,
     command: str,
@@ -896,6 +903,17 @@ def _blocking_local_items(session: dict) -> list[dict]:
     ]
 
 
+def _auto_simple_local_gate_failed(result: core_gate.GateResult) -> bool:
+    return any(
+        code
+        in {
+            core_gate.FINAL_GATE_BLOCKING_LOCAL_ITEMS,
+            core_gate.FINAL_GATE_MISSING_VALIDATION_EVIDENCE,
+        }
+        for code in result.failure_codes
+    )
+
+
 def _write_simple_address_request(repo: str, pr_number: str, session: dict, *, command: str, run_id: str) -> Path:
     request_path = workspace_root(repo, pr_number) / f"simple-address-request-{run_id}-{uuid4().hex}.json"
     request = {
@@ -926,7 +944,8 @@ def _parse_native_high_level_args(command: str, args: list[str]) -> argparse.Nam
     parser.add_argument("repo")
     parser.add_argument("pr_number")
     parser.add_argument("adapter_cmd", nargs="*")
-    parser.add_argument("--auto-simple", action="store_true")
+    if command == "review":
+        parser.add_argument("--auto-simple", action="store_true")
     parser.add_argument("--input")
     parser.add_argument("--source")
     parser.add_argument("--sync", action="store_true")
@@ -940,6 +959,8 @@ def _parse_native_high_level_args(command: str, args: list[str]) -> argparse.Nam
         parsed.adapter_cmd.extend(unknown)
     if parsed.adapter_cmd and parsed.adapter_cmd[0] == "--":
         parsed.adapter_cmd = parsed.adapter_cmd[1:]
+    if not hasattr(parsed, "auto_simple"):
+        parsed.auto_simple = False
     return parsed
 
 
@@ -997,7 +1018,7 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
         if auto_simple and _blocking_local_items(session):
             next_action = (
                 "Auto-simple only handles GitHub review threads. Run normal review/findings/adapter workflow "
-                "to handle blocking local findings, then rerun address."
+                "to handle local findings, then rerun this command."
             )
             item = _blocking_local_items(session)[0]
             _set_loop_state(
@@ -1077,6 +1098,38 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
         return 5
 
     if auto_simple and not result.passed:
+        if _auto_simple_local_gate_failed(result):
+            next_action = (
+                "Auto-simple only handles GitHub review threads. Run normal review/findings/adapter workflow "
+                "to handle local findings, then rerun this command."
+            )
+            item = _first_local_item(session) or _first_blocking_item(session)
+            _set_loop_state(
+                session,
+                run_id=run_id,
+                status="BLOCKED",
+                iteration=1,
+                max_iterations=parsed.max_iterations,
+                current_item_id=item.get("item_id") if item else None,
+                last_error=next_action,
+            )
+            _recalc_native_metrics(session)
+            session_store.save_session(repo, pr_number, session)
+            summary = _native_summary(
+                command=command,
+                repo=repo,
+                pr_number=pr_number,
+                status="BLOCKED",
+                reason_code="AUTO_SIMPLE_NOT_ELIGIBLE",
+                waiting_on="local_findings",
+                next_action=next_action,
+                exit_code=5,
+                session=session,
+                item=item,
+                include_threads=True,
+            )
+            _emit_native_summary(summary, human=human)
+            return 5
         item = _first_blocking_item(session)
         request_path = _write_simple_address_request(repo, pr_number, session, command=command, run_id=run_id)
         next_action = (

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -56,10 +56,10 @@ COMMAND_TO_SCRIPT = {
     "submit-action": "submit_action.py",
 }
 
-HIGH_LEVEL_COMMANDS = {"review", "threads", "findings", "adapter", "submit-action"}
-NATIVE_HIGH_LEVEL_COMMANDS = {"review", "threads", "findings", "adapter"}
+HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter", "submit-action"}
+NATIVE_HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter"}
 OUTPUT_FLAGS = {"--machine", "--human"}
-HIGH_LEVEL_GH_COMMANDS = {"review", "threads", "adapter"}
+HIGH_LEVEL_GH_COMMANDS = {"address", "review", "threads", "adapter"}
 INPUT_REQUIRED_COMMANDS = {"findings"}
 WAITING_FOR_EXTERNAL_REVIEW_EXIT = 6
 PR_IO_PREFLIGHT_EXIT = 5
@@ -181,12 +181,22 @@ def rewrite_alias_args(
 def alias_help(command: str) -> str:
     if command == "review":
         return (
-            "usage: cli.py review <owner/repo> <pr_number> [--input <path>|-] [--human|--machine]\n\n"
+            "usage: cli.py review [--auto-simple] <owner/repo> <pr_number> [--input <path>|-] [--human|--machine]\n\n"
             "High-level PR review entrypoint.\n\n"
             "Use when you want the full PR review workflow to run automatically.\n"
             "This command waits for external review findings when they are absent,\n"
             "then tells you to re-run the same review command once handoff artifacts are filled.\n"
             "You may still provide findings JSON explicitly via --input <path> or --input -.\n"
+            "Use --auto-simple for a lightweight GitHub thread-only path that does not wait for external review findings.\n"
+            "Default output is a structured JSON summary. Use --human for narrative text.\n"
+            "--machine remains a compatibility alias for the default machine summary.\n"
+        )
+    if command == "address":
+        return (
+            "usage: cli.py address <owner/repo> <pr_number> [--human|--machine]\n\n"
+            "Lightweight GitHub thread-only entrypoint.\n\n"
+            "Use for simple PRs where only GitHub review threads need addressing.\n"
+            "This command does not wait for external review findings and does not ingest local findings.\n"
             "Default output is a structured JSON summary. Use --human for narrative text.\n"
             "--machine remains a compatibility alias for the default machine summary.\n"
         )
@@ -486,6 +496,11 @@ def normalize_high_level_target_args(args: argparse.Namespace) -> None:
     args.args = [repo, pr_number, *args.args[1:]]
 
 
+def normalize_leading_high_level_options(args: argparse.Namespace) -> None:
+    if args.command == "review" and args.args and args.args[0] == "--auto-simple":
+        args.args = [*args.args[1:], "--auto-simple"]
+
+
 def output_preflight_error(
     args: argparse.Namespace,
     repo: str,
@@ -573,6 +588,9 @@ def preflight_high_level(args: argparse.Namespace) -> int | None:
         gh_preflight = preflight_github_cli(args, repo, pr_number)
         if gh_preflight is not None:
             return gh_preflight
+
+    if args.command == "review" and has_option(args.args, "--auto-simple"):
+        return None
 
     if args.command == "review" and not has_option(args.args, "--input"):
         normalized_input, handoff_sha256, error = normalize_review_handoff(repo, pr_number)
@@ -814,6 +832,7 @@ def _native_summary(
     session: dict,
     artifact_path: str | None = None,
     item: dict | None = None,
+    include_threads: bool = False,
 ) -> dict:
     metrics = session.get("metrics") if isinstance(session.get("metrics"), dict) else {}
     summary = {
@@ -834,7 +853,7 @@ def _native_summary(
         "next_action": next_action,
         "exit_code": exit_code,
     }
-    if command == "threads":
+    if command == "threads" or include_threads:
         summary["threads"] = _native_thread_rows(session)
     return summary
 
@@ -868,11 +887,46 @@ def _native_thread_rows(session: dict) -> list[dict]:
     return rows
 
 
+def _blocking_local_items(session: dict) -> list[dict]:
+    items = session.get("items") if isinstance(session.get("items"), dict) else {}
+    return [
+        item
+        for item in items.values()
+        if isinstance(item, dict) and item.get("item_kind") == "local_finding" and bool(item.get("blocking"))
+    ]
+
+
+def _write_simple_address_request(repo: str, pr_number: str, session: dict, *, command: str, run_id: str) -> Path:
+    request_path = workspace_root(repo, pr_number) / f"simple-address-request-{run_id}-{uuid4().hex}.json"
+    request = {
+        "mode": "simple-address",
+        "repo": repo,
+        "pr_number": str(pr_number),
+        "run_id": run_id,
+        "source_command": command,
+        "threads": _native_thread_rows(session),
+        "instructions": [
+            "Use existing per-thread ActionResponse evidence; do not submit a batch response.",
+            "For each actionable GitHub thread, run agent classify, agent next, agent submit, then agent publish.",
+            "Common commit, file, and validation evidence may be reused in each per-thread response when applicable.",
+        ],
+        "commands": {
+            "classify": f"gh-address-cr agent classify {repo} {pr_number} <item_id> --classification fix --note <note>",
+            "next": f"gh-address-cr agent next {repo} {pr_number} --role fixer --agent-id <agent_id>",
+            "submit": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+            "publish": f"gh-address-cr agent publish {repo} {pr_number}",
+        },
+    }
+    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return request_path
+
+
 def _parse_native_high_level_args(command: str, args: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=f"gh-address-cr {command}", add_help=False)
     parser.add_argument("repo")
     parser.add_argument("pr_number")
     parser.add_argument("adapter_cmd", nargs="*")
+    parser.add_argument("--auto-simple", action="store_true")
     parser.add_argument("--input")
     parser.add_argument("--source")
     parser.add_argument("--sync", action="store_true")
@@ -903,6 +957,7 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
     repo = parsed.repo
     pr_number = str(parsed.pr_number)
     run_id = parsed.audit_id or f"native-{_utc_now()}"
+    auto_simple = command == "address" or (command == "review" and bool(parsed.auto_simple))
     session = _load_or_create_session(repo, pr_number)
     _set_loop_state(session, run_id=run_id, status="ACTIVE", iteration=1, max_iterations=parsed.max_iterations)
 
@@ -934,11 +989,43 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
             )
 
         remote_threads: list[dict] = []
-        if command in {"review", "threads", "adapter"}:
+        if command in {"address", "review", "threads", "adapter"}:
             client = GitHubClient()
             remote_threads = client.list_threads(repo, pr_number)
             session = core_gate.session_with_remote_threads(session, remote_threads)
         _recalc_native_metrics(session)
+        if auto_simple and _blocking_local_items(session):
+            next_action = (
+                "Auto-simple only handles GitHub review threads. Run normal review/findings/adapter workflow "
+                "to handle blocking local findings, then rerun address."
+            )
+            item = _blocking_local_items(session)[0]
+            _set_loop_state(
+                session,
+                run_id=run_id,
+                status="BLOCKED",
+                iteration=1,
+                max_iterations=parsed.max_iterations,
+                current_item_id=item.get("item_id"),
+                last_error=next_action,
+            )
+            _recalc_native_metrics(session)
+            session_store.save_session(repo, pr_number, session)
+            summary = _native_summary(
+                command=command,
+                repo=repo,
+                pr_number=pr_number,
+                status="BLOCKED",
+                reason_code="AUTO_SIMPLE_NOT_ELIGIBLE",
+                waiting_on="local_findings",
+                next_action=next_action,
+                exit_code=5,
+                session=session,
+                item=item,
+                include_threads=True,
+            )
+            _emit_native_summary(summary, human=human)
+            return 5
         result = core_gate.evaluate_final_gate(session, remote_threads=remote_threads)
     except (FindingsFormatError, OSError) as exc:
         _set_loop_state(
@@ -985,6 +1072,41 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
             next_action=str(exc),
             exit_code=5,
             session=session,
+        )
+        _emit_native_summary(summary, human=human)
+        return 5
+
+    if auto_simple and not result.passed:
+        item = _first_blocking_item(session)
+        request_path = _write_simple_address_request(repo, pr_number, session, command=command, run_id=run_id)
+        next_action = (
+            "Address GitHub review threads with per-thread agent evidence, then run "
+            f"`gh-address-cr agent publish {repo} {pr_number}` and rerun this command."
+        )
+        _set_loop_state(
+            session,
+            run_id=run_id,
+            status="BLOCKED",
+            iteration=1,
+            max_iterations=parsed.max_iterations,
+            current_item_id=item.get("item_id") if item else None,
+            last_error=next_action,
+        )
+        _recalc_native_metrics(session)
+        session_store.save_session(repo, pr_number, session)
+        summary = _native_summary(
+            command=command,
+            repo=repo,
+            pr_number=pr_number,
+            status="BLOCKED",
+            reason_code="WAITING_FOR_SIMPLE_ADDRESS",
+            waiting_on="agent_fix",
+            next_action=next_action,
+            exit_code=5,
+            session=session,
+            artifact_path=str(request_path),
+            item=item,
+            include_threads=True,
         )
         _emit_native_summary(summary, human=human)
         return 5
@@ -1045,6 +1167,7 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
         next_action="No action required.",
         exit_code=0,
         session=session,
+        include_threads=auto_simple,
     )
     _emit_native_summary(summary, human=human)
     return 0
@@ -1110,7 +1233,7 @@ def build_agent_manifest() -> dict:
         "constraints": {
             "max_parallel_claims": 2,
         },
-        "public_commands": sorted(["review", "threads", "findings", "adapter", "submit-action", "final-gate"]),
+        "public_commands": sorted(["address", "review", "threads", "findings", "adapter", "submit-action", "final-gate"]),
     }
 
 
@@ -1514,10 +1637,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "command",
-        metavar="{review,threads,findings,adapter,review-to-findings,submit-feedback,submit-action}",
+        metavar="{address,review,threads,findings,adapter,review-to-findings,submit-feedback,submit-action}",
         help=(
             "High-level commands:\n"
+            "  cli.py address owner/repo 123 [--human]\n"
             "  cli.py review owner/repo 123 [--human]\n"
+            "  cli.py review --auto-simple owner/repo 123 [--human]\n"
             "  cli.py threads owner/repo 123 [--human]\n"
             "  cli.py findings owner/repo 123 --input findings.json [--human]\n"
             "  cli.py --human adapter owner/repo 123 python3 tools/review_adapter.py\n"
@@ -1611,6 +1736,7 @@ def main(argv: list[str] | None = None) -> int:
         supported_commands = ", ".join(sorted([*COMMAND_TO_SCRIPT, *NATIVE_HIGH_LEVEL_COMMANDS, "agent"]))
         print(f"Unknown command. Supported commands: {supported_commands}.", file=sys.stderr)
         return 2
+    normalize_leading_high_level_options(args)
     if not normalize_output_args(args):
         return 2
     normalize_high_level_target_args(args)

--- a/tests/test_native_runtime_boundary.py
+++ b/tests/test_native_runtime_boundary.py
@@ -136,6 +136,22 @@ class NativeRuntimeBoundaryTest(unittest.TestCase):
         self.assertEqual(summary["status"], "PASSED")
         self.assertEqual(summary["reason_code"], "PASSED")
 
+    def test_address_command_runs_without_legacy_scripts(self):
+        bin_dir = self.install_fake_gh()
+
+        with patch.dict(os.environ, {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}, clear=False):
+            rc, stdout, stderr = self.run_cli_without_legacy_scripts(
+                "address",
+                self.repo,
+                self.pr_number,
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertNotIn("Required gh-address-cr runtime script is missing", stderr)
+        summary = json.loads(stdout)
+        self.assertEqual(summary["status"], "PASSED")
+        self.assertEqual(summary["reason_code"], "PASSED")
+
     def test_adapter_command_runs_without_legacy_scripts(self):
         adapter = self.root / "adapter.py"
         adapter.write_text("import json\nprint(json.dumps([]))\n", encoding="utf-8")
@@ -157,7 +173,7 @@ class NativeRuntimeBoundaryTest(unittest.TestCase):
         self.assertEqual(summary["reason_code"], "PASSED")
 
     def test_core_public_commands_are_not_legacy_script_mapped(self):
-        for command in ("review", "findings", "threads", "adapter"):
+        for command in ("review", "findings", "threads", "adapter", "address"):
             self.assertNotIn(command, cli.COMMAND_TO_SCRIPT)
 
 

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -23,11 +23,53 @@ from tests.helpers import (
 
 
 class PythonWrapperCLITest(PythonScriptTestCase):
+    def install_fake_gh_for_threads(self, nodes):
+        payload = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": nodes,
+                        }
+                    }
+                }
+            }
+        }
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json",
+                    "import sys",
+                    "args = sys.argv[1:]",
+                    "if args[:2] == ['auth', 'status']:",
+                    "    raise SystemExit(0)",
+                    "if args[:2] == ['api', 'graphql']:",
+                    f"    print(json.dumps({payload!r}))",
+                    "    raise SystemExit(0)",
+                    "if args[:2] == ['api', 'user']:",
+                    "    print(json.dumps({'login': 'agent-login'}))",
+                    "    raise SystemExit(0)",
+                    "if args[:2] == ['api', 'repos/octo/example/pulls/77/reviews?per_page=100&page=1']:",
+                    "    print('[]')",
+                    "    raise SystemExit(0)",
+                    "raise SystemExit(f'unhandled gh args: {args}')",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        return gh
+
     def test_cli_help_lists_unified_commands(self):
         result = self.run_cmd([sys.executable, str(CLI_PY), "--help"])
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--machine", result.stdout)
         self.assertIn("--human", result.stdout)
+        self.assertIn("address", result.stdout)
         self.assertIn("review", result.stdout)
         self.assertIn("threads", result.stdout)
         self.assertIn("findings", result.stdout)
@@ -46,10 +88,19 @@ class PythonWrapperCLITest(PythonScriptTestCase):
         self.assertIn("waits for external review findings", result.stdout)
         self.assertIn("re-run the same review command", result.stdout)
         self.assertIn("Default output is a structured JSON summary.", result.stdout)
+        self.assertIn("--auto-simple", result.stdout)
         self.assertIn("--human", result.stdout)
         self.assertIn("--machine", result.stdout)
         self.assertNotIn("cr-loop", result.stdout)
         self.assertNotIn("{ingest,local,mixed,remote}", result.stdout)
+
+    def test_cli_address_help_uses_lightweight_alias_text(self):
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", "--help"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("usage: cli.py address", result.stdout)
+        self.assertIn("Lightweight GitHub thread-only entrypoint.", result.stdout)
+        self.assertIn("does not wait for external review findings", result.stdout)
+        self.assertIn("Default output is a structured JSON summary.", result.stdout)
 
     def test_cli_adapter_help_matches_orchestration_behavior(self):
         result = self.run_cmd([sys.executable, str(CLI_PY), "adapter", "--help"])
@@ -291,6 +342,127 @@ else:
         persisted = json.loads(summary_path.read_text(encoding="utf-8"))
         self.assertEqual(persisted["status"], "WAITING_FOR_EXTERNAL_REVIEW")
         self.assertEqual(persisted["reason_code"], "WAITING_FOR_EXTERNAL_REVIEW")
+
+    def test_cli_review_auto_simple_waits_for_simple_address_without_external_handoff(self):
+        self.install_fake_gh_for_threads(
+            [
+                {
+                    "id": "THREAD_SIMPLE",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/simple.py",
+                    "line": 7,
+                    "comments": {
+                        "nodes": [
+                            {
+                                "url": "https://example.test/thread/simple",
+                                "body": "Please fix this thread.",
+                                "author": {"login": "reviewer"},
+                            }
+                        ]
+                    },
+                    "firstComment": {
+                        "nodes": [{"url": "https://example.test/thread/simple", "body": "Please fix this thread."}]
+                    },
+                    "latestComment": {
+                        "nodes": [{"url": "https://example.test/thread/simple", "body": "Please fix this thread."}]
+                    },
+                }
+            ]
+        )
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "review", "--auto-simple", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "WAITING_FOR_SIMPLE_ADDRESS")
+        self.assertEqual(summary["waiting_on"], "agent_fix")
+        self.assertEqual(summary["threads"][0]["thread_id"], "THREAD_SIMPLE")
+        request_path = Path(summary["artifact_path"])
+        self.assertTrue(request_path.exists())
+        self.assertTrue(request_path.name.startswith("simple-address-request-"))
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        self.assertEqual(request["mode"], "simple-address")
+        self.assertEqual(request["threads"][0]["thread_id"], "THREAD_SIMPLE")
+        self.assertFalse((self.workspace_dir() / "producer-request.md").exists())
+
+    def test_cli_address_matches_review_auto_simple_for_unresolved_threads(self):
+        self.install_fake_gh_for_threads(
+            [
+                {
+                    "id": "THREAD_ADDRESS",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/address.py",
+                    "line": 14,
+                    "comments": {
+                        "nodes": [
+                            {
+                                "url": "https://example.test/thread/address",
+                                "body": "Please fix address path.",
+                                "author": {"login": "reviewer"},
+                            }
+                        ]
+                    },
+                    "firstComment": {
+                        "nodes": [{"url": "https://example.test/thread/address", "body": "Please fix address path."}]
+                    },
+                    "latestComment": {
+                        "nodes": [{"url": "https://example.test/thread/address", "body": "Please fix address path."}]
+                    },
+                }
+            ]
+        )
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "WAITING_FOR_SIMPLE_ADDRESS")
+        self.assertEqual(summary["waiting_on"], "agent_fix")
+        self.assertEqual(summary["threads"][0]["thread_id"], "THREAD_ADDRESS")
+        self.assertTrue(Path(summary["artifact_path"]).exists())
+
+    def test_cli_address_accepts_pr_url_target(self):
+        self.install_fake_gh_for_threads([])
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", f"https://github.com/{self.repo}/pull/{self.pr}"])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "PASSED")
+        self.assertEqual(summary["repo"], self.repo)
+        self.assertEqual(summary["pr_number"], self.pr)
+        self.assertEqual(summary["reason_code"], "PASSED")
+
+    def test_cli_address_rejects_existing_blocking_local_findings(self):
+        findings = Path(self.temp_dir.name) / "findings.json"
+        findings.write_text(
+            json.dumps(
+                [
+                    {
+                        "title": "Local finding",
+                        "body": "This local finding makes simple address ineligible.",
+                        "path": "src/local.py",
+                        "line": 9,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.run_cmd([sys.executable, str(CLI_PY), "findings", self.repo, self.pr, "--input", str(findings)])
+        self.install_fake_gh_for_threads([])
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "AUTO_SIMPLE_NOT_ELIGIBLE")
+        self.assertEqual(summary["waiting_on"], "local_findings")
+        self.assertIn("normal review", summary["next_action"])
 
     def test_cli_findings_help_mentions_source_required_for_sync(self):
         result = self.run_cmd([sys.executable, str(CLI_PY), "findings", "--help"])

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -464,6 +464,67 @@ else:
         self.assertEqual(summary["waiting_on"], "local_findings")
         self.assertIn("normal review", summary["next_action"])
 
+    def test_cli_review_auto_simple_rejects_local_findings_without_switching_commands(self):
+        findings = Path(self.temp_dir.name) / "findings.json"
+        findings.write_text(
+            json.dumps(
+                [
+                    {
+                        "title": "Local finding",
+                        "body": "This local finding makes simple address ineligible.",
+                        "path": "src/local.py",
+                        "line": 9,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.run_cmd([sys.executable, str(CLI_PY), "findings", self.repo, self.pr, "--input", str(findings)])
+        self.install_fake_gh_for_threads([])
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "review", "--auto-simple", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "AUTO_SIMPLE_NOT_ELIGIBLE")
+        self.assertEqual(summary["waiting_on"], "local_findings")
+        self.assertIn("rerun this command", summary["next_action"])
+        self.assertNotIn("rerun address", summary["next_action"])
+
+    def test_cli_address_does_not_emit_simple_request_for_local_gate_failures(self):
+        findings = Path(self.temp_dir.name) / "findings.json"
+        findings.write_text(
+            json.dumps(
+                [
+                    {
+                        "title": "Local finding",
+                        "body": "Closed local finding is missing validation.",
+                        "path": "src/local.py",
+                        "line": 9,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.run_cmd([sys.executable, str(CLI_PY), "findings", self.repo, self.pr, "--input", str(findings)])
+        session = json.loads(self.session_file().read_text(encoding="utf-8"))
+        item = next(iter(session["items"].values()))
+        item["state"] = "fixed"
+        item["status"] = "CLOSED"
+        item["blocking"] = False
+        self.session_file().write_text(json.dumps(session, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        self.install_fake_gh_for_threads([])
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "AUTO_SIMPLE_NOT_ELIGIBLE")
+        self.assertEqual(summary["waiting_on"], "local_findings")
+        self.assertFalse(list(self.workspace_dir().glob("simple-address-request-*.json")))
+
     def test_cli_findings_help_mentions_source_required_for_sync(self):
         result = self.run_cmd([sys.executable, str(CLI_PY), "findings", "--help"])
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -1098,12 +1159,13 @@ else:
                 str(adapter),
                 "--human",
                 "--machine",
+                "--auto-simple",
             ]
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         summary = json.loads(result.stdout)
         self.assertEqual(summary["status"], "PASSED")
-        self.assertEqual(json.loads(seen_args.read_text(encoding="utf-8")), ["--human", "--machine"])
+        self.assertEqual(json.loads(seen_args.read_text(encoding="utf-8")), ["--human", "--machine", "--auto-simple"])
 
     def test_cli_review_fails_fast_when_gh_is_missing(self):
         self.env["PATH"] = str(self.bin_dir)

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -171,6 +171,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("review", result.stdout)
+        self.assertIn("address", result.stdout)
         self.assertIn("threads", result.stdout)
         self.assertIn("findings", result.stdout)
         self.assertIn("final-gate", result.stdout)
@@ -183,6 +184,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
 
     def test_runtime_public_command_help_parity(self):
         commands = [
+            ("address", "--help"),
             ("review", "--help"),
             ("threads", "--help"),
             ("findings", "--help"),
@@ -204,6 +206,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "MANIFEST_READY")
+        self.assertIn("address", payload["public_commands"])
         validate_capability_manifest(payload)
         self.assertIn("coordinator", payload["roles"])
         self.assertIn("triage", payload["roles"])


### PR DESCRIPTION
## Summary

Adds the lightweight GitHub-thread-only address path for simple PRs.

Fixes #22
Refs #16

This PR is stacked on #25 (`codex/issue-16-agent-workflow-contracts`). #23 batch evidence submission and #24 environment/auth diagnostics remain out of scope.

## Changes

- Add `gh-address-cr address <repo> <pr>` as a native high-level command.
- Add `gh-address-cr review --auto-simple <repo> <pr>` as an equivalent lightweight path.
- Skip external review handoff for auto-simple runs while preserving normal `review` behavior.
- Emit `WAITING_FOR_SIMPLE_ADDRESS` with actionable thread rows and a `simple-address-request-*.json` artifact when GitHub threads need per-thread agent evidence.
- Emit `AUTO_SIMPLE_NOT_ELIGIBLE` when blocking local findings already exist, directing callers back to normal `review` / `findings` / `adapter` workflows.
- Update runtime/skill docs and status-action mapping for the new public surface.

## Validation

- `ruff check src tests`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `PYTHONPATH=src PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
- `git diff --check`

## Notes

The bare `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help` command fails in this checkout because the package is not installed into that pyenv environment and `src/` is not on `PYTHONPATH`. The checkout smoke passes with `PYTHONPATH=src`.
