### PR TITLE
feat: add CLI version flags and subcommand

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/007-cli-distribution"
-}
+{"feature_directory": "specs/008-cli-version"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,5 +84,5 @@ A task is complete only when:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-`specs/007-cli-distribution/plan.md`.
+`specs/008-cli-version/plan.md`.
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Stable machine summary fields:
 When present, `diagnostics` includes the underlying `gh` command, `returncode`, `stderr_category` (`auth`, `network`, `sandbox`, `environment`, `rate_limit`, `not_found`, `api`, or `unknown`), and a bounded redacted `stderr_excerpt`.
 The `threads` command and lightweight address states may also include a `threads` array with actionable thread context for agents: `thread_id`, `path`, `line`, `body`, `url`, state/status, reply evidence, and accepted-response presence.
 
+### Metadata Commands
+
+```bash
+# Display version
+gh-address-cr --version
+# or
+gh-address-cr version
+```
+
 ## Multi-Agent Coordination
 
 The runtime is the coordinator. AI agents consume structured requests and return structured evidence.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -15,6 +15,7 @@ The runtime owns session state, intake routing, GitHub side effects, leases, and
 /gh-address-cr review <owner/repo> <pr_number>
 /gh-address-cr address <owner/repo> <pr_number>
 /gh-address-cr threads <owner/repo> <pr_number>
+/gh-address-cr version
 /gh-address-cr findings <owner/repo> <pr_number> --input <path>|-
 /gh-address-cr adapter <owner/repo> <pr_number> <adapter_cmd...>
 ```

--- a/specs/008-cli-version/checklists/requirements.md
+++ b/specs/008-cli-version/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: CLI Version Query
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [specs/008-cli-version/spec.md](specs/008-cli-version/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification is complete and ready for the next phase.

--- a/specs/008-cli-version/contracts/cli-schema.md
+++ b/specs/008-cli-version/contracts/cli-schema.md
@@ -1,0 +1,25 @@
+# CLI Contract: Version Query
+
+## Global Flags
+
+| Flag | Shorthand | Description | Expected Output |
+|------|-----------|-------------|-----------------|
+| `--version` | `-v` | Prints the program version and exits. | `gh-address-cr X.Y.Z` |
+
+## Subcommands
+
+### `version`
+
+Prints the program version and exits.
+
+**Usage:**
+```bash
+gh-address-cr version
+```
+
+**Output:**
+```text
+gh-address-cr X.Y.Z
+```
+
+**Exit Code:** 0

--- a/specs/008-cli-version/plan.md
+++ b/specs/008-cli-version/plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan: CLI Version Query
+
+**Branch**: `008-cli-version` | **Date**: 2026-04-30 | **Spec**: [specs/008-cli-version/spec.md](specs/008-cli-version/spec.md)
+**Input**: Feature specification from `/specs/008-cli-version/spec.md`
+
+## Summary
+
+Add version query capability to the `gh-address-cr` CLI via a global `--version` flag, a `-v` shorthand, and a `version` subcommand. The implementation will use the existing `__version__` variable in `src/gh_address_cr/__init__.py` as the source of truth.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+  
+**Primary Dependencies**: `argparse` (standard library)  
+**Storage**: N/A  
+**Testing**: `unittest`  
+**Target Platform**: Darwin (macOS), Linux  
+**Project Type**: CLI Tool  
+**Performance Goals**: Instant response (< 1s)  
+**Constraints**: Must work offline without GitHub authentication  
+**Scale/Scope**: Minimal impact, metadata only  
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Control plane ownership**: PASSED. Version query is a deterministic metadata function.
+- **Public CLI contract**: PASSED. Adds new entry points without breaking existing ones. Follows standard CLI conventions.
+- **Evidence-first handling**: N/A. Does not affect review items or gating.
+- **Packaged Skill Boundary**: PASSED. Changes are in `src/gh_address_cr/cli.py`. Skill-root relative paths will be preserved in documentation.
+- **External Intake Replaceability**: PASSED. No impact on findings ingestion.
+- **Fail-fast verification**: PASSED. Will include unit tests and smoke tests for the new flag/command.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-cli-version/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (CLI schema)
+└── checklists/          # Requirement checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── gh_address_cr/
+    ├── __init__.py      # Version source
+    └── cli.py           # CLI routing and version logic
+
+tests/
+├── test_python_wrappers.py  # CLI integration tests
+└── test_version_query.py    # New unit tests for version logic
+```
+
+**Structure Decision**: Standard single-project structure used by `gh-address-cr`. No new directories required.
+
+## Complexity Tracking
+
+> **No Constitution Check violations.**

--- a/specs/008-cli-version/quickstart.md
+++ b/specs/008-cli-version/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: CLI Version Query
+
+## How to use
+
+To check the current version of the CLI tool:
+
+```bash
+# Using the long flag
+gh-address-cr --version
+
+# Using the short flag
+gh-address-cr -v
+
+# Using the subcommand
+gh-address-cr version
+```
+
+## Expected Result
+
+The output will be formatted as:
+`gh-address-cr <version>`
+
+Example:
+`gh-address-cr 2.2.1`

--- a/specs/008-cli-version/research.md
+++ b/specs/008-cli-version/research.md
@@ -1,0 +1,24 @@
+# Research: CLI Version Query
+
+## Unknowns & Research Tasks
+
+- **Decision**: Use `argparse`'s built-in `action='version'` for the flag and manual routing for the subcommand.
+- **Rationale**: `action='version'` is the standard way to handle version flags in Python. It automatically prints the version and exits. For the `version` subcommand, we need to handle it in `main` or via a dedicated handler to maintain consistency.
+- **Alternatives considered**: 
+    - Manual flag parsing: Rejected. `argparse` is already used and provides standard support.
+    - Only flag, no subcommand: Rejected. Requirements specify both.
+
+## Findings
+
+### 1. argparse Version Action
+Standard usage:
+```python
+parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
+```
+This handles printing and exiting automatically.
+
+### 2. Subcommand Routing
+In `gh_address_cr/cli.py`, the `main` function dispatches based on `args.command`. Adding `version` to the supported commands list and handling it in `main` is straightforward.
+
+### 3. Source of Truth
+`src/gh_address_cr/__init__.py` already exports `__version__`. This will be imported in `cli.py`.

--- a/specs/008-cli-version/spec.md
+++ b/specs/008-cli-version/spec.md
@@ -1,0 +1,75 @@
+# Feature Specification: CLI Version Query
+
+**Feature Branch**: `008-cli-version`  
+**Created**: 2026-04-30  
+**Status**: Verified
+**Input**: User description: "少了知道当前cli的版本号的功能，需要补充一个新功能。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Standard Version Flag (Priority: P1)
+
+As a developer or agent, I want to quickly check which version of `gh-address-cr` I am running using a standard `--version` flag, so I can confirm compatibility or report bugs accurately.
+
+**Why this priority**: High. This is the industry-standard way to query CLI versions and is essential for troubleshooting and environment verification.
+
+**Independent Test**: Running `gh-address-cr --version` returns a semantic version string (e.g., `2.2.1`).
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI is installed, **When** I run `gh-address-cr --version`, **Then** the system outputs the current version number and exits with code 0.
+2. **Given** the CLI is installed, **When** I run `gh-address-cr -v` (optional alias), **Then** the system outputs the current version number.
+
+---
+
+### User Story 2 - Version Subcommand (Priority: P2)
+
+As a user who prefers subcommands, I want to run `gh-address-cr version` to see the version information.
+
+**Why this priority**: Medium. Provides consistency with other tools that use subcommands for metadata.
+
+**Independent Test**: Running `gh-address-cr version` returns the version string.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI is installed, **When** I run `gh-address-cr version`, **Then** the system outputs the current version number and exits with code 0.
+
+---
+
+### Edge Cases
+
+- **Mixed Flags**: Running `gh-address-cr --version review` should prioritize showing the version and potentially exit, or show the version as part of a preflight check. Industry standard is usually for `--version` to be a terminal command that prints and exits.
+- **Malformed Input**: If used with invalid arguments, `--version` should still function if it is the primary intent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST support a `--version` global flag.
+- **FR-002**: The CLI SHOULD support a `-v` shorthand flag for version query.
+- **FR-003**: The CLI MUST support a `version` subcommand.
+- **FR-004**: The version output MUST match the `__version__` defined in `src/gh_address_cr/__init__.py`.
+- **FR-005**: The output format MUST be clear and machine-parsable (e.g., just the version string or `gh-address-cr vX.Y.Z`).
+- **FR-006**: Querying the version MUST NOT require a GitHub token or internet connectivity.
+
+### Constitution Alignment *(mandatory)*
+
+- **Control Plane Impact**: No impact. Version query is a metadata operation that does not affect session state or PR orchestration.
+- **CLI / Agent Contract Impact**: Adds new commands/flags to the CLI contract. Does not change existing high-level command behavior.
+- **Evidence Requirements**: N/A for this feature.
+- **Packaged Skill Boundary**: Changes affect `src/gh_address_cr/cli.py`.
+- **External Intake Replaceability**: No impact.
+- **Fail-Fast Behavior**: Should fail loudly if the version cannot be determined (unlikely in this architecture).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: User can obtain the CLI version in < 1 second using standard flags.
+- **SC-002**: 100% of version queries return a valid semantic version string.
+- **SC-003**: Version output remains consistent across all supported entry points (installed CLI and skill scripts).
+
+## Assumptions
+
+- **Version source**: `src/gh_address_cr/__init__.py`'s `__version__` is the single source of truth.
+- **Output stream**: Version information is written to `stdout`.

--- a/specs/008-cli-version/tasks.md
+++ b/specs/008-cli-version/tasks.md
@@ -1,0 +1,120 @@
+---
+description: "Task list for CLI version query feature implementation"
+---
+
+# Tasks: CLI Version Query
+
+**Input**: Design documents from `/specs/008-cli-version/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/
+
+**Tests**: TDD approach. Write tests for version flags and subcommand before implementation.
+
+**Organization**: Tasks are grouped by user story (US1: Flags, US2: Subcommand).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [x] T001 [P] Create test file for version query in `tests/test_version_query.py`
+- [x] T002 [P] Verify `src/gh_address_cr/__init__.py` exports `__version__`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure prerequisites
+
+- [x] T003 Define public CLI contract for version query in `src/gh_address_cr/cli.py` (imports and basic parser structure)
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Standard Version Flag (Priority: P1) 🎯 MVP
+
+**Goal**: Support `--version` and `-v` global flags
+
+**Independent Test**: Running `gh-address-cr --version` or `gh-address-cr -v` returns the current version string.
+
+### Tests for User Story 1
+
+- [x] T004 [P] [US1] Add unit tests for `--version` flag in `tests/test_version_query.py`
+- [x] T005 [P] [US1] Add unit tests for `-v` flag in `tests/test_version_query.py`
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Add `--version` and `-v` arguments using `action='version'` in `src/gh_address_cr/cli.py`
+- [x] T007 [US1] Verify `--version` output format matches `gh-address-cr X.Y.Z`
+
+**Checkpoint**: User Story 1 should be fully functional independently
+
+---
+
+## Phase 4: User Story 2 - Version Subcommand (Priority: P2)
+
+**Goal**: Support `version` subcommand
+
+**Independent Test**: Running `gh-address-cr version` returns the current version string.
+
+### Tests for User Story 2
+
+- [x] T008 [P] [US2] Add unit tests for `version` subcommand in `tests/test_version_query.py`
+
+### Implementation for User Story 2
+
+- [x] T009 [US2] Add `version` to `NATIVE_HIGH_LEVEL_COMMANDS` and `HIGH_LEVEL_COMMANDS` in `src/gh_address_cr/cli.py`
+- [x] T010 [US2] Implement `version` command handling in `main` (instead of `handle_native_high_level` because it's simpler and doesn't require repo/pr) within `src/gh_address_cr/cli.py`
+
+**Checkpoint**: User Story 2 should be fully functional independently
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements and final validation
+
+- [x] T011 [P] Update `README.md` to include version query examples
+- [x] T012 [P] Update `skill/SKILL.md` to include version query examples (if applicable to agent guidance)
+- [x] T013 Run quickstart.md validation
+- [x] T014 Run `python3 -m unittest discover -s tests`
+- [x] T015 Verify version output is consistent across `gh-address-cr` and `python3 skill/scripts/cli.py`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1
+- **User Stories (Phase 3+)**: Depend on Phase 2
+- **Polish (Final Phase)**: Depends on US1 and US2 completion
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel
+- T004, T005, T008 can run in parallel
+- T011 and T012 can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Setup and Foundational
+2. Complete User Story 1 (Flags)
+3. Validate and commit
+
+### Incremental Delivery
+
+1. Foundation ready
+2. Add US1 (Flags) → Test independently
+3. Add US2 (Subcommand) → Test independently
+4. Polish and final verification

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -57,8 +57,8 @@ COMMAND_TO_SCRIPT = {
     "submit-action": "submit_action.py",
 }
 
-HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter", "submit-action"}
-NATIVE_HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter"}
+HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter", "submit-action", "version"}
+NATIVE_HIGH_LEVEL_COMMANDS = {"address", "review", "threads", "findings", "adapter", "version"}
 OUTPUT_FLAGS = {"--machine", "--human"}
 HIGH_LEVEL_GH_COMMANDS = {"address", "review", "threads", "adapter"}
 INPUT_REQUIRED_COMMANDS = {"findings"}
@@ -1773,14 +1773,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Emit human-oriented text instead of the default machine summary.",
     )
     parser.add_argument(
+        "--version",
+        "-v",
+        action="version",
+        version=f"gh-address-cr {__version__}",
+    )
+    parser.add_argument(
         "command",
-        metavar="{address,review,threads,findings,adapter,review-to-findings,submit-feedback,submit-action}",
+        metavar="{address,review,threads,findings,adapter,review-to-findings,submit-feedback,submit-action,version}",
         help=(
             "High-level commands:\n"
             "  cli.py address owner/repo 123 [--human]\n"
             "  cli.py review owner/repo 123 [--human]\n"
             "  cli.py review --auto-simple owner/repo 123 [--human]\n"
             "  cli.py threads owner/repo 123 [--human]\n"
+            "  cli.py version\n"
             "  cli.py findings owner/repo 123 --input findings.json [--human]\n"
             "  cli.py --human adapter owner/repo 123 python3 tools/review_adapter.py\n"
             "Notes:\n"
@@ -1821,6 +1828,10 @@ def run_script(script_name: str, passthrough_args: list[str]) -> subprocess.Comp
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    if args.command == "version":
+        sys.stdout.write(f"gh-address-cr {__version__}\n")
+        return 0
 
     if args.command == "agent":
         return handle_agent_command(args)

--- a/tests/test_version_query.py
+++ b/tests/test_version_query.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+import unittest
+
+from tests.helpers import SRC_ROOT
+
+class VersionQueryTestCase(unittest.TestCase):
+    def run_cli(self, args):
+        env = {"PYTHONPATH": str(SRC_ROOT)}
+        return subprocess.run(
+            [sys.executable, "-m", "gh_address_cr", *args],
+            capture_output=True,
+            text=True,
+            env=env
+        )
+
+    def test_version_flag(self):
+        """T004: Test --version flag"""
+        result = self.run_cli(["--version"])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("gh-address-cr", result.stdout)
+        # We don't assert the exact version here to avoid fragility, 
+        # but we check it contains numbers and dots.
+        self.assertRegex(result.stdout, r"\d+\.\d+\.\d+")
+
+    def test_version_shorthand_flag(self):
+        """T005: Test -v flag"""
+        result = self.run_cli(["-v"])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("gh-address-cr", result.stdout)
+        self.assertRegex(result.stdout, r"\d+\.\d+\.\d+")
+
+    def test_version_subcommand(self):
+        """T008: Test version subcommand"""
+        result = self.run_cli(["version"])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("gh-address-cr", result.stdout)
+        self.assertRegex(result.stdout, r"\d+\.\d+\.\d+")


### PR DESCRIPTION
This PR adds the standard '--version' and '-v' flags, as well as a 'version' subcommand to the `gh-address-cr` CLI.

### Key Changes:
- **Global Flags**: Added `--version` and `-v` using `argparse` built-in version action.
- **Subcommand**: Added `version` subcommand for consistent metadata access.
- **Source of Truth**: Version string is centrally managed in `src/gh_address_cr/__init__.py`.
- **Testing**: Added `tests/test_version_query.py` covering flags and subcommand.
- **Documentation**: Updated `README.md` and `skill/SKILL.md` with usage examples.

### Verification:
- Ran `python3 -m unittest discover -s tests`: 425 tests passed (including 3 new tests).
- Manual smoke tests for all version entry points.