### PR TITLE
fix: classify github environment diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,11 @@ Stable machine summary fields:
 - `waiting_on`
 - `next_action`
 - `exit_code`
+- `diagnostics` (optional, for GitHub CLI/API failures)
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
+When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded `stderr_excerpt`.
 The `threads` command and lightweight address states may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
 
 ## Multi-Agent Coordination

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Stable machine summary fields:
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
-When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded `stderr_excerpt`.
+When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded redacted `stderr_excerpt`.
 The `threads` command and lightweight address states may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
 
 ## Multi-Agent Coordination

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -77,7 +77,7 @@ High-level commands emit structured JSON by default. Agents MUST consume these f
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
-When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded `stderr_excerpt`.
+When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded redacted `stderr_excerpt`.
 The `threads` command and lightweight address states may also include a `threads` array with actionable GitHub thread context (`thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence).
 
 ## Multi-Agent Protocol

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -73,9 +73,11 @@ High-level commands emit structured JSON by default. Agents MUST consume these f
 - `waiting_on`
 - `next_action`
 - `exit_code`
+- `diagnostics` (optional, for GitHub CLI/API failures)
 
 `reason_code` is the stable machine reason. `waiting_on` is the stable wait-state category.
 `counts.*` may be `null` in preflight wait/fail states before GitHub or session scans run.
+When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded `stderr_excerpt`.
 The `threads` command and lightweight address states may also include a `threads` array with actionable GitHub thread context (`thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence).
 
 ## Multi-Agent Protocol

--- a/skill/references/status-action-map.md
+++ b/skill/references/status-action-map.md
@@ -19,6 +19,12 @@ If `reason_code` is `WAITING_FOR_SIMPLE_ADDRESS`:
 If `reason_code` is `AUTO_SIMPLE_NOT_ELIGIBLE`:
 - **Action**: Stop the lightweight path and run the normal `review`, `findings`, or `adapter` workflow to handle local findings.
 
+If `reason_code` is `GH_AUTH_FAILED` or `GITHUB_AUTH_FAILED`:
+- **Action**: Inspect `diagnostics.command` and `diagnostics.stderr_category`. Fix GitHub CLI authentication with `gh auth status` / `gh auth login`, then rerun the same command.
+
+If `reason_code` is `GH_NETWORK_FAILED`, `GITHUB_NETWORK_FAILED`, `GH_ENVIRONMENT_FAILED`, or `GITHUB_ENVIRONMENT_FAILED`:
+- **Action**: Inspect `diagnostics.command`, `diagnostics.stderr_category`, and `diagnostics.stderr_excerpt`. Fix network, sandbox, PATH, or local permission issues before retrying; do not treat these as code-review findings.
+
 ## External Interactions
 
 If `status` is `WAITING_FOR_EXTERNAL_REVIEW`:

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -18,7 +18,7 @@ from gh_address_cr.core import gate as core_gate
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core import session as session_store
 from gh_address_cr.core import workflow
-from gh_address_cr.github.diagnostics import classify_github_failure
+from gh_address_cr.github.diagnostics import classify_github_failure, github_waiting_on
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.errors import GitHubError
 from gh_address_cr.intake.findings import (
@@ -575,19 +575,6 @@ def _preflight_gh_failure_response(diagnostics: dict) -> tuple[str, str, str, st
         "Authenticate GitHub CLI with `gh auth login`, then rerun the command.",
         "GitHub CLI `gh` is not authenticated. Run `gh auth status` and fix authentication before rerunning.",
     )
-
-
-def _github_waiting_on(exc: GitHubError) -> str:
-    category = exc.diagnostics.get("stderr_category") if isinstance(exc.diagnostics, dict) else None
-    if category == "auth":
-        return "github_auth"
-    if category == "network":
-        return "github_network"
-    if category in {"environment", "sandbox"}:
-        return "github_environment"
-    if category == "rate_limit":
-        return "github_rate_limit"
-    return "github"
 
 
 def preflight_github_cli(args: argparse.Namespace, repo: str, pr_number: str) -> int | None:
@@ -1156,7 +1143,7 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
             pr_number=pr_number,
             status="BLOCKED",
             reason_code=exc.reason_code,
-            waiting_on=_github_waiting_on(exc),
+            waiting_on=github_waiting_on(exc.diagnostics),
             next_action=str(exc),
             exit_code=5,
             session=session,

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -18,6 +18,7 @@ from gh_address_cr.core import gate as core_gate
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core import session as session_store
 from gh_address_cr.core import workflow
+from gh_address_cr.github.diagnostics import classify_github_failure
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.errors import GitHubError
 from gh_address_cr.intake.findings import (
@@ -454,8 +455,9 @@ def build_preflight_summary(
     waiting_on: str | None,
     next_action: str,
     artifact_path: str | None = None,
+    diagnostics: dict | None = None,
 ) -> dict:
-    return {
+    summary = {
         "status": status,
         "repo": repo,
         "pr_number": pr_number,
@@ -473,6 +475,9 @@ def build_preflight_summary(
         "next_action": next_action,
         "exit_code": exit_code,
     }
+    if diagnostics:
+        summary["diagnostics"] = diagnostics
+    return summary
 
 
 def has_option(args: list[str], flag: str) -> bool:
@@ -514,6 +519,7 @@ def output_preflight_error(
     artifact_path: str | None = None,
     exit_code: int = 2,
     persist: bool = True,
+    diagnostics: dict | None = None,
 ) -> int:
     if not args.human:
         summary = build_preflight_summary(
@@ -526,6 +532,7 @@ def output_preflight_error(
             waiting_on=waiting_on,
             next_action=next_action,
             artifact_path=artifact_path,
+            diagnostics=diagnostics,
         )
         if persist:
             persist_machine_summary(repo, pr_number, summary)
@@ -539,8 +546,58 @@ def _gh_auth_fixture_is_unimplemented(result: subprocess.CompletedProcess[str]) 
     return "unhandled gh args" in combined and "auth" in combined and "status" in combined
 
 
+def _preflight_gh_failure_response(diagnostics: dict) -> tuple[str, str, str, str]:
+    category = diagnostics.get("stderr_category")
+    if category == "network":
+        return (
+            "GH_NETWORK_FAILED",
+            "github_network",
+            "Fix GitHub network connectivity or sandbox network access, then rerun the command.",
+            "GitHub CLI `gh` could not reach GitHub. Inspect `gh auth status` stderr and network/sandbox access before rerunning.",
+        )
+    if category in {"environment", "sandbox"}:
+        return (
+            "GH_ENVIRONMENT_FAILED",
+            "github_environment",
+            "Fix the local sandbox or permission issue for GitHub CLI, then rerun the command.",
+            "GitHub CLI `gh` failed due to a local environment or sandbox permission issue.",
+        )
+    if category == "rate_limit":
+        return (
+            "GH_RATE_LIMITED",
+            "github_rate_limit",
+            "Wait for GitHub rate limits to recover or use a token with sufficient quota, then rerun the command.",
+            "GitHub CLI `gh` is authenticated, but GitHub reported rate limiting.",
+        )
+    return (
+        "GH_AUTH_FAILED",
+        "github_auth",
+        "Authenticate GitHub CLI with `gh auth login`, then rerun the command.",
+        "GitHub CLI `gh` is not authenticated. Run `gh auth status` and fix authentication before rerunning.",
+    )
+
+
+def _github_waiting_on(exc: GitHubError) -> str:
+    category = exc.diagnostics.get("stderr_category") if isinstance(exc.diagnostics, dict) else None
+    if category == "auth":
+        return "github_auth"
+    if category == "network":
+        return "github_network"
+    if category in {"environment", "sandbox"}:
+        return "github_environment"
+    if category == "rate_limit":
+        return "github_rate_limit"
+    return "github"
+
+
 def preflight_github_cli(args: argparse.Namespace, repo: str, pr_number: str) -> int | None:
     if shutil.which("gh") is None:
+        diagnostics = classify_github_failure(
+            "Missing GitHub CLI `gh` on PATH.",
+            "",
+            None,
+            ["gh"],
+        )
         return output_preflight_error(
             args,
             repo,
@@ -551,20 +608,25 @@ def preflight_github_cli(args: argparse.Namespace, repo: str, pr_number: str) ->
             next_action="Install GitHub CLI and ensure `gh` is available on PATH, then rerun the command.",
             exit_code=PR_IO_PREFLIGHT_EXIT,
             persist=False,
+            diagnostics=diagnostics,
         )
 
-    result = subprocess.run(["gh", "auth", "status"], text=True, capture_output=True)
+    auth_command = ["gh", "auth", "status"]
+    result = subprocess.run(auth_command, text=True, capture_output=True)
     if result.returncode != 0 and not _gh_auth_fixture_is_unimplemented(result):
+        diagnostics = classify_github_failure(result.stderr, result.stdout, result.returncode, auth_command)
+        reason_code, waiting_on, next_action, message = _preflight_gh_failure_response(diagnostics)
         return output_preflight_error(
             args,
             repo,
             pr_number,
-            "GitHub CLI `gh` is not authenticated. Run `gh auth status` and fix authentication before rerunning.",
-            reason_code="GH_AUTH_FAILED",
-            waiting_on="github_auth",
-            next_action="Authenticate GitHub CLI with `gh auth login`, then rerun the command.",
+            message,
+            reason_code=reason_code,
+            waiting_on=waiting_on,
+            next_action=next_action,
             exit_code=PR_IO_PREFLIGHT_EXIT,
             persist=False,
+            diagnostics=diagnostics,
         )
     return None
 
@@ -840,6 +902,7 @@ def _native_summary(
     artifact_path: str | None = None,
     item: dict | None = None,
     include_threads: bool = False,
+    diagnostics: dict | None = None,
 ) -> dict:
     metrics = session.get("metrics") if isinstance(session.get("metrics"), dict) else {}
     summary = {
@@ -860,6 +923,8 @@ def _native_summary(
         "next_action": next_action,
         "exit_code": exit_code,
     }
+    if diagnostics:
+        summary["diagnostics"] = diagnostics
     if command == "threads" or include_threads:
         summary["threads"] = _native_thread_rows(session)
     return summary
@@ -1091,10 +1156,11 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
             pr_number=pr_number,
             status="BLOCKED",
             reason_code=exc.reason_code,
-            waiting_on="github",
+            waiting_on=_github_waiting_on(exc),
             next_action=str(exc),
             exit_code=5,
             session=session,
+            diagnostics=exc.diagnostics,
         )
         _emit_native_summary(summary, human=human)
         return 5

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -1247,14 +1247,30 @@ def _record_publish_blocked(
 
 
 def _publish_error(repo: str, pr_number: str, item_id: str, exc: GitHubError) -> WorkflowError:
+    payload = {"item_id": item_id, "retryable": exc.retryable, "repo": repo, "pr_number": str(pr_number)}
+    if exc.diagnostics:
+        payload["diagnostics"] = exc.diagnostics
     return WorkflowError(
         status="PUBLISH_BLOCKED",
         reason_code=exc.reason_code,
-        waiting_on="github",
+        waiting_on=_github_waiting_on(exc),
         exit_code=5,
         message=f"GitHub publish failed for {item_id}: {exc}",
-        payload={"item_id": item_id, "retryable": exc.retryable, "repo": repo, "pr_number": str(pr_number)},
+        payload=payload,
     )
+
+
+def _github_waiting_on(exc: GitHubError) -> str:
+    category = exc.diagnostics.get("stderr_category") if isinstance(exc.diagnostics, dict) else None
+    if category == "auth":
+        return "github_auth"
+    if category == "network":
+        return "github_network"
+    if category in {"environment", "sandbox"}:
+        return "github_environment"
+    if category == "rate_limit":
+        return "github_rate_limit"
+    return "github"
 
 
 def _next_item(session: dict[str, Any], role: str) -> tuple[str, dict[str, Any] | None]:

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -22,6 +22,7 @@ from gh_address_cr.core.models import ActionRequest
 from gh_address_cr.core.reply_templates import fix_reply as render_fix_reply
 from gh_address_cr.evidence.ledger import EvidenceLedger, SideEffectAttempt
 from gh_address_cr.github.client import GitHubClient
+from gh_address_cr.github.diagnostics import github_waiting_on
 from gh_address_cr.github.errors import GitHubError
 
 
@@ -1253,24 +1254,11 @@ def _publish_error(repo: str, pr_number: str, item_id: str, exc: GitHubError) ->
     return WorkflowError(
         status="PUBLISH_BLOCKED",
         reason_code=exc.reason_code,
-        waiting_on=_github_waiting_on(exc),
+        waiting_on=github_waiting_on(exc.diagnostics),
         exit_code=5,
         message=f"GitHub publish failed for {item_id}: {exc}",
         payload=payload,
     )
-
-
-def _github_waiting_on(exc: GitHubError) -> str:
-    category = exc.diagnostics.get("stderr_category") if isinstance(exc.diagnostics, dict) else None
-    if category == "auth":
-        return "github_auth"
-    if category == "network":
-        return "github_network"
-    if category in {"environment", "sandbox"}:
-        return "github_environment"
-    if category == "rate_limit":
-        return "github_rate_limit"
-    return "github"
 
 
 def _next_item(session: dict[str, Any], role: str) -> tuple[str, dict[str, Any] | None]:

--- a/src/gh_address_cr/github/client.py
+++ b/src/gh_address_cr/github/client.py
@@ -23,7 +23,6 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess]
 TRANSIENT_MARKERS = (
     "502",
     "503",
-    "api.github.com",
     "error connecting",
     "failed to connect",
     "temporary failure",

--- a/src/gh_address_cr/github/client.py
+++ b/src/gh_address_cr/github/client.py
@@ -6,9 +6,12 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from gh_address_cr.github.diagnostics import classify_github_failure
 from gh_address_cr.github.errors import (
     GitHubAuthError,
+    GitHubEnvironmentError,
     GitHubError,
+    GitHubNetworkError,
     GitHubNotFoundError,
     GitHubRateLimitError,
     GitHubTransientError,
@@ -20,6 +23,9 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess]
 TRANSIENT_MARKERS = (
     "502",
     "503",
+    "api.github.com",
+    "error connecting",
+    "failed to connect",
     "temporary failure",
     "timeout",
     "timed out",
@@ -219,7 +225,7 @@ class GitHubClient:
     def _read_json(self, args: list[str], *, retries: int = 1) -> Any:
         result = self._run_gh(args, retries=retries)
         if result.returncode != 0:
-            _raise_classified_error(result.stderr, result.stdout, result.returncode)
+            _raise_classified_error(result.stderr, result.stdout, result.returncode, _completed_command(result))
         try:
             payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError as exc:
@@ -227,7 +233,12 @@ class GitHubClient:
         if isinstance(payload, dict):
             errors = payload.get("errors")
             if errors:
-                _raise_classified_error(_format_graphql_errors(errors), result.stdout, result.returncode)
+                _raise_classified_error(
+                    _format_graphql_errors(errors),
+                    result.stdout,
+                    result.returncode,
+                    _completed_command(result),
+                )
         return payload
 
     def _run_gh(self, args: list[str], *, retries: int) -> subprocess.CompletedProcess:
@@ -237,7 +248,15 @@ class GitHubClient:
             try:
                 result = self._runner(cmd)
             except FileNotFoundError as exc:
-                raise GitHubError("GITHUB_CLI_MISSING", "Missing GitHub CLI `gh` on PATH.") from exc
+                raise GitHubEnvironmentError(
+                    "Missing GitHub CLI `gh` on PATH.",
+                    diagnostics=classify_github_failure(
+                        "Missing GitHub CLI `gh` on PATH.",
+                        "",
+                        None,
+                        cmd,
+                    ),
+                ) from exc
             if result.returncode == 0 or not _is_transient(result.stderr, result.stdout):
                 return result
             if attempt < attempts - 1:
@@ -321,18 +340,37 @@ def _format_graphql_errors(errors: Any) -> str:
     return "; ".join(message for message in messages if message) or "GraphQL request failed."
 
 
-def _raise_classified_error(stderr: str | None, stdout: str | None, returncode: int | None) -> None:
+def _raise_classified_error(
+    stderr: str | None,
+    stdout: str | None,
+    returncode: int | None,
+    command: list[str] | tuple[str, ...] | None = None,
+) -> None:
     detail = (stderr or stdout or "GitHub command failed.").strip()
-    text = detail.lower()
-    if "authentication" in text or "gh auth login" in text or "bad credentials" in text or "401" in text:
-        raise GitHubAuthError(detail)
-    if "rate limit" in text or "secondary rate" in text:
-        raise GitHubRateLimitError(detail)
-    if "not found" in text or "could not resolve to a node" in text or "404" in text:
-        raise GitHubNotFoundError(detail)
+    diagnostics = classify_github_failure(stderr, stdout, returncode, command)
+    category = diagnostics["stderr_category"]
+    if category == "auth":
+        raise GitHubAuthError(detail, diagnostics=diagnostics)
+    if category == "network":
+        raise GitHubNetworkError(detail, diagnostics=diagnostics)
+    if category in {"environment", "sandbox"}:
+        raise GitHubEnvironmentError(detail, diagnostics=diagnostics)
+    if category == "rate_limit":
+        raise GitHubRateLimitError(detail, diagnostics=diagnostics)
+    if category == "not_found":
+        raise GitHubNotFoundError(detail, diagnostics=diagnostics)
     if _is_transient(stderr, stdout):
-        raise GitHubTransientError(detail)
-    raise GitHubError("GITHUB_API_FAILED", detail, retryable=False)
+        raise GitHubTransientError(detail, diagnostics=diagnostics)
+    raise GitHubError("GITHUB_API_FAILED", detail, retryable=False, diagnostics=diagnostics)
+
+
+def _completed_command(result: subprocess.CompletedProcess) -> list[str]:
+    args = result.args
+    if isinstance(args, (list, tuple)):
+        return [str(part) for part in args]
+    if isinstance(args, str):
+        return [args]
+    return []
 
 
 def _is_transient(stderr: str | None, stdout: str | None) -> bool:

--- a/src/gh_address_cr/github/client.py
+++ b/src/gh_address_cr/github/client.py
@@ -228,7 +228,16 @@ class GitHubClient:
         try:
             payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError as exc:
-            raise GitHubError("GITHUB_INVALID_JSON", f"GitHub response was not valid JSON: {exc}") from exc
+            raise GitHubError(
+                "GITHUB_INVALID_JSON",
+                f"GitHub response was not valid JSON: {exc}",
+                diagnostics=classify_github_failure(
+                    result.stderr,
+                    result.stdout,
+                    result.returncode,
+                    _completed_command(result),
+                ),
+            ) from exc
         if isinstance(payload, dict):
             errors = payload.get("errors")
             if errors:

--- a/src/gh_address_cr/github/diagnostics.py
+++ b/src/gh_address_cr/github/diagnostics.py
@@ -12,7 +12,6 @@ AUTH_MARKERS = (
     "401",
 )
 NETWORK_MARKERS = (
-    "api.github.com",
     "could not resolve host",
     "failed to connect",
     "error connecting",

--- a/src/gh_address_cr/github/diagnostics.py
+++ b/src/gh_address_cr/github/diagnostics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+AUTH_MARKERS = (
+    "authentication",
+    "gh auth login",
+    "bad credentials",
+    "not logged into",
+    "not logged in",
+    "401",
+)
+NETWORK_MARKERS = (
+    "api.github.com",
+    "could not resolve host",
+    "failed to connect",
+    "error connecting",
+    "network is unreachable",
+    "temporary failure",
+    "connection reset",
+    "timeout",
+    "timed out",
+)
+SANDBOX_MARKERS = (
+    "operation not permitted",
+    "permission denied",
+    "sandbox",
+    "not permitted",
+)
+ENVIRONMENT_MARKERS = (
+    "missing github cli",
+    "`gh` on path",
+    "executable file not found",
+)
+RATE_LIMIT_MARKERS = ("rate limit", "secondary rate")
+NOT_FOUND_MARKERS = ("not found", "could not resolve to a node", "404")
+API_MARKERS = ("graphql", "api")
+
+
+def classify_github_failure(
+    stderr: str | None,
+    stdout: str | None = None,
+    returncode: int | None = None,
+    command: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    detail = (stderr or stdout or "").strip()
+    text = detail.lower()
+    category = _stderr_category(text)
+    diagnostics: dict[str, Any] = {
+        "stderr_category": category,
+    }
+    if command:
+        diagnostics["command"] = [str(part) for part in command]
+    if returncode is not None:
+        diagnostics["returncode"] = returncode
+    if detail:
+        diagnostics["stderr_excerpt"] = _excerpt(detail)
+    return diagnostics
+
+
+def _stderr_category(text: str) -> str:
+    if any(marker in text for marker in AUTH_MARKERS):
+        return "auth"
+    if any(marker in text for marker in SANDBOX_MARKERS):
+        return "sandbox"
+    if any(marker in text for marker in ENVIRONMENT_MARKERS):
+        return "environment"
+    if any(marker in text for marker in NETWORK_MARKERS):
+        return "network"
+    if any(marker in text for marker in RATE_LIMIT_MARKERS):
+        return "rate_limit"
+    if any(marker in text for marker in NOT_FOUND_MARKERS):
+        return "not_found"
+    if any(marker in text for marker in API_MARKERS):
+        return "api"
+    return "unknown"
+
+
+def _excerpt(value: str, *, limit: int = 500) -> str:
+    one_line = " ".join(value.split())
+    if len(one_line) <= limit:
+        return one_line
+    return f"{one_line[: limit - 3]}..."

--- a/src/gh_address_cr/github/diagnostics.py
+++ b/src/gh_address_cr/github/diagnostics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+import re
 from typing import Any
 
 
@@ -35,6 +37,20 @@ ENVIRONMENT_MARKERS = (
 RATE_LIMIT_MARKERS = ("rate limit", "secondary rate")
 NOT_FOUND_MARKERS = ("not found", "could not resolve to a node", "404")
 API_MARKERS = ("graphql", "api")
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+TOKEN_PATTERNS = (
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]{16,}\b", re.IGNORECASE),
+)
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:[A-Za-z0-9]+[_-])*token|secret|password|api[_-]?key)\b([=: ]+)([^\s,;&]+)"
+)
+PRIVATE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(username|user|email|hostname|host|machine|machine_name|computer|computer_name)\b([=: ]+)([^\s,;&]+)"
+)
 
 
 def classify_github_failure(
@@ -54,8 +70,21 @@ def classify_github_failure(
     if returncode is not None:
         diagnostics["returncode"] = returncode
     if detail:
-        diagnostics["stderr_excerpt"] = _excerpt(detail)
+        diagnostics["stderr_excerpt"] = _excerpt(_redact_diagnostic_text(detail))
     return diagnostics
+
+
+def github_waiting_on(diagnostics: Mapping[str, Any] | None) -> str:
+    category = diagnostics.get("stderr_category") if isinstance(diagnostics, Mapping) else None
+    if category == "auth":
+        return "github_auth"
+    if category == "network":
+        return "github_network"
+    if category in {"environment", "sandbox"}:
+        return "github_environment"
+    if category == "rate_limit":
+        return "github_rate_limit"
+    return "github"
 
 
 def _stderr_category(text: str) -> str:
@@ -81,3 +110,11 @@ def _excerpt(value: str, *, limit: int = 500) -> str:
     if len(one_line) <= limit:
         return one_line
     return f"{one_line[: limit - 3]}..."
+
+
+def _redact_diagnostic_text(value: str) -> str:
+    redacted = EMAIL_RE.sub("[redacted-email]", value)
+    for pattern in TOKEN_PATTERNS:
+        redacted = pattern.sub("[redacted-token]", redacted)
+    redacted = SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}[redacted-token]", redacted)
+    return PRIVATE_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}[redacted]", redacted)

--- a/src/gh_address_cr/github/errors.py
+++ b/src/gh_address_cr/github/errors.py
@@ -1,28 +1,48 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 class GitHubError(RuntimeError):
-    def __init__(self, reason_code: str, detail: str, *, retryable: bool = False):
+    def __init__(
+        self,
+        reason_code: str,
+        detail: str,
+        *,
+        retryable: bool = False,
+        diagnostics: dict[str, Any] | None = None,
+    ):
         self.reason_code = reason_code
         self.retryable = retryable
+        self.diagnostics = diagnostics or {}
         super().__init__(detail)
 
 
 class GitHubAuthError(GitHubError):
-    def __init__(self, detail: str):
-        super().__init__("GITHUB_AUTH_FAILED", detail, retryable=False)
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_AUTH_FAILED", detail, retryable=False, diagnostics=diagnostics)
+
+
+class GitHubNetworkError(GitHubError):
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_NETWORK_FAILED", detail, retryable=True, diagnostics=diagnostics)
+
+
+class GitHubEnvironmentError(GitHubError):
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_ENVIRONMENT_FAILED", detail, retryable=False, diagnostics=diagnostics)
 
 
 class GitHubRateLimitError(GitHubError):
-    def __init__(self, detail: str):
-        super().__init__("GITHUB_RATE_LIMITED", detail, retryable=True)
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_RATE_LIMITED", detail, retryable=True, diagnostics=diagnostics)
 
 
 class GitHubNotFoundError(GitHubError):
-    def __init__(self, detail: str):
-        super().__init__("GITHUB_NOT_FOUND", detail, retryable=False)
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_NOT_FOUND", detail, retryable=False, diagnostics=diagnostics)
 
 
 class GitHubTransientError(GitHubError):
-    def __init__(self, detail: str):
-        super().__init__("GITHUB_TRANSIENT_ERROR", detail, retryable=True)
+    def __init__(self, detail: str, *, diagnostics: dict[str, Any] | None = None):
+        super().__init__("GITHUB_TRANSIENT_ERROR", detail, retryable=True, diagnostics=diagnostics)

--- a/tests/test_native_foundation.py
+++ b/tests/test_native_foundation.py
@@ -99,6 +99,42 @@ class NativeFoundationTests(unittest.TestCase):
         self.assertEqual(caught.exception.diagnostics["command"], ["gh", "api", "user"])
         self.assertIn("api.github.com", caught.exception.diagnostics["stderr_excerpt"])
 
+    def test_github_api_urls_do_not_make_http_errors_network_failures(self):
+        import subprocess
+
+        from gh_address_cr.github.client import GitHubClient
+        from gh_address_cr.github.errors import GitHubError, GitHubNotFoundError
+
+        def not_found_runner(cmd):
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                "",
+                "HTTP 404: Not Found (https://api.github.com/repos/owner/repo)",
+            )
+
+        with self.assertRaises(GitHubNotFoundError) as not_found:
+            GitHubClient(runner=not_found_runner).viewer_login()
+
+        self.assertEqual(not_found.exception.reason_code, "GITHUB_NOT_FOUND")
+        self.assertFalse(not_found.exception.retryable)
+        self.assertEqual(not_found.exception.diagnostics["stderr_category"], "not_found")
+
+        def forbidden_runner(cmd):
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                "",
+                "HTTP 403: Resource not accessible by integration (https://api.github.com/graphql)",
+            )
+
+        with self.assertRaises(GitHubError) as forbidden:
+            GitHubClient(runner=forbidden_runner).viewer_login()
+
+        self.assertEqual(forbidden.exception.reason_code, "GITHUB_API_FAILED")
+        self.assertFalse(forbidden.exception.retryable)
+        self.assertEqual(forbidden.exception.diagnostics["stderr_category"], "api")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_native_foundation.py
+++ b/tests/test_native_foundation.py
@@ -135,6 +135,41 @@ class NativeFoundationTests(unittest.TestCase):
         self.assertFalse(forbidden.exception.retryable)
         self.assertEqual(forbidden.exception.diagnostics["stderr_category"], "api")
 
+    def test_github_invalid_json_errors_include_redacted_diagnostics(self):
+        import subprocess
+
+        from gh_address_cr.github.client import GitHubClient
+        from gh_address_cr.github.errors import GitHubError
+
+        def runner(cmd):
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                "not-json token=ghp_abcdefghijklmnopqrstuvwxyz12 user=alice@example.com",
+                "",
+            )
+
+        with self.assertRaises(GitHubError) as caught:
+            GitHubClient(runner=runner).viewer_login()
+
+        diagnostics = caught.exception.diagnostics
+        self.assertEqual(caught.exception.reason_code, "GITHUB_INVALID_JSON")
+        self.assertEqual(diagnostics["command"], ["gh", "api", "user"])
+        self.assertEqual(diagnostics["returncode"], 0)
+        self.assertIn("[redacted-token]", diagnostics["stderr_excerpt"])
+        self.assertIn("[redacted]", diagnostics["stderr_excerpt"])
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz12", diagnostics["stderr_excerpt"])
+        self.assertNotIn("alice@example.com", diagnostics["stderr_excerpt"])
+
+    def test_github_waiting_on_uses_shared_diagnostic_mapping(self):
+        from gh_address_cr.github.diagnostics import github_waiting_on
+
+        self.assertEqual(github_waiting_on({"stderr_category": "auth"}), "github_auth")
+        self.assertEqual(github_waiting_on({"stderr_category": "network"}), "github_network")
+        self.assertEqual(github_waiting_on({"stderr_category": "sandbox"}), "github_environment")
+        self.assertEqual(github_waiting_on({"stderr_category": "rate_limit"}), "github_rate_limit")
+        self.assertEqual(github_waiting_on({"stderr_category": "unknown"}), "github")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_native_foundation.py
+++ b/tests/test_native_foundation.py
@@ -74,6 +74,31 @@ class NativeFoundationTests(unittest.TestCase):
         self.assertEqual(auth.reason_code, "GITHUB_AUTH_FAILED")
         self.assertFalse(auth.retryable)
 
+    def test_github_client_errors_include_command_and_stderr_category(self):
+        import subprocess
+
+        from gh_address_cr.github.client import GitHubClient
+        from gh_address_cr.github.errors import GitHubNetworkError
+
+        def runner(cmd):
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                "",
+                "error connecting to api.github.com",
+            )
+
+        client = GitHubClient(runner=runner)
+
+        with self.assertRaises(GitHubNetworkError) as caught:
+            client.viewer_login()
+
+        self.assertEqual(caught.exception.reason_code, "GITHUB_NETWORK_FAILED")
+        self.assertTrue(caught.exception.retryable)
+        self.assertEqual(caught.exception.diagnostics["stderr_category"], "network")
+        self.assertEqual(caught.exception.diagnostics["command"], ["gh", "api", "user"])
+        self.assertIn("api.github.com", caught.exception.diagnostics["stderr_excerpt"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -1189,6 +1189,33 @@ else:
         self.assertEqual(summary["waiting_on"], "github_cli")
         self.assertIn("gh", result.stderr)
 
+    def test_cli_address_api_network_failure_includes_github_diagnostics(self):
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            "\n".join(
+                [
+                    "#!/bin/sh",
+                    'if [ "$1" = "auth" ]; then exit 0; fi',
+                    'if [ "$1" = "api" ]; then echo "error connecting to api.github.com" >&2; exit 1; fi',
+                    "exit 1",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+        result = self.run_cmd([sys.executable, str(CLI_PY), "address", self.repo, self.pr])
+
+        self.assertEqual(result.returncode, 5)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "GITHUB_NETWORK_FAILED")
+        self.assertEqual(summary["waiting_on"], "github_network")
+        self.assertEqual(summary["diagnostics"]["stderr_category"], "network")
+        self.assertEqual(summary["diagnostics"]["command"][:3], ["gh", "api", "graphql"])
+        self.assertIn("api.github.com", summary["diagnostics"]["stderr_excerpt"])
+
     def test_run_local_review_requires_explicit_source_for_sync(self):
         adapter = Path(self.temp_dir.name) / "adapter.py"
         adapter.write_text("import json\nprint(json.dumps([]))\n", encoding="utf-8")

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -263,6 +263,34 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertEqual(payload["reason_code"], "GH_AUTH_FAILED")
         self.assertFalse(self.session_file().exists())
 
+    def test_network_gh_preflight_is_not_reported_as_auth_failure(self):
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            '#!/bin/sh\nif [ "$1" = "auth" ]; then echo "error connecting to api.github.com" >&2; exit 1; fi\nexit 0\n',
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        env = self.env.copy()
+        env["PYTHONPATH"] = str(SRC_ROOT)
+        env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "gh_address_cr", "review", self.repo, self.pr],
+            text=True,
+            capture_output=True,
+            cwd=self.cwd,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 5)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["reason_code"], "GH_NETWORK_FAILED")
+        self.assertEqual(payload["waiting_on"], "github_network")
+        self.assertEqual(payload["diagnostics"]["stderr_category"], "network")
+        self.assertEqual(payload["diagnostics"]["command"], ["gh", "auth", "status"])
+        self.assertIn("api.github.com", payload["diagnostics"]["stderr_excerpt"])
+        self.assertFalse(self.session_file().exists())
+
     def test_runtime_compatibility_preflight(self):
         result = self.run_runtime_module("adapter", "check-runtime")
 


### PR DESCRIPTION
## Summary
- Classify GitHub CLI/API failures into auth, network, environment/sandbox, rate limit, not_found/api/unknown diagnostics.
- Surface command, returncode, stderr_category, and bounded stderr_excerpt in machine summaries for preflight, native commands, and publish failures.
- Update runtime/skill docs and status-action mapping for diagnostic reason codes.

## Validation
- ruff check src tests
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests
- PYTHONPATH=src PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help
- git diff --check

Fixes #24
Refs #16

Stacked on #27 / codex/issue-23-batch-evidence.