### PR TITLE
feat: add batch evidence submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Advanced/internal integration entrypoints:
 - `agent classify`
 - `agent next`
 - `agent submit`
+- `agent submit-batch`
 - `agent publish`
 - `agent leases`
 - `agent reclaim`
@@ -216,6 +217,7 @@ gh-address-cr agent manifest
 gh-address-cr agent classify owner/repo 123 local-finding:abc --classification fix --note "Real defect."
 gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1
 gh-address-cr agent submit owner/repo 123 --input action-response.json
+gh-address-cr agent submit-batch owner/repo 123 --input batch-response.json
 gh-address-cr agent publish owner/repo 123
 gh-address-cr agent leases owner/repo 123
 gh-address-cr agent reclaim owner/repo 123
@@ -235,6 +237,37 @@ Role split:
 
 Parallel work is lease-based. Independent items may be claimed concurrently, but overlapping file, item, thread, or GitHub side-effect conflict keys are rejected. AI agents must not post replies or resolve GitHub threads directly; accepted evidence is published by the runtime.
 After `agent submit` returns `ACTION_ACCEPTED`, follow the returned `next_action`; GitHub-thread fixes publish through `agent publish`.
+Use `agent submit-batch` only for GitHub review-thread `fix` evidence when one commit/files/validation set addresses multiple leased threads. The batch payload still references each thread's issued `request_id` and `lease_id`, and each item supplies its own `summary`/`why`; the runtime expands it into per-item accepted evidence before `agent publish`.
+
+Minimal `BatchActionResponse` shape:
+
+```json
+{
+  "schema_version": "1.0",
+  "agent_id": "codex-fixer-1",
+  "resolution": "fix",
+  "common": {
+    "files": ["src/example.py", "tests/test_example.py"],
+    "validation_commands": [
+      {"command": "python3 -m unittest tests.test_example", "result": "passed"}
+    ],
+    "fix_reply": {
+      "commit_hash": "abc123",
+      "test_command": "python3 -m unittest tests.test_example",
+      "test_result": "passed"
+    }
+  },
+  "items": [
+    {
+      "request_id": "req_1",
+      "lease_id": "lease_1",
+      "item_id": "github-thread:THREAD_1",
+      "summary": "Fixed thread 1.",
+      "why": "The input is now validated before use."
+    }
+  ]
+}
+```
 
 Main entrypoint examples:
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -89,6 +89,9 @@ Use the runtime as the coordinator:
 - `gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>`
   - validates an `ActionResponse`, lease ownership, and required evidence
   - when it returns `ACTION_ACCEPTED`, run the returned `next_action`; accepted GitHub-thread fixes publish through `agent publish`
+- `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>`
+  - validates a `BatchActionResponse` for multiple leased GitHub review-thread `fix` items
+  - shares common commit/files/validation evidence while keeping per-thread `summary`/`why`
 - `gh-address-cr agent leases <owner/repo> <pr_number>`
   - inspects active and terminal claims
 - `gh-address-cr agent reclaim <owner/repo> <pr_number>`
@@ -106,6 +109,7 @@ Role boundaries:
 
 Allowed `ActionResponse.resolution` values are `fix`, `clarify`, `defer`, and `reject`.
 Fix responses require changed files and validation evidence. Clarify/defer/reject responses require `reply_markdown` and validation evidence. GitHub side-effect claims from AI agents are invalid.
+`BatchActionResponse` is limited to GitHub review-thread `fix` evidence with existing per-item leases; it is not a GitHub publishing shortcut and does not support local findings.
 
 ## Advanced References
 

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -6,7 +6,7 @@ interface:
     Use `SKILL.md` as the source of truth.
     1. Treat `python3 scripts/cli.py` as a compatibility shim. Stateful work belongs to the external `gh-address-cr` runtime.
     2. Start with `python3 scripts/cli.py review <owner/repo> <pr_number>` or `gh-address-cr review <owner/repo> <pr_number>`.
-    3. For multi-agent work, inspect `gh-address-cr agent manifest`, claim with `agent next`, submit evidence with `agent submit`, inspect with `agent leases`, and recover stale claims with `agent reclaim`.
+    3. For multi-agent work, inspect `gh-address-cr agent manifest`, claim with `agent next`, submit evidence with `agent submit` or GitHub-thread batch evidence with `agent submit-batch`, inspect with `agent leases`, and recover stale claims with `agent reclaim`.
     4. AI agents may classify, fix, clarify, defer, reject, or verify. They must not post GitHub replies or resolve threads directly.
     5. GitHub review threads require both reply and resolve, with durable reply evidence from the current authenticated login.
     6. Local findings require valid terminal notes and validation evidence.

--- a/skill/references/evidence-ledger.md
+++ b/skill/references/evidence-ledger.md
@@ -11,6 +11,7 @@ Agents should expect the runtime to record:
 - `lease_created`, `lease_submitted`, `lease_accepted`, `lease_rejected`,
   `lease_expired`, and `lease_released` for lease lifecycle changes
 - `response_accepted` and `response_rejected` for `ActionResponse` handling
+- batch evidence submissions expand into per-item `response_accepted` or `response_rejected` records
 - `verification_rejected` when verifier evidence reopens a work item
 - `reply_posted`, `thread_resolved`, and side-effect attempt records for
   deterministic GitHub publishing

--- a/skill/references/status-action-map.md
+++ b/skill/references/status-action-map.md
@@ -14,7 +14,7 @@ If `status` is `BLOCKED`:
 - **Action**: Inspect the `reason_code` and `waiting_on`. Handle the blocked item by applying a resolution (`fix`, `clarify`, `defer`, `reject`).
 
 If `reason_code` is `WAITING_FOR_SIMPLE_ADDRESS`:
-- **Action**: Inspect the `artifact_path` and `threads` array. Use per-thread `agent classify`, `agent next`, `agent submit`, and `agent publish`; do not invent a batch response.
+- **Action**: Inspect the `artifact_path` and `threads` array. Use per-thread `agent classify` and `agent next` to claim each actionable thread. Use `agent submit` for independent evidence, or `agent submit-batch` when one commit/files/validation set addresses multiple claimed GitHub threads, then run `agent publish`.
 
 If `reason_code` is `AUTO_SIMPLE_NOT_ELIGIBLE`:
 - **Action**: Stop the lightweight path and run the normal `review`, `findings`, or `adapter` workflow to handle local findings.

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -924,14 +924,16 @@ def _write_simple_address_request(repo: str, pr_number: str, session: dict, *, c
         "source_command": command,
         "threads": _native_thread_rows(session),
         "instructions": [
-            "Use existing per-thread ActionResponse evidence; do not submit a batch response.",
-            "For each actionable GitHub thread, run agent classify, agent next, agent submit, then agent publish.",
-            "Common commit, file, and validation evidence may be reused in each per-thread response when applicable.",
+            "Use per-thread ActionResponse evidence, or agent submit-batch when one commit/files/validation set addresses multiple threads.",
+            "For each actionable GitHub thread, run agent classify and agent next to acquire leases before submitting evidence.",
+            "When common commit, file, and validation evidence applies, submit one BatchActionResponse with per-thread summary/why entries.",
+            "After accepted evidence is present, run agent publish.",
         ],
         "commands": {
             "classify": f"gh-address-cr agent classify {repo} {pr_number} <item_id> --classification fix --note <note>",
             "next": f"gh-address-cr agent next {repo} {pr_number} --role fixer --agent-id <agent_id>",
             "submit": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+            "submit_batch": f"gh-address-cr agent submit-batch {repo} {pr_number} --input batch-response.json",
             "publish": f"gh-address-cr agent publish {repo} {pr_number}",
         },
     }
@@ -1280,6 +1282,7 @@ def build_agent_manifest() -> dict:
         ],
         "output_formats": [
             "action_response.v1",
+            "batch_action_response.v1",
             "evidence_record.v1",
             "gate_report.v1",
         ],
@@ -1293,7 +1296,7 @@ def build_agent_manifest() -> dict:
 def handle_agent_command(args: argparse.Namespace) -> int:
     if args.repo in {None, "-h", "--help"}:
         sys.stdout.write(
-            "usage: gh-address-cr agent {manifest,classify,next,submit,publish,leases,reclaim,orchestrate} ...\n\n"
+            "usage: gh-address-cr agent {manifest,classify,next,submit,submit-batch,publish,leases,reclaim,orchestrate} ...\n\n"
             "Agent protocol utilities.\n"
         )
         return 0
@@ -1306,6 +1309,8 @@ def handle_agent_command(args: argparse.Namespace) -> int:
         return handle_agent_next(args.pr_number, args.args)
     if args.repo == "submit":
         return handle_agent_submit(args.pr_number, args.args)
+    if args.repo == "submit-batch":
+        return handle_agent_submit_batch(args.pr_number, args.args)
     if args.repo == "publish":
         return handle_agent_publish(args.pr_number, args.args)
     if args.repo == "leases":
@@ -1315,7 +1320,7 @@ def handle_agent_command(args: argparse.Namespace) -> int:
     if args.repo == "orchestrate":
         return handle_agent_orchestrate(args.pr_number, args.args)
     print(
-        "Unknown agent command. Supported commands: manifest, classify, next, submit, publish, leases, reclaim, orchestrate.",
+        "Unknown agent command. Supported commands: manifest, classify, next, submit, submit-batch, publish, leases, reclaim, orchestrate.",
         file=sys.stderr,
     )
     return 2
@@ -1382,6 +1387,32 @@ def handle_agent_submit(repo: str | None, passthrough: list[str]) -> int:
         if parsed.now:
             now_dt = datetime.fromisoformat(parsed.now.replace("Z", "+00:00"))
         payload = workflow.submit_action_response(parsed.repo, parsed.pr_number, response_path=parsed.input, now=now_dt)
+    except workflow.WorkflowError as exc:
+        return output_workflow_error(exc, repo=parsed.repo, pr_number=parsed.pr_number)
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+def handle_agent_submit_batch(repo: str | None, passthrough: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="gh-address-cr agent submit-batch",
+        description="Submit a BatchActionResponse with common fix evidence for multiple GitHub review threads.",
+    )
+    parser.add_argument("repo")
+    parser.add_argument("pr_number")
+    parser.add_argument("--input", required=True, help="Path to a BatchActionResponse JSON file.")
+    parser.add_argument("--now")
+    parsed = parser.parse_args(_prepend_optional(repo, passthrough))
+    try:
+        now_dt = None
+        if parsed.now:
+            now_dt = datetime.fromisoformat(parsed.now.replace("Z", "+00:00"))
+        payload = workflow.submit_batch_action_response(
+            parsed.repo,
+            parsed.pr_number,
+            batch_path=parsed.input,
+            now=now_dt,
+        )
     except workflow.WorkflowError as exc:
         return output_workflow_error(exc, repo=parsed.repo, pr_number=parsed.pr_number)
     sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
@@ -1709,6 +1740,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  review-to-findings accepts fixed finding blocks only, not arbitrary Markdown.\n"
             "Runtime commands:\n"
             "  gh-address-cr agent manifest\n"
+            "  gh-address-cr agent submit-batch owner/repo 123 --input batch-response.json\n"
             "  gh-address-cr final-gate owner/repo 123\n"
         ),
     )

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -395,6 +395,17 @@ def submit_batch_action_response(
                     lease_id=lease_id,
                 )
             _validate_batch_fix_contract(session, ledger, response, item_id=item_id, lease_id=lease_id)
+            lease_reason_code = _lease_submission_rejection_reason(response, prepared, now)
+            if lease_reason_code:
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    lease_reason_code,
+                    status="BATCH_ACTION_REJECTED",
+                    item_id=item_id,
+                    lease_id=lease_id,
+                )
             prepared_rows.append((response, prepared))
 
         accepted = [
@@ -784,6 +795,34 @@ def _validate_batch_fix_contract(
             item_id=item_id,
             lease_id=lease_id,
         )
+
+
+def _lease_submission_rejection_reason(
+    response: dict[str, Any],
+    prepared: dict[str, Any],
+    now: datetime,
+) -> str | None:
+    lease = prepared["lease"]
+    status = str(_get(lease, "status") or "")
+    if status == "submitted":
+        return "DUPLICATE_SUBMISSION"
+    if status in {"accepted", "rejected", "expired", "released"}:
+        return "STALE_LEASE"
+    if status != "active":
+        return "STALE_LEASE"
+
+    expires_at = _get(lease, "expires_at")
+    if isinstance(expires_at, str):
+        expires_at = _coerce_now(expires_at)
+    if expires_at is not None and expires_at <= now:
+        return "EXPIRED_LEASE"
+    if str(_get(lease, "agent_id")) != str(response["agent_id"]):
+        return "WRONG_AGENT"
+    if str(_get(lease, "item_id")) != str(prepared["item_id"]):
+        return "WRONG_ITEM"
+    if str(_get(lease, "request_hash")) != str(prepared["expected_request_hash"]):
+        return "STALE_REQUEST_CONTEXT"
+    return None
 
 
 def _raise_response_rejected(

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -282,42 +282,304 @@ def submit_action_response(
     now = _coerce_now(now)
     session = session_store.load_session(repo, pr_number)
     ledger = _ledger(session)
+    response = _load_response_json_object(
+        response_path,
+        status="ACTION_REJECTED",
+        missing_reason_code="RESPONSE_FILE_NOT_FOUND",
+        invalid_reason_code="INVALID_RESPONSE_JSON",
+        shape_reason_code="INVALID_RESPONSE_SHAPE",
+        shape_message="ActionResponse must be a JSON object.",
+        payload_name="ActionResponse",
+    )
+
+    try:
+        prepared = _prepare_action_response_submission(session, ledger, response)
+        record = _accept_action_response_submission(session, ledger, response, prepared, now=now)
+    except WorkflowError:
+        session_store.save_session(repo, pr_number, session)
+        raise
+    session_store.save_session(repo, pr_number, session)
+    return {
+        "status": "ACTION_ACCEPTED",
+        "repo": repo,
+        "pr_number": str(pr_number),
+        "lease_id": prepared["lease_id"],
+        "item_id": prepared["item_id"],
+        "evidence_record_id": record.record_id,
+        "next_action": f"Run `gh-address-cr agent publish {repo} {pr_number}` to publish accepted evidence.",
+    }
+
+
+def submit_batch_action_response(
+    repo: str, pr_number: str, *, batch_path: str | Path, now: datetime | None = None
+) -> dict[str, Any]:
+    now = _coerce_now(now)
+    session = session_store.load_session(repo, pr_number)
+    ledger = _ledger(session)
+    batch = _load_response_json_object(
+        batch_path,
+        status="BATCH_ACTION_REJECTED",
+        missing_reason_code="BATCH_RESPONSE_FILE_NOT_FOUND",
+        invalid_reason_code="INVALID_BATCH_RESPONSE_JSON",
+        shape_reason_code="INVALID_BATCH_RESPONSE_SHAPE",
+        shape_message="BatchActionResponse must be a JSON object.",
+        payload_name="BatchActionResponse",
+    )
+    responses = _batch_action_responses(batch)
+    prepared_rows: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    seen_leases: set[str] = set()
+    seen_items: set[str] = set()
+
+    try:
+        for response in responses:
+            lease_id = str(response.get("lease_id") or "")
+            if lease_id in seen_leases:
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    "BATCH_DUPLICATE_LEASE",
+                    status="BATCH_ACTION_REJECTED",
+                )
+            seen_leases.add(lease_id)
+
+            prepared = _prepare_action_response_submission(
+                session,
+                ledger,
+                response,
+                rejected_status="BATCH_ACTION_REJECTED",
+            )
+            item_id = str(prepared["item_id"])
+            if item_id in seen_items:
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    "BATCH_DUPLICATE_ITEM",
+                    status="BATCH_ACTION_REJECTED",
+                    item_id=item_id,
+                    lease_id=lease_id,
+                )
+            seen_items.add(item_id)
+
+            item = prepared["item"]
+            lease = prepared["lease"]
+            if item.get("item_kind") != "github_thread":
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    "BATCH_UNSUPPORTED_ITEM_KIND",
+                    status="BATCH_ACTION_REJECTED",
+                    item_id=item_id,
+                    lease_id=lease_id,
+                )
+            if str(lease.get("role")) != "fixer":
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    "BATCH_UNSUPPORTED_ROLE",
+                    status="BATCH_ACTION_REJECTED",
+                    item_id=item_id,
+                    lease_id=lease_id,
+                )
+            if str(response.get("resolution")) != "fix":
+                _raise_response_rejected(
+                    session,
+                    ledger,
+                    response,
+                    "BATCH_UNSUPPORTED_RESOLUTION",
+                    status="BATCH_ACTION_REJECTED",
+                    item_id=item_id,
+                    lease_id=lease_id,
+                )
+            _validate_batch_fix_contract(session, ledger, response, item_id=item_id, lease_id=lease_id)
+            prepared_rows.append((response, prepared))
+
+        accepted = [
+            _batch_acceptance_payload(
+                response,
+                prepared,
+                _accept_action_response_submission(
+                    session,
+                    ledger,
+                    response,
+                    prepared,
+                    now=now,
+                    rejected_status="BATCH_ACTION_REJECTED",
+                ),
+            )
+            for response, prepared in prepared_rows
+        ]
+    except WorkflowError:
+        session_store.save_session(repo, pr_number, session)
+        raise
+
+    session_store.save_session(repo, pr_number, session)
+    return {
+        "status": "BATCH_ACTION_ACCEPTED",
+        "repo": repo,
+        "pr_number": str(pr_number),
+        "accepted_count": len(accepted),
+        "accepted": accepted,
+        "item_ids": [row["item_id"] for row in accepted],
+        "next_action": f"Run `gh-address-cr agent publish {repo} {pr_number}` to publish accepted evidence.",
+    }
+
+
+def _load_response_json_object(
+    response_path: str | Path,
+    *,
+    status: str,
+    missing_reason_code: str,
+    invalid_reason_code: str,
+    shape_reason_code: str,
+    shape_message: str,
+    payload_name: str,
+) -> dict[str, Any]:
     path = Path(response_path)
     try:
-        response = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise WorkflowError(
-            status="ACTION_REJECTED",
-            reason_code="RESPONSE_FILE_NOT_FOUND",
+            status=status,
+            reason_code=missing_reason_code,
             waiting_on="action_response",
             exit_code=2,
-            message=f"ActionResponse file does not exist: {path}",
+            message=f"{payload_name} file does not exist: {path}",
         ) from exc
     except json.JSONDecodeError as exc:
         raise WorkflowError(
-            status="ACTION_REJECTED",
-            reason_code="INVALID_RESPONSE_JSON",
+            status=status,
+            reason_code=invalid_reason_code,
             waiting_on="action_response",
             exit_code=2,
-            message=f"Invalid ActionResponse JSON: {exc}",
+            message=f"Invalid {payload_name} JSON: {exc}",
         ) from exc
 
-    if not isinstance(response, dict):
+    if not isinstance(payload, dict):
         raise WorkflowError(
-            status="ACTION_REJECTED",
-            reason_code="INVALID_RESPONSE_SHAPE",
+            status=status,
+            reason_code=shape_reason_code,
             waiting_on="action_response",
             exit_code=2,
-            message="ActionResponse must be a JSON object.",
+            message=shape_message,
         )
+    return payload
 
-    lease_id = _required_response_field(response, "lease_id")
+
+def _batch_action_responses(batch: dict[str, Any]) -> list[dict[str, Any]]:
+    common = batch.get("common") or {}
+    if not isinstance(common, dict):
+        _raise_batch_schema_error("INVALID_BATCH_COMMON", "BatchActionResponse.common must be a JSON object.")
+
+    items = batch.get("items")
+    if not isinstance(items, list) or not items:
+        _raise_batch_schema_error("BATCH_ITEMS_REQUIRED", "BatchActionResponse requires a non-empty items list.")
+
+    agent_id = str(batch.get("agent_id") or common.get("agent_id") or "").strip()
+    if not agent_id:
+        _raise_batch_schema_error("MISSING_BATCH_AGENT_ID", "BatchActionResponse requires agent_id.")
+
+    resolution = str(batch.get("resolution") or common.get("resolution") or "fix").strip().lower()
+    if resolution != "fix":
+        _raise_batch_schema_error("BATCH_UNSUPPORTED_RESOLUTION", "BatchActionResponse only supports fix evidence.")
+
+    schema_version = str(batch.get("schema_version") or "1.0")
+    common_fix_reply = common.get("fix_reply") or {}
+    if not isinstance(common_fix_reply, dict):
+        _raise_batch_schema_error("INVALID_BATCH_FIX_REPLY", "BatchActionResponse.common.fix_reply must be an object.")
+
+    common_files = common.get("files") or common_fix_reply.get("files")
+    common_validation = common.get("validation_commands")
+    common_commit_hash = str(common.get("commit_hash") or common_fix_reply.get("commit_hash") or "").strip()
+
+    responses: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            _raise_batch_schema_error("INVALID_BATCH_ITEM", f"BatchActionResponse item {index} must be an object.")
+        item_fix_reply = item.get("fix_reply") or {}
+        if not isinstance(item_fix_reply, dict):
+            _raise_batch_schema_error(
+                "INVALID_BATCH_ITEM_FIX_REPLY",
+                f"BatchActionResponse item {index} fix_reply must be an object.",
+            )
+
+        item_resolution = str(item.get("resolution") or resolution).strip().lower()
+        if item_resolution != "fix":
+            _raise_batch_schema_error(
+                "BATCH_UNSUPPORTED_RESOLUTION",
+                f"BatchActionResponse item {index} only supports fix evidence.",
+            )
+
+        request_id = str(item.get("request_id") or "").strip()
+        lease_id = str(item.get("lease_id") or "").strip()
+        if not request_id:
+            _raise_batch_schema_error("MISSING_BATCH_ITEM_REQUEST_ID", f"BatchActionResponse item {index} needs request_id.")
+        if not lease_id:
+            _raise_batch_schema_error("MISSING_BATCH_ITEM_LEASE_ID", f"BatchActionResponse item {index} needs lease_id.")
+
+        summary = str(item.get("summary") or item.get("note") or item_fix_reply.get("summary") or "").strip()
+        why = str(item.get("why") or item_fix_reply.get("why") or summary).strip()
+        note = str(item.get("note") or summary or why).strip()
+        if not note:
+            _raise_batch_schema_error("MISSING_BATCH_ITEM_NOTE", f"BatchActionResponse item {index} needs note or summary.")
+
+        files = _normalize_string_list(item.get("files") or item_fix_reply.get("files") or common_files)
+        validation_commands = item.get("validation_commands") or common_validation
+        fix_reply = dict(common_fix_reply)
+        fix_reply.update(item_fix_reply)
+        if common_commit_hash and not fix_reply.get("commit_hash"):
+            fix_reply["commit_hash"] = common_commit_hash
+        if files:
+            fix_reply["files"] = files
+        if summary and not fix_reply.get("summary"):
+            fix_reply["summary"] = summary
+        if why:
+            fix_reply["why"] = why
+
+        response = {
+            "schema_version": schema_version,
+            "request_id": request_id,
+            "lease_id": lease_id,
+            "agent_id": str(item.get("agent_id") or agent_id),
+            "resolution": "fix",
+            "note": note,
+            "files": files,
+            "validation_commands": validation_commands,
+            "fix_reply": fix_reply,
+        }
+        if item.get("item_id"):
+            response["item_id"] = str(item["item_id"])
+        responses.append(response)
+
+    return responses
+
+
+def _raise_batch_schema_error(reason_code: str, message: str) -> None:
+    raise WorkflowError(
+        status="BATCH_ACTION_REJECTED",
+        reason_code=reason_code,
+        waiting_on="batch_action_response",
+        exit_code=2,
+        message=message,
+    )
+
+
+def _prepare_action_response_submission(
+    session: dict[str, Any],
+    ledger: EvidenceLedger,
+    response: dict[str, Any],
+    *,
+    rejected_status: str = "ACTION_REJECTED",
+) -> dict[str, Any]:
+    lease_id = _required_response_field(response, "lease_id", status=rejected_status)
     lease = session.get("leases", {}).get(lease_id)
     if not isinstance(lease, dict):
         _record_response_rejected(session, ledger, response, "LEASE_NOT_FOUND")
-        session_store.save_session(repo, pr_number, session)
         raise WorkflowError(
-            status="ACTION_REJECTED",
+            status=rejected_status,
             reason_code="LEASE_NOT_FOUND",
             waiting_on="lease",
             exit_code=5,
@@ -325,12 +587,23 @@ def submit_action_response(
         )
 
     item_id = str(lease["item_id"])
+    declared_item_id = response.get("item_id")
+    if declared_item_id and str(declared_item_id) != item_id:
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "ITEM_ID_MISMATCH",
+            status=rejected_status,
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+
     item = _items(session).get(item_id)
     if not isinstance(item, dict):
         _record_response_rejected(session, ledger, response, "ITEM_NOT_FOUND")
-        session_store.save_session(repo, pr_number, session)
         raise WorkflowError(
-            status="ACTION_REJECTED",
+            status=rejected_status,
             reason_code="ITEM_NOT_FOUND",
             waiting_on="work_item",
             exit_code=5,
@@ -339,30 +612,50 @@ def submit_action_response(
 
     reason_code = _validate_response(response, item)
     if reason_code:
-        _record_response_rejected(session, ledger, response, reason_code, item_id=item_id)
-        session_store.save_session(repo, pr_number, session)
-        raise WorkflowError(
-            status="ACTION_REJECTED",
-            reason_code=reason_code,
-            waiting_on="action_response",
-            exit_code=5,
-            message=f"ActionResponse rejected: {reason_code}",
-            payload={"item_id": item_id, "lease_id": lease_id},
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            reason_code,
+            status=rejected_status,
+            item_id=item_id,
+            lease_id=lease_id,
         )
 
     expected_request_hash, context_reason_code = _expected_request_hash_for_response(response, lease)
     if context_reason_code:
-        _record_response_rejected(session, ledger, response, context_reason_code, item_id=item_id)
-        session_store.save_session(repo, pr_number, session)
-        raise WorkflowError(
-            status="ACTION_REJECTED",
-            reason_code=context_reason_code,
-            waiting_on="action_response",
-            exit_code=5,
-            message=f"ActionResponse rejected: {context_reason_code}",
-            payload={"item_id": item_id, "lease_id": lease_id},
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            context_reason_code,
+            status=rejected_status,
+            item_id=item_id,
+            lease_id=lease_id,
         )
 
+    return {
+        "lease_id": lease_id,
+        "lease": lease,
+        "item_id": item_id,
+        "item": item,
+        "expected_request_hash": expected_request_hash,
+    }
+
+
+def _accept_action_response_submission(
+    session: dict[str, Any],
+    ledger: EvidenceLedger,
+    response: dict[str, Any],
+    prepared: dict[str, Any],
+    *,
+    now: datetime,
+    rejected_status: str = "ACTION_REJECTED",
+) -> Any:
+    lease_id = str(prepared["lease_id"])
+    lease = prepared["lease"]
+    item_id = str(prepared["item_id"])
+    item = prepared["item"]
     try:
         submit_lease(
             session,
@@ -370,15 +663,14 @@ def submit_action_response(
             agent_id=str(response["agent_id"]),
             role=str(lease["role"]),
             item_id=item_id,
-            request_hash=str(expected_request_hash),
+            request_hash=str(prepared["expected_request_hash"]),
             now=now,
         )
-        accept_lease(session, lease_id)
+        accept_lease(session, lease_id, now=now)
     except LeaseSubmissionError as exc:
         _record_response_rejected(session, ledger, response, exc.reason_code, item_id=item_id)
-        session_store.save_session(repo, pr_number, session)
         raise WorkflowError(
-            status="ACTION_REJECTED",
+            status=rejected_status,
             reason_code=exc.reason_code,
             waiting_on="lease",
             exit_code=5,
@@ -399,7 +691,6 @@ def submit_action_response(
             event_type="verification_rejected",
             payload={"note": response["note"], "validation_commands": response.get("validation_commands", [])},
         )
-        session_store.save_session(repo, pr_number, session)
         raise WorkflowError(
             status="VERIFICATION_REJECTED",
             reason_code="VERIFICATION_REJECTED",
@@ -410,7 +701,7 @@ def submit_action_response(
         )
 
     _apply_response_to_item(item, response)
-    record = ledger.append_event(
+    return ledger.append_event(
         session_id=str(session["session_id"]),
         item_id=item_id,
         lease_id=lease_id,
@@ -419,15 +710,109 @@ def submit_action_response(
         event_type="response_accepted",
         payload={"resolution": response["resolution"], "note": response["note"]},
     )
-    session_store.save_session(repo, pr_number, session)
+
+
+def _validate_batch_fix_contract(
+    session: dict[str, Any],
+    ledger: EvidenceLedger,
+    response: dict[str, Any],
+    *,
+    item_id: str,
+    lease_id: str,
+) -> None:
+    files = _normalize_string_list(response.get("files"))
+    if not files:
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "MISSING_BATCH_FILES",
+            status="BATCH_ACTION_REJECTED",
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+    validation_commands = response.get("validation_commands")
+    if not isinstance(validation_commands, list) or not validation_commands:
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "MISSING_BATCH_VALIDATION_COMMANDS",
+            status="BATCH_ACTION_REJECTED",
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+    for command in validation_commands:
+        if not isinstance(command, dict) or not command.get("command") or not command.get("result"):
+            _raise_response_rejected(
+                session,
+                ledger,
+                response,
+                "INVALID_BATCH_VALIDATION_COMMAND",
+                status="BATCH_ACTION_REJECTED",
+                item_id=item_id,
+                lease_id=lease_id,
+            )
+    fix_reply = response.get("fix_reply")
+    if not isinstance(fix_reply, dict):
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "MISSING_BATCH_FIX_REPLY",
+            status="BATCH_ACTION_REJECTED",
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+    if not str(fix_reply.get("commit_hash") or "").strip():
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "MISSING_BATCH_COMMIT_HASH",
+            status="BATCH_ACTION_REJECTED",
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+    if not str(fix_reply.get("why") or "").strip():
+        _raise_response_rejected(
+            session,
+            ledger,
+            response,
+            "MISSING_BATCH_ITEM_WHY",
+            status="BATCH_ACTION_REJECTED",
+            item_id=item_id,
+            lease_id=lease_id,
+        )
+
+
+def _raise_response_rejected(
+    session: dict[str, Any],
+    ledger: EvidenceLedger,
+    response: dict[str, Any],
+    reason_code: str,
+    *,
+    status: str,
+    item_id: str | None = None,
+    lease_id: str | None = None,
+) -> None:
+    _record_response_rejected(session, ledger, response, reason_code, item_id=item_id)
+    raise WorkflowError(
+        status=status,
+        reason_code=reason_code,
+        waiting_on="action_response",
+        exit_code=5,
+        message=f"ActionResponse rejected: {reason_code}",
+        payload={"item_id": item_id, "lease_id": lease_id or response.get("lease_id")},
+    )
+
+
+def _batch_acceptance_payload(response: dict[str, Any], prepared: dict[str, Any], record: Any) -> dict[str, Any]:
     return {
-        "status": "ACTION_ACCEPTED",
-        "repo": repo,
-        "pr_number": str(pr_number),
-        "lease_id": lease_id,
-        "item_id": item_id,
+        "item_id": str(prepared["item_id"]),
+        "lease_id": str(prepared["lease_id"]),
+        "request_id": str(response["request_id"]),
         "evidence_record_id": record.record_id,
-        "next_action": f"Run `gh-address-cr agent publish {repo} {pr_number}` to publish accepted evidence.",
     }
 
 
@@ -1024,11 +1409,11 @@ def _ledger(session: dict[str, Any]) -> EvidenceLedger:
     )
 
 
-def _required_response_field(response: dict[str, Any], field: str) -> str:
+def _required_response_field(response: dict[str, Any], field: str, *, status: str = "ACTION_REJECTED") -> str:
     value = response.get(field)
     if not value:
         raise WorkflowError(
-            status="ACTION_REJECTED",
+            status=status,
             reason_code=f"MISSING_{field.upper()}",
             waiting_on="action_response",
             exit_code=2,

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -324,6 +324,7 @@ def submit_batch_action_response(
         shape_reason_code="INVALID_BATCH_RESPONSE_SHAPE",
         shape_message="BatchActionResponse must be a JSON object.",
         payload_name="BatchActionResponse",
+        waiting_on="batch_action_response",
     )
     responses = _batch_action_responses(batch)
     prepared_rows: list[tuple[dict[str, Any], dict[str, Any]]] = []
@@ -448,6 +449,7 @@ def _load_response_json_object(
     shape_reason_code: str,
     shape_message: str,
     payload_name: str,
+    waiting_on: str = "action_response",
 ) -> dict[str, Any]:
     path = Path(response_path)
     try:
@@ -456,7 +458,7 @@ def _load_response_json_object(
         raise WorkflowError(
             status=status,
             reason_code=missing_reason_code,
-            waiting_on="action_response",
+            waiting_on=waiting_on,
             exit_code=2,
             message=f"{payload_name} file does not exist: {path}",
         ) from exc
@@ -464,7 +466,7 @@ def _load_response_json_object(
         raise WorkflowError(
             status=status,
             reason_code=invalid_reason_code,
-            waiting_on="action_response",
+            waiting_on=waiting_on,
             exit_code=2,
             message=f"Invalid {payload_name} JSON: {exc}",
         ) from exc
@@ -473,7 +475,7 @@ def _load_response_json_object(
         raise WorkflowError(
             status=status,
             reason_code=shape_reason_code,
-            waiting_on="action_response",
+            waiting_on=waiting_on,
             exit_code=2,
             message=shape_message,
         )
@@ -836,12 +838,14 @@ def _raise_response_rejected(
     lease_id: str | None = None,
 ) -> None:
     _record_response_rejected(session, ledger, response, reason_code, item_id=item_id)
+    is_batch = status == "BATCH_ACTION_REJECTED"
+    payload_name = "BatchActionResponse" if is_batch else "ActionResponse"
     raise WorkflowError(
         status=status,
         reason_code=reason_code,
-        waiting_on="action_response",
+        waiting_on="batch_action_response" if is_batch else "action_response",
         exit_code=5,
-        message=f"ActionResponse rejected: {reason_code}",
+        message=f"{payload_name} rejected: {reason_code}",
         payload={"item_id": item_id, "lease_id": lease_id or response.get("lease_id")},
     )
 

--- a/tests/fixtures/thin_skill_orchestration/documentation_contracts.json
+++ b/tests/fixtures/thin_skill_orchestration/documentation_contracts.json
@@ -5,6 +5,7 @@
     "agent manifest",
     "agent next",
     "agent submit",
+    "agent submit-batch",
     "adapter check-runtime"
   ],
   "forbidden_script_exports": [

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -454,6 +454,106 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(session["leases"][request["lease_id"]]["status"], "active")
         self.assertIn("response_rejected", [row["event_type"] for row in self.ledger_rows()])
 
+    def test_agent_submit_batch_rejects_expired_later_lease_without_partial_acceptance(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example_one.py",
+                    line=10,
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_1",
+                    },
+                    thread_id="PRRT_abc",
+                ),
+                open_item(
+                    "github-thread:def",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example_two.py",
+                    line=20,
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_2",
+                    },
+                    thread_id="PRRT_def",
+                ),
+            ]
+        )
+        first = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1", "--now", NOW.isoformat()
+        )
+        second = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1", "--now", NOW.isoformat()
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        first_request = json.loads(Path(json.loads(first.stdout)["request_path"]).read_text(encoding="utf-8"))
+        second_request = json.loads(Path(json.loads(second.stdout)["request_path"]).read_text(encoding="utf-8"))
+        session = self.load_session()
+        session["leases"][second_request["lease_id"]]["expires_at"] = (NOW - timedelta(seconds=1)).isoformat()
+        self.session_file().write_text(json.dumps(session, indent=2, sort_keys=True), encoding="utf-8")
+        batch_path = self.workspace_dir() / "expired-batch-action-response.json"
+        batch_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "agent_id": "codex-1",
+                    "resolution": "fix",
+                    "common": {
+                        "files": ["src/example_one.py", "src/example_two.py"],
+                        "validation_commands": [
+                            {"command": "python3 -m unittest tests.test_examples", "result": "passed"}
+                        ],
+                        "fix_reply": {
+                            "commit_hash": "abc123",
+                            "test_command": "python3 -m unittest tests.test_examples",
+                            "test_result": "passed",
+                        },
+                    },
+                    "items": [
+                        {
+                            "request_id": first_request["request_id"],
+                            "lease_id": first_request["lease_id"],
+                            "item_id": "github-thread:abc",
+                            "summary": "Fixed first thread.",
+                            "why": "The first thread now validates the input before use.",
+                        },
+                        {
+                            "request_id": second_request["request_id"],
+                            "lease_id": second_request["lease_id"],
+                            "item_id": "github-thread:def",
+                            "summary": "Fixed second thread.",
+                            "why": "The second thread now shares the same guarded path.",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_runtime_module(
+            "agent", "submit-batch", self.repo, self.pr, "--input", str(batch_path), "--now", NOW.isoformat()
+        )
+
+        self.assertEqual(result.returncode, 5)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BATCH_ACTION_REJECTED")
+        self.assertEqual(payload["reason_code"], "EXPIRED_LEASE")
+        session = self.load_session()
+        self.assertEqual(session["items"]["github-thread:abc"]["state"], "claimed")
+        self.assertEqual(session["items"]["github-thread:def"]["state"], "claimed")
+        self.assertEqual(session["leases"][first_request["lease_id"]]["status"], "active")
+        self.assertEqual(session["leases"][second_request["lease_id"]]["status"], "active")
+        event_types = [row["event_type"] for row in self.ledger_rows()]
+        self.assertNotIn("response_accepted", event_types)
+        self.assertIn("response_rejected", event_types)
+
     def test_agent_publish_reports_no_work_when_no_thread_is_publish_ready(self):
         self.write_session(items=[open_item()])
 

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -293,6 +293,167 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(item["publish_resolution"], "fix")
         self.assertNotIn("side_effect_attempt", [row["event_type"] for row in self.ledger_rows()])
 
+    def test_agent_submit_batch_accepts_common_evidence_for_github_threads(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example_one.py",
+                    line=10,
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_1",
+                    },
+                    thread_id="PRRT_abc",
+                ),
+                open_item(
+                    "github-thread:def",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example_two.py",
+                    line=20,
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_2",
+                    },
+                    thread_id="PRRT_def",
+                ),
+            ]
+        )
+        first = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1")
+        second = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1")
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        first_request = json.loads(Path(json.loads(first.stdout)["request_path"]).read_text(encoding="utf-8"))
+        second_request = json.loads(Path(json.loads(second.stdout)["request_path"]).read_text(encoding="utf-8"))
+        batch_path = self.workspace_dir() / "batch-action-response.json"
+        batch_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "agent_id": "codex-1",
+                    "resolution": "fix",
+                    "common": {
+                        "files": ["src/example_one.py", "src/example_two.py"],
+                        "validation_commands": [
+                            {"command": "python3 -m unittest tests.test_examples", "result": "passed"}
+                        ],
+                        "fix_reply": {
+                            "commit_hash": "abc123",
+                            "test_command": "python3 -m unittest tests.test_examples",
+                            "test_result": "passed",
+                        },
+                    },
+                    "items": [
+                        {
+                            "request_id": first_request["request_id"],
+                            "lease_id": first_request["lease_id"],
+                            "item_id": "github-thread:abc",
+                            "summary": "Fixed first thread.",
+                            "why": "The first thread now validates the input before use.",
+                        },
+                        {
+                            "request_id": second_request["request_id"],
+                            "lease_id": second_request["lease_id"],
+                            "item_id": "github-thread:def",
+                            "summary": "Fixed second thread.",
+                            "why": "The second thread now shares the same guarded path.",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(batch_path))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BATCH_ACTION_ACCEPTED")
+        self.assertEqual(payload["accepted_count"], 2)
+        self.assertEqual(
+            payload["next_action"],
+            f"Run `gh-address-cr agent publish {self.repo} {self.pr}` to publish accepted evidence.",
+        )
+        session = self.load_session()
+        first_item = session["items"]["github-thread:abc"]
+        second_item = session["items"]["github-thread:def"]
+        self.assertEqual(first_item["state"], "publish_ready")
+        self.assertEqual(second_item["state"], "publish_ready")
+        self.assertEqual(first_item["accepted_response"]["fix_reply"]["commit_hash"], "abc123")
+        self.assertEqual(second_item["accepted_response"]["fix_reply"]["commit_hash"], "abc123")
+        self.assertEqual(
+            first_item["accepted_response"]["fix_reply"]["why"],
+            "The first thread now validates the input before use.",
+        )
+        self.assertEqual(
+            second_item["accepted_response"]["fix_reply"]["why"],
+            "The second thread now shares the same guarded path.",
+        )
+        self.assertEqual(session["leases"][first_request["lease_id"]]["status"], "accepted")
+        self.assertEqual(session["leases"][second_request["lease_id"]]["status"], "accepted")
+        self.assertEqual([row["event_type"] for row in self.ledger_rows()].count("response_accepted"), 2)
+
+    def test_agent_submit_batch_rejects_local_findings_without_mutation(self):
+        self.write_session(
+            items=[
+                open_item(
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified",
+                    }
+                )
+            ]
+        )
+        issued = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1"
+        )
+        self.assertEqual(issued.returncode, 0, issued.stderr)
+        request = json.loads(Path(json.loads(issued.stdout)["request_path"]).read_text(encoding="utf-8"))
+        batch_path = self.workspace_dir() / "local-batch-action-response.json"
+        batch_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "agent_id": "codex-1",
+                    "resolution": "fix",
+                    "common": {
+                        "files": ["src/example.py"],
+                        "validation_commands": [
+                            {"command": "python3 -m unittest tests.test_example", "result": "passed"}
+                        ],
+                        "fix_reply": {"commit_hash": "abc123"},
+                    },
+                    "items": [
+                        {
+                            "request_id": request["request_id"],
+                            "lease_id": request["lease_id"],
+                            "item_id": "local-finding:1",
+                            "summary": "Fixed validation.",
+                            "why": "The input is now validated.",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(batch_path))
+
+        self.assertEqual(result.returncode, 5)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BATCH_ACTION_REJECTED")
+        self.assertEqual(payload["reason_code"], "BATCH_UNSUPPORTED_ITEM_KIND")
+        session = self.load_session()
+        self.assertEqual(session["items"]["local-finding:1"]["state"], "claimed")
+        self.assertEqual(session["leases"][request["lease_id"]]["status"], "active")
+        self.assertIn("response_rejected", [row["event_type"] for row in self.ledger_rows()])
+
     def test_agent_publish_reports_no_work_when_no_thread_is_publish_ready(self):
         self.write_session(items=[open_item()])
 

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -449,10 +449,25 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "BATCH_ACTION_REJECTED")
         self.assertEqual(payload["reason_code"], "BATCH_UNSUPPORTED_ITEM_KIND")
+        self.assertEqual(payload["waiting_on"], "batch_action_response")
+        self.assertIn("BatchActionResponse rejected", payload["next_action"])
         session = self.load_session()
         self.assertEqual(session["items"]["local-finding:1"]["state"], "claimed")
         self.assertEqual(session["leases"][request["lease_id"]]["status"], "active")
         self.assertIn("response_rejected", [row["event_type"] for row in self.ledger_rows()])
+
+    def test_agent_submit_batch_missing_file_reports_batch_waiting_on(self):
+        self.write_session(items=[])
+        missing_path = self.workspace_dir() / "missing-batch-action-response.json"
+
+        result = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(missing_path))
+
+        self.assertEqual(result.returncode, 2)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BATCH_ACTION_REJECTED")
+        self.assertEqual(payload["reason_code"], "BATCH_RESPONSE_FILE_NOT_FOUND")
+        self.assertEqual(payload["waiting_on"], "batch_action_response")
+        self.assertIn("BatchActionResponse file does not exist", payload["next_action"])
 
     def test_agent_submit_batch_rejects_expired_later_lease_without_partial_acceptance(self):
         self.write_session(

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -385,6 +385,7 @@ else:
         request = json.loads(request_path.read_text(encoding="utf-8"))
         self.assertEqual(request["mode"], "simple-address")
         self.assertEqual(request["threads"][0]["thread_id"], "THREAD_SIMPLE")
+        self.assertIn("submit-batch", request["commands"]["submit_batch"])
         self.assertFalse((self.workspace_dir() / "producer-request.md").exists())
 
     def test_cli_address_matches_review_auto_simple_for_unresolved_threads(self):

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -214,6 +214,14 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("verify", payload["actions"])
         self.assertEqual(payload["constraints"]["max_parallel_claims"], 2)
         self.assertIn("action_request.v1", payload["input_formats"])
+        self.assertIn("batch_action_response.v1", payload["output_formats"])
+
+    def test_agent_submit_batch_help_documents_batch_contract(self):
+        result = self.run_runtime_module("agent", "submit-batch", "--help")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("usage: gh-address-cr agent submit-batch", result.stdout)
+        self.assertIn("BatchActionResponse", result.stdout)
 
     def test_missing_gh_preflight_fails_before_session_mutation(self):
         env = self.env.copy()


### PR DESCRIPTION
## Summary
- add `gh-address-cr agent submit-batch` for BatchActionResponse evidence across multiple leased GitHub review threads
- share common commit/files/validation evidence while preserving per-thread summary/why and existing publish flow
- update runtime manifest, lightweight address guidance, README, and skill docs for the new batch contract

Fixes #23.
Refs #16.

Stacked on #26 / `codex/issue-22-lightweight-address`.

## Scope
- Supports GitHub review-thread `fix` items with existing per-item leases.
- Expands batch evidence into per-item accepted responses; `agent publish` still owns GitHub replies/resolves.
- Does not implement #24 auth/env diagnostic classification.

## Verification
- `ruff check src tests`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `PYTHONPATH=src PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
- `git diff --check`
