### PR TITLE
[codex] Restore GitHub reply template parity

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/008-cli-version"}
+{"feature_directory": "specs/009-reply-template-parity"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,5 +84,5 @@ A task is complete only when:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-`specs/008-cli-version/plan.md`.
+`specs/009-reply-template-parity/plan.md`.
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ If you omit the producer where it is required:
   - `resolution`: `fix`, `clarify`, or `defer`
   - `note`
   - for GitHub thread `fix`: `fix_reply`
+    - `summary`
     - `commit_hash`
     - `files`
     - optional `severity`, `why`, `test_command`, `test_result`

--- a/skill/references/mode-producer-matrix.md
+++ b/skill/references/mode-producer-matrix.md
@@ -157,6 +157,7 @@ External fixer commands must read a JSON payload from stdin and return a JSON ob
 - `resolution`: `fix`, `clarify`, or `defer`
 - `note`
 - for GitHub thread `fix`: `fix_reply`
+  - `summary`
   - `commit_hash`
   - `files`
   - optional `severity`, `why`, `test_command`, `test_result`

--- a/skill/scripts/generate_reply.py
+++ b/skill/scripts/generate_reply.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 import argparse
+import sys
 from pathlib import Path
 
 
-SEVERITY_RISK_NOTES = {
-    "P1": "High-severity path validated with targeted regression checks.",
-    "P2": "Medium-severity path validated and behavior aligned with expected workflow.",
-    "P3": "Low-severity improvement validated for non-breaking behavior.",
-}
+def bootstrap_runtime_path() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    src_root = repo_root / "src"
+    if src_root.is_dir():
+        sys.path.insert(0, str(src_root))
+
+
+bootstrap_runtime_path()
+
+from gh_address_cr.core.reply_templates import clarify_reply, defer_reply, fix_reply  # noqa: E402
 
 
 def write_text(path: Path, content: str) -> None:
@@ -23,80 +29,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("output_md")
     parser.add_argument("args", nargs="*")
     return parser.parse_args()
-
-
-def fix_reply(severity: str, payload: list[str]) -> str:
-    if len(payload) < 4:
-        raise SystemExit(
-            "Usage for fix: generate_reply.py [--severity P1|P2|P3] <output_md> <commit_hash> <files_csv> <test_command> <test_result> [why]"
-        )
-    normalized_severity = severity.upper()
-    if normalized_severity not in SEVERITY_RISK_NOTES:
-        raise SystemExit(f"Invalid severity: {severity} (expected P1/P2/P3)")
-
-    commit_hash, files_csv, test_command, test_result, *rest = payload
-    why = rest[0] if rest else "Addressed the CR with minimal targeted changes and regression coverage."
-    files = [item.strip() for item in files_csv.split(",") if item.strip()]
-    lines = [
-        f"Fixed in `{commit_hash}`.",
-        "",
-        f"Severity: `{normalized_severity}`",
-        "",
-        "What I changed:",
-    ]
-    lines.extend([f"- `{path}`: updated per CR scope" for path in files] or ["- No file list provided."])
-    lines.extend(
-        [
-            "",
-            "Why this addresses the CR:",
-            f"- {why}",
-            f"- {SEVERITY_RISK_NOTES[normalized_severity]}",
-            "",
-            "Validation:",
-            f"- `{test_command}`",
-            f"- Result: {test_result}",
-            "",
-            "If anything still looks off, I can follow up with a focused patch.",
-        ]
-    )
-    return "\n".join(lines) + "\n"
-
-
-def clarify_reply(payload: list[str]) -> str:
-    rationale = payload[0] if payload else "No code changes were made for this specific comment."
-    return "\n".join(
-        [
-            "Thanks for the review.",
-            "",
-            "Analysis & Rationale:",
-            f"- {rationale}",
-            "",
-            "Decision:",
-            "- No code changes were made for this specific comment.",
-            "",
-            "If you feel this still needs an adjustment, let me know and I can follow up with a patch!",
-            "",
-        ]
-    )
-
-
-def defer_reply(payload: list[str]) -> str:
-    rationale = payload[0] if payload else "Marking as deferred (non-blocking for this PR)."
-    return "\n".join(
-        [
-            "Thanks, this is valid feedback.",
-            "",
-            "Decision:",
-            f"- Marking as deferred (non-blocking for this PR) because: {rationale}",
-            "",
-            "Follow-up plan:",
-            "1. Track in follow-up issue/PR.",
-            "2. Risk before follow-up: Low.",
-            "",
-            "If you prefer, I can bring this into the current PR instead.",
-            "",
-        ]
-    )
 
 
 def main() -> int:

--- a/specs/009-reply-template-parity/checklists/requirements.md
+++ b/specs/009-reply-template-parity/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Reply Template Parity
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-30  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details beyond required repository contract references
+- [x] Focused on user value and business needs
+- [x] Written for maintainers and agents using the public workflow
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic where possible
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] Implementation constraints are limited to constitution-required boundaries
+
+## Notes
+
+- Ready for implementation planning.

--- a/specs/009-reply-template-parity/contracts/reply-template-contract.md
+++ b/specs/009-reply-template-parity/contracts/reply-template-contract.md
@@ -1,0 +1,46 @@
+# Contract: GitHub Reply Template Rendering
+
+## Fix
+
+Input:
+- `resolution`: `fix`
+- `fix_reply.commit_hash`
+- `fix_reply.files` or top-level `files`
+- validation command/result evidence
+- severity from `fix_reply.severity`, item severity, or default P2
+
+Output:
+- Starts with `Fixed in `<commit_hash>`.`
+- Includes `Severity: `<P1|P2|P3>``
+- Includes `What I changed:`
+- Includes `Why this addresses the CR:`
+- Includes `Validation:`
+- Uses severity-specific risk/closing wording matching the packaged skill templates.
+
+## Clarify
+
+Input:
+- `resolution`: `clarify`
+- `reply_markdown`: non-empty rationale
+
+Output:
+- Starts with `Thanks for the review.`
+- Includes `Analysis & Rationale:`
+- Includes the rationale as a bullet
+- Includes `Decision:` and `No code changes were made for this specific comment.`
+
+## Defer
+
+Input:
+- `resolution`: `defer`
+- `reply_markdown`: non-empty defer reason
+
+Output:
+- Starts with `Thanks, this is valid feedback.`
+- Includes `Decision:`
+- Includes the reason in the defer decision line
+- Includes `Follow-up plan:` with issue/PR tracking, exact scope, and risk bullets.
+
+## Failure Behavior
+
+Missing required evidence returns `MISSING_PUBLISH_REPLY` or the existing fix-specific reason before posting a reply or resolving a thread.

--- a/specs/009-reply-template-parity/data-model.md
+++ b/specs/009-reply-template-parity/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Reply Template Parity
+
+## ReplyTemplateContract
+
+Represents the public Markdown structure used for GitHub review-thread replies.
+
+Fields:
+- `mode`: `fix`, `clarify`, or `defer`
+- `severity`: P1/P2/P3 for fix mode
+- `commit_hash`: fix mode commit identifier
+- `files`: fix mode changed files
+- `validation`: commands and result text
+- `rationale`: clarify/defer rationale from accepted response evidence
+
+Validation:
+- Fix mode requires commit hash, file list, validation command, and validation result.
+- Clarify mode requires non-empty rationale.
+- Defer mode requires non-empty reason.
+- Unknown severity normalizes to P2 before rendering.
+
+## ActionResponse Evidence
+
+Existing accepted response payload used to populate reply templates.
+
+Fields used:
+- `resolution`
+- `reply_markdown`
+- `fix_reply`
+- `files`
+- `validation_commands`
+
+State transitions:
+- `publish_ready` items render a reply body before any GitHub side effect.
+- Invalid or incomplete evidence blocks publish and preserves the existing failure behavior.

--- a/specs/009-reply-template-parity/plan.md
+++ b/specs/009-reply-template-parity/plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: Reply Template Parity
+
+**Branch**: `009-reply-template-parity` | **Date**: 2026-04-30 | **Spec**: [specs/009-reply-template-parity/spec.md](specs/009-reply-template-parity/spec.md)
+**Input**: Feature specification from `/specs/009-reply-template-parity/spec.md`
+
+## Summary
+
+Make native GitHub review-thread replies use the documented v1 reply templates for `fix`, `clarify`, and `defer`. The implementation keeps runtime rendering authoritative, updates the packaged skill generator to match it, and adds parity tests so `agent publish`, `generate-reply`, and `skill/assets` cannot drift silently.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+  
+**Primary Dependencies**: Standard library only  
+**Storage**: Existing PR session JSON and audit ledger files  
+**Testing**: `unittest`, `ruff`  
+**Target Platform**: macOS/Linux CLI runtime  
+**Project Type**: CLI and packaged skill  
+**Performance Goals**: No measurable overhead beyond existing publish path  
+**Constraints**: Preserve ActionResponse schema and final-gate behavior  
+**Scale/Scope**: GitHub review-thread reply body rendering only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Control plane ownership**: PASSED. Reply generation used by GitHub side effects remains in deterministic runtime code.
+- **Public CLI contract**: PASSED. Reply body text changes but command shape, machine fields, wait states, and exit codes remain compatible.
+- **Evidence-first handling**: PASSED. Existing accepted evidence and pre-side-effect validation stay in place.
+- **Packaged Skill Boundary**: PASSED. Skill assets and script stay aligned to runtime output without becoming the authoritative state machine.
+- **External intake replaceability**: PASSED. Findings intake and normalized findings are unchanged.
+- **Fail-fast verification**: PASSED. Tests cover missing evidence, renderer parity, and publish behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-reply-template-parity/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── reply-template-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/gh_address_cr/core/reply_templates.py
+src/gh_address_cr/core/workflow.py
+src/gh_address_cr/legacy_scripts/generate_reply.py
+skill/scripts/generate_reply.py
+skill/assets/reply-templates/
+tests/
+```
+
+**Structure Decision**: Use the existing single Python package plus packaged skill payload. No new runtime package or schema namespace is needed.
+
+## Complexity Tracking
+
+> **No Constitution Check violations.**

--- a/specs/009-reply-template-parity/quickstart.md
+++ b/specs/009-reply-template-parity/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Reply Template Parity
+
+## Validate Fix Rendering
+
+Run the native workflow tests:
+
+```bash
+PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest tests.test_native_workflow
+```
+
+Expected result:
+- Fix replies use severity-specific v1 template wording.
+- Clarify/defer replies are templated instead of raw markdown.
+
+## Validate Skill Parity
+
+Run the auxiliary script tests:
+
+```bash
+PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest tests.test_aux_scripts tests.test_skill_docs
+```
+
+Expected result:
+- `skill/scripts/generate_reply.py` output matches runtime rendering.
+- `skill/assets/reply-templates/*` stays aligned with the renderer contract.
+
+## Full Verification
+
+```bash
+ruff check src tests
+PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests
+PYTHONPATH=src PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help
+PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help
+git diff --check
+```

--- a/specs/009-reply-template-parity/research.md
+++ b/specs/009-reply-template-parity/research.md
@@ -1,0 +1,19 @@
+# Research: Reply Template Parity
+
+## Decision: Runtime renderer is authoritative
+
+**Rationale**: The constitution requires deterministic runtime code to own GitHub side effects. Reply body generation is part of the publish side effect, so it belongs under `src/gh_address_cr/core`.
+
+**Alternatives considered**: Reading `skill/assets` at runtime would mirror the packaged files directly but would make the skill payload an implementation dependency.
+
+## Decision: Preserve ActionResponse fields
+
+**Rationale**: The existing protocol already separates `fix_reply` for fixes from `reply_markdown` for clarify/defer. The bug is output rendering drift, not schema insufficiency.
+
+**Alternatives considered**: Adding structured clarify/defer schemas would be heavier and would create unnecessary protocol churn.
+
+## Decision: Parity tests over code generation
+
+**Rationale**: The smallest durable fix is to test runtime output, skill script output, and template asset headings together. Introducing a generator for assets would add maintenance cost without changing runtime behavior.
+
+**Alternatives considered**: Generating all assets from Python constants was rejected for this bugfix because it expands the build process.

--- a/specs/009-reply-template-parity/spec.md
+++ b/specs/009-reply-template-parity/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Reply Template Parity
+
+**Feature Branch**: `009-reply-template-parity`  
+**Created**: 2026-04-30  
+**Status**: Verified
+**Input**: User description: "Fix GitHub CR reply template parity so native runtime publishes v1-style skill reply templates for fix, clarify, and defer."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Template-Consistent Fix Replies (Priority: P1)
+
+As a reviewer or PR author, I want fix replies posted by `agent publish` to match the documented v1 fix templates, so GitHub review conversations remain predictable and audit-friendly.
+
+**Why this priority**: Fix replies are the most common terminal CR response and currently show the visible template drift.
+
+**Independent Test**: Publishing an accepted `fix` response for a GitHub thread posts a body matching the severity-specific v1 template.
+
+**Acceptance Scenarios**:
+
+1. **Given** a publish-ready GitHub thread with a P1 fix response, **When** `agent publish` posts the reply, **Then** the body uses the P1 `Fixed in` / `Severity` / `What I changed` / `Why this addresses the CR` / `Validation` template and P1 closing line.
+2. **Given** a fix response includes both `reply_markdown` and `fix_reply`, **When** the response is published, **Then** `fix_reply` remains the source for the templated fix reply.
+
+---
+
+### User Story 2 - Template-Consistent Clarify And Defer Replies (Priority: P2)
+
+As a reviewer or PR author, I want clarify and defer replies to use the documented v1 templates, so non-code-change decisions are explicit and consistent.
+
+**Why this priority**: Raw `reply_markdown` preserves content but bypasses the policy language that explains why no code change was made or why work is deferred.
+
+**Independent Test**: Publishing accepted `clarify` and `defer` responses wraps their rationale in the v1 clarify/defer templates.
+
+**Acceptance Scenarios**:
+
+1. **Given** a publish-ready GitHub thread with a `clarify` response, **When** `agent publish` posts the reply, **Then** the body starts with `Thanks for the review.` and includes `Analysis & Rationale` plus `Decision`.
+2. **Given** a publish-ready GitHub thread with a `defer` response, **When** `agent publish` posts the reply, **Then** the body starts with `Thanks, this is valid feedback.` and includes `Decision` plus `Follow-up plan`.
+
+---
+
+### User Story 3 - Skill And Runtime Renderer Parity (Priority: P3)
+
+As a maintainer, I want `generate-reply`, `skill/assets`, and native publish output to stay aligned, so future changes cannot silently reintroduce template drift.
+
+**Why this priority**: The bug exists because runtime and skill template outputs drifted without executable parity checks.
+
+**Independent Test**: Tests compare skill script output and asset templates against the runtime renderer contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** `skill/scripts/generate_reply.py` is used in fix, clarify, or defer mode, **When** it renders a reply, **Then** its output matches the native runtime renderer for the same inputs.
+2. **Given** packaged skill template assets are inspected, **When** parity tests run, **Then** the documented headings and severity-specific lines match the runtime contract.
+
+### Edge Cases
+
+- Missing `fix_reply` for a `fix` response must fail before GitHub side effects.
+- Missing `reply_markdown` for `clarify` or `defer` must fail before GitHub side effects.
+- Unknown fix severity must normalize to P2.
+- Existing final-gate reply evidence behavior must remain unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The runtime MUST render GitHub `fix` replies using severity-specific v1 template wording for P1, P2, and P3.
+- **FR-002**: The runtime MUST render GitHub `clarify` replies using the v1 clarify template and the accepted `reply_markdown` as rationale.
+- **FR-003**: The runtime MUST render GitHub `defer` replies using the v1 defer template and the accepted `reply_markdown` as the defer reason.
+- **FR-004**: `agent publish` MUST keep `fix_reply` as the required evidence for `fix` responses and `reply_markdown` as the required evidence for `clarify` and `defer`.
+- **FR-005**: `skill/scripts/generate_reply.py` MUST render replies through the same runtime contract or equivalent output as `agent publish`.
+- **FR-006**: The project MUST include executable parity tests that fail when runtime output, skill script output, or documented skill assets drift.
+- **FR-007**: The change MUST NOT alter final-gate pass criteria, batch evidence schema, findings intake, or ActionResponse schema version.
+
+### Constitution Alignment *(mandatory)*
+
+- **Control Plane Impact**: GitHub reply body generation remains deterministic runtime behavior owned by `src/gh_address_cr/core`.
+- **CLI / Agent Contract Impact**: Public reply text changes, but `ActionResponse` fields, reason codes, wait states, and exit codes remain compatible.
+- **Evidence Requirements**: Existing accepted evidence is still required before publish; missing reply evidence fails before GitHub side effects.
+- **Packaged Skill Boundary**: `skill/` keeps template assets and script output as a packaged policy surface, but runtime remains authoritative.
+- **External Intake Replaceability**: No changes to findings normalization or review producer contracts.
+- **Fail-Fast Behavior**: Malformed or incomplete reply evidence must continue to block publish without posting or resolving threads.
+
+### Key Entities
+
+- **ReplyTemplateContract**: The documented output structure for fix, clarify, and defer replies.
+- **ActionResponse Evidence**: Existing accepted response fields used to populate templates.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of runtime GitHub reply modes covered by tests render documented v1 template headings.
+- **SC-002**: `generate-reply` and runtime renderer produce identical output for representative fix, clarify, and defer inputs.
+- **SC-003**: Full project unit tests, lint, CLI smoke checks, and `git diff --check` pass after implementation.
+
+## Assumptions
+
+- Runtime renderer is the single source of truth for generated reply bodies.
+- `skill/assets/reply-templates/*` are documentation/parity fixtures, not runtime business logic.
+- P2 remains the default severity for missing or unknown fix severity.

--- a/specs/009-reply-template-parity/tasks.md
+++ b/specs/009-reply-template-parity/tasks.md
@@ -1,0 +1,112 @@
+---
+description: "Task list for reply template parity implementation"
+---
+
+# Tasks: Reply Template Parity
+
+**Input**: Design documents from `/specs/009-reply-template-parity/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: TDD approach. Write or update tests for every changed renderer, publish, and skill parity behavior before implementation.
+
+**Organization**: Tasks are grouped by user story to keep each behavior independently testable.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the active feature context and baseline.
+
+- [x] T001 Confirm `009-reply-template-parity` branch and `.specify/feature.json` point to `specs/009-reply-template-parity`
+- [x] T002 Run baseline targeted tests for current reply rendering in `tests/test_native_workflow.py`, `tests/test_aux_scripts.py`, and `tests/test_skill_docs.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the shared renderer contract before story work.
+
+- [x] T003 Add shared runtime renderer contract tests in `tests/test_aux_scripts.py`
+- [x] T004 Add skill asset parity tests in `tests/test_skill_docs.py`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Template-Consistent Fix Replies (Priority: P1) MVP
+
+**Goal**: Publish fix replies with v1 severity-specific template wording.
+
+**Independent Test**: `agent publish` posts exact P1/P2/P3 style bodies and ignores raw `reply_markdown` for fix responses.
+
+### Tests for User Story 1
+
+- [x] T005 [US1] Update fix publish golden tests in `tests/test_native_workflow.py`
+- [x] T006 [US1] Add runtime fix renderer tests for P1/P2/P3 in `tests/test_aux_scripts.py`
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Extend `src/gh_address_cr/core/reply_templates.py` with severity-specific fix rendering
+- [x] T008 [US1] Keep `src/gh_address_cr/core/workflow.py` fix publish path using `fix_reply` evidence
+
+---
+
+## Phase 4: User Story 2 - Template-Consistent Clarify And Defer Replies (Priority: P2)
+
+**Goal**: Publish clarify/defer replies through templates instead of raw markdown.
+
+**Independent Test**: `agent publish` wraps accepted rationale in v1 clarify/defer template structure.
+
+### Tests for User Story 2
+
+- [x] T009 [US2] Add clarify/defer publish tests in `tests/test_native_workflow.py`
+- [x] T010 [US2] Add missing `reply_markdown` fail-fast regression tests in `tests/test_native_workflow.py`
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Add clarify and defer renderers in `src/gh_address_cr/core/reply_templates.py`
+- [x] T012 [US2] Update `src/gh_address_cr/core/workflow.py` to render clarify/defer bodies before GitHub side effects
+
+---
+
+## Phase 5: User Story 3 - Skill And Runtime Renderer Parity (Priority: P3)
+
+**Goal**: Keep skill script and packaged template assets aligned with runtime output.
+
+**Independent Test**: Script output and asset contract tests fail if templates drift.
+
+### Tests for User Story 3
+
+- [x] T013 [US3] Update `skill/scripts/generate_reply.py` behavior tests in `tests/test_aux_scripts.py`
+- [x] T014 [US3] Add skill/runtime parity checks in `tests/test_skill_docs.py`
+
+### Implementation for User Story 3
+
+- [x] T015 [US3] Make `skill/scripts/generate_reply.py` and `src/gh_address_cr/legacy_scripts/generate_reply.py` reuse the runtime renderer
+- [x] T016 [US3] Sync `skill/assets/reply-templates/*.md` with the runtime contract
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Complete Speckit and repository verification.
+
+- [x] T017 Update README or skill references only if public wording needs clarification
+- [x] T018 Mark completed tasks in `specs/009-reply-template-parity/tasks.md`
+- [x] T019 Run `ruff check src tests`
+- [x] T020 Run `/opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
+- [x] T021 Run CLI smoke checks for `python -m gh_address_cr --help` and `skill/scripts/cli.py --help`
+- [x] T022 Run `git diff --check`
+
+## Dependencies & Execution Order
+
+- Phase 1 before all implementation.
+- Phase 2 before user stories.
+- US1 before US2 only where shared `_publish_reply_body` behavior overlaps.
+- US3 after runtime renderers are stable.
+- Polish after all selected user stories pass.
+
+## Implementation Strategy
+
+1. Add failing tests for runtime publish and parity.
+2. Implement the shared renderer and workflow integration.
+3. Update skill script/assets to match runtime.
+4. Run full verification and mark tasks complete.

--- a/src/gh_address_cr/core/cr_loop.py
+++ b/src/gh_address_cr/core/cr_loop.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core import session_engine as engine
-from gh_address_cr.core.reply_templates import fix_reply as render_fix_reply
+from gh_address_cr.core.reply_templates import (
+    clarify_reply as render_clarify_reply,
+    defer_reply as render_defer_reply,
+    fix_reply as render_fix_reply,
+)
 
 
 COMPAT_SCRIPT_DIR = Path(
@@ -576,6 +580,7 @@ def build_github_fix_reply(action: dict, item: dict, validation_commands: object
         reply_markdown = render_fix_reply(
             severity,
             [commit_hash, ",".join(files), test_command, test_result, why],
+            summary=str(fix_reply.get("summary") or "").strip() or None,
         )
     except SystemExit as exc:
         return None, str(exc) or "Invalid fix_reply payload."
@@ -813,6 +818,11 @@ def handle_batch(
                 reply_markdown, error = build_github_fix_reply(action, item, validation_commands)
             else:
                 reply_markdown = action.get("reply_markdown")
+                if isinstance(reply_markdown, str) and reply_markdown.strip():
+                    if resolution == "clarify":
+                        reply_markdown = render_clarify_reply([reply_markdown.strip()])
+                    elif resolution == "defer":
+                        reply_markdown = render_defer_reply([reply_markdown.strip()])
                 error = ""
             if not reply_markdown:
                 error = error or "GitHub thread actions require reply_markdown."

--- a/src/gh_address_cr/core/reply_templates.py
+++ b/src/gh_address_cr/core/reply_templates.py
@@ -3,24 +3,44 @@ from __future__ import annotations
 
 SEVERITY_RISK_NOTES = {
     "P1": "High-severity path validated with targeted regression checks.",
-    "P2": "Medium-severity path validated and behavior aligned with expected workflow.",
+    "P2": "Medium-severity path validated and aligned with expected workflow.",
     "P3": "Low-severity improvement validated for non-breaking behavior.",
 }
 
+DEFAULT_FILE_SUMMARY = "updated per CR scope"
 
-def fix_reply(severity: str, payload: list[str]) -> str:
+SEVERITY_CLOSING_LINES = {
+    "P1": "This should now be safe to merge from the original P1 perspective.",
+    "P2": "If you want, I can also run a broader suite before merge.",
+}
+
+
+def _normalize_severity(severity: str) -> str:
+    normalized = str(severity or "P2").upper()
+    return normalized if normalized in SEVERITY_RISK_NOTES else "P2"
+
+
+def _sentence_with_period(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return text
+    return text if text.endswith((".", "!", "?")) else f"{text}."
+
+
+def fix_reply(severity: str, payload: list[str], *, summary: str | None = None) -> str:
     if len(payload) < 4:
         raise SystemExit(
             "Usage for fix: generate_reply.py [--severity P1|P2|P3] <output_md> "
             "<commit_hash> <files_csv> <test_command> <test_result> [why]"
         )
-    normalized_severity = severity.upper()
-    if normalized_severity not in SEVERITY_RISK_NOTES:
+    normalized_severity = _normalize_severity(severity)
+    if str(severity or "").upper() not in SEVERITY_RISK_NOTES:
         raise SystemExit(f"Invalid severity: {severity} (expected P1/P2/P3)")
 
     commit_hash, files_csv, test_command, test_result, *rest = payload
     why = rest[0] if rest else "Addressed the CR with minimal targeted changes and regression coverage."
     files = [item.strip() for item in files_csv.split(",") if item.strip()]
+    file_summary = str(summary or DEFAULT_FILE_SUMMARY).strip()
     lines = [
         f"Fixed in `{commit_hash}`.",
         "",
@@ -28,7 +48,7 @@ def fix_reply(severity: str, payload: list[str]) -> str:
         "",
         "What I changed:",
     ]
-    lines.extend([f"- `{path}`: updated per CR scope" for path in files] or ["- No file list provided."])
+    lines.extend([f"- `{path}`: {file_summary}" for path in files] or ["- No file list provided."])
     lines.extend(
         [
             "",
@@ -39,8 +59,47 @@ def fix_reply(severity: str, payload: list[str]) -> str:
             "Validation:",
             f"- `{test_command}`",
             f"- Result: {test_result}",
-            "",
-            "If anything still looks off, I can follow up with a focused patch.",
         ]
     )
+    closing = SEVERITY_CLOSING_LINES.get(normalized_severity)
+    if closing:
+        lines.extend(["", closing])
     return "\n".join(lines) + "\n"
+
+
+def clarify_reply(payload: list[str]) -> str:
+    rationale = payload[0] if payload else "No code changes were made for this specific comment."
+    return "\n".join(
+        [
+            "Thanks for the review.",
+            "",
+            "Analysis & Rationale:",
+            f"- {rationale}",
+            "",
+            "Decision:",
+            "- No code changes were made for this specific comment.",
+            "",
+            "If you feel this still needs an adjustment, let me know and I can follow up with a patch!",
+            "",
+        ]
+    )
+
+
+def defer_reply(payload: list[str]) -> str:
+    reason = payload[0] if payload else "Marking as deferred (non-blocking for this PR)."
+    return "\n".join(
+        [
+            "Thanks, this is valid feedback.",
+            "",
+            "Decision:",
+            f"- Marking as deferred (non-blocking for this PR) because: {_sentence_with_period(reason)}",
+            "",
+            "Follow-up plan:",
+            "1. Track in `<issue_or_followup_pr>`.",
+            "2. Scope: `<exact scope>`.",
+            "3. Risk before follow-up: `<low/medium/high + short reason>`.",
+            "",
+            "If you prefer, I can bring this into the current PR instead.",
+            "",
+        ]
+    )

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -19,7 +19,11 @@ from gh_address_cr.core.leases import (
     submit_lease,
 )
 from gh_address_cr.core.models import ActionRequest
-from gh_address_cr.core.reply_templates import fix_reply as render_fix_reply
+from gh_address_cr.core.reply_templates import (
+    clarify_reply as render_clarify_reply,
+    defer_reply as render_defer_reply,
+    fix_reply as render_fix_reply,
+)
 from gh_address_cr.evidence.ledger import EvidenceLedger, SideEffectAttempt
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.diagnostics import github_waiting_on
@@ -1113,10 +1117,14 @@ def _github_thread_id(item_id: str, item: dict[str, Any]) -> str:
 def _publish_reply_body(item: dict[str, Any], response: dict[str, Any]) -> tuple[str | None, str | None]:
     resolution = str(response.get("resolution") or item.get("publish_resolution") or "")
     reply_markdown = response.get("reply_markdown")
-    if resolution != "fix" and isinstance(reply_markdown, str) and reply_markdown.strip():
-        return reply_markdown, None
     if resolution != "fix":
-        return None, "MISSING_PUBLISH_REPLY"
+        if not isinstance(reply_markdown, str) or not reply_markdown.strip():
+            return None, "MISSING_PUBLISH_REPLY"
+        if resolution == "clarify":
+            return render_clarify_reply([reply_markdown.strip()]), None
+        if resolution == "defer":
+            return render_defer_reply([reply_markdown.strip()]), None
+        return reply_markdown, None
     fix_reply = response.get("fix_reply")
     if not isinstance(fix_reply, dict):
         return None, "MISSING_PUBLISH_REPLY"
@@ -1135,8 +1143,13 @@ def _publish_reply_body(item: dict[str, Any], response: dict[str, Any]) -> tuple
         return None, "MISSING_FIX_REPLY_TEST_RESULT"
     severity = _normalize_fix_reply_severity(fix_reply.get("severity") or item.get("severity") or "P2")
     why = str(fix_reply.get("why") or "Addressed the CR with targeted changes and validation evidence.").strip()
+    summary = str(fix_reply.get("summary") or "").strip() or None
     try:
-        return render_fix_reply(severity, [commit_hash, ",".join(files), test_command, test_result, why]), None
+        return render_fix_reply(
+            severity,
+            [commit_hash, ",".join(files), test_command, test_result, why],
+            summary=summary,
+        ), None
     except SystemExit as exc:
         return None, str(exc) or "MISSING_PUBLISH_REPLY"
 

--- a/src/gh_address_cr/legacy_scripts/generate_reply.py
+++ b/src/gh_address_cr/legacy_scripts/generate_reply.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-
-SEVERITY_RISK_NOTES = {
-    "P1": "High-severity path validated with targeted regression checks.",
-    "P2": "Medium-severity path validated and behavior aligned with expected workflow.",
-    "P3": "Low-severity improvement validated for non-breaking behavior.",
-}
+from gh_address_cr.core.reply_templates import clarify_reply, defer_reply, fix_reply
 
 
 def write_text(path: Path, content: str) -> None:
@@ -23,80 +18,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("output_md")
     parser.add_argument("args", nargs="*")
     return parser.parse_args()
-
-
-def fix_reply(severity: str, payload: list[str]) -> str:
-    if len(payload) < 4:
-        raise SystemExit(
-            "Usage for fix: generate_reply.py [--severity P1|P2|P3] <output_md> <commit_hash> <files_csv> <test_command> <test_result> [why]"
-        )
-    normalized_severity = severity.upper()
-    if normalized_severity not in SEVERITY_RISK_NOTES:
-        raise SystemExit(f"Invalid severity: {severity} (expected P1/P2/P3)")
-
-    commit_hash, files_csv, test_command, test_result, *rest = payload
-    why = rest[0] if rest else "Addressed the CR with minimal targeted changes and regression coverage."
-    files = [item.strip() for item in files_csv.split(",") if item.strip()]
-    lines = [
-        f"Fixed in `{commit_hash}`.",
-        "",
-        f"Severity: `{normalized_severity}`",
-        "",
-        "What I changed:",
-    ]
-    lines.extend([f"- `{path}`: updated per CR scope" for path in files] or ["- No file list provided."])
-    lines.extend(
-        [
-            "",
-            "Why this addresses the CR:",
-            f"- {why}",
-            f"- {SEVERITY_RISK_NOTES[normalized_severity]}",
-            "",
-            "Validation:",
-            f"- `{test_command}`",
-            f"- Result: {test_result}",
-            "",
-            "If anything still looks off, I can follow up with a focused patch.",
-        ]
-    )
-    return "\n".join(lines) + "\n"
-
-
-def clarify_reply(payload: list[str]) -> str:
-    rationale = payload[0] if payload else "No code changes were made for this specific comment."
-    return "\n".join(
-        [
-            "Thanks for the review.",
-            "",
-            "Analysis & Rationale:",
-            f"- {rationale}",
-            "",
-            "Decision:",
-            "- No code changes were made for this specific comment.",
-            "",
-            "If you feel this still needs an adjustment, let me know and I can follow up with a patch!",
-            "",
-        ]
-    )
-
-
-def defer_reply(payload: list[str]) -> str:
-    rationale = payload[0] if payload else "Marking as deferred (non-blocking for this PR)."
-    return "\n".join(
-        [
-            "Thanks, this is valid feedback.",
-            "",
-            "Decision:",
-            f"- Marking as deferred (non-blocking for this PR) because: {rationale}",
-            "",
-            "Follow-up plan:",
-            "1. Track in follow-up issue/PR.",
-            "2. Risk before follow-up: Low.",
-            "",
-            "If you prefer, I can bring this into the current PR instead.",
-            "",
-        ]
-    )
 
 
 def main() -> int:

--- a/tests/test_aux_scripts.py
+++ b/tests/test_aux_scripts.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
+from gh_address_cr.core.reply_templates import clarify_reply, defer_reply, fix_reply
+
 from tests.helpers import (
     BATCH_RESOLVE_PY,
     CLEAN_STATE_PY,
@@ -107,7 +109,38 @@ class AuxiliaryScriptsTest(PythonScriptTestCase):
         body = output.read_text(encoding="utf-8")
         self.assertIn("Fixed in `abc123`.", body)
         self.assertIn("- `src/a.py`: updated per CR scope", body)
+        self.assertNotIn("<critical-path fix>", body)
         self.assertIn("- Fixed the root cause.", body)
+        self.assertIn("This should now be safe to merge from the original P1 perspective.", body)
+
+    def test_generate_reply_modes_match_runtime_renderer(self):
+        cases = [
+            (
+                ["--severity", "P2"],
+                ["abc123", "src/a.py", "pytest", "passed", "Fixed the root cause."],
+                fix_reply(
+                    "P2",
+                    ["abc123", "src/a.py", "pytest", "passed", "Fixed the root cause."],
+                    summary="updated per CR scope",
+                ),
+            ),
+            (
+                ["--mode", "clarify"],
+                ["The current lazy initialization is intentional."],
+                clarify_reply(["The current lazy initialization is intentional."]),
+            ),
+            (
+                ["--mode", "defer"],
+                ["This needs a broader cleanup outside this PR."],
+                defer_reply(["This needs a broader cleanup outside this PR."]),
+            ),
+        ]
+        for flags, args, expected in cases:
+            with self.subTest(flags=flags):
+                output = Path(self.temp_dir.name) / f"reply-{len(flags)}-{len(args)}.md"
+                result = self.run_cmd([sys.executable, str(GENERATE_REPLY_PY), *flags, str(output), *args])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(output.read_text(encoding="utf-8"), expected)
 
     def test_generate_reply_rejects_invalid_severity(self):
         output = Path(self.temp_dir.name) / "reply.md"

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -513,6 +513,7 @@ else:
         self.assertIn("Severity: `P2`", captured["reply_body"])
         self.assertIn("What I changed:", captured["reply_body"])
         self.assertIn("- `src/template_fix.py`: updated per CR scope", captured["reply_body"])
+        self.assertNotIn("<fix summary>", captured["reply_body"])
         self.assertIn("Why this addresses the CR:", captured["reply_body"])
         self.assertIn("Validation:", captured["reply_body"])
         self.assertIn("`python3 -m unittest tests.test_cr_loop`", captured["reply_body"])

--- a/tests/test_native_workflow.py
+++ b/tests/test_native_workflow.py
@@ -184,9 +184,18 @@ class NativeWorkflowTests(unittest.TestCase):
                 ]
                 self.assertEqual(result["status"], "PUBLISH_COMPLETE")
                 self.assertEqual(result["published_count"], 1)
-                self.assertEqual(
-                    client.replies[0], (repo, pr_number, "THREAD_1", "Can you confirm the intended behavior?")
+                expected_reply = (
+                    "Thanks for the review.\n"
+                    "\n"
+                    "Analysis & Rationale:\n"
+                    "- Can you confirm the intended behavior?\n"
+                    "\n"
+                    "Decision:\n"
+                    "- No code changes were made for this specific comment.\n"
+                    "\n"
+                    "If you feel this still needs an adjustment, let me know and I can follow up with a patch!\n"
                 )
+                self.assertEqual(client.replies[0], (repo, pr_number, "THREAD_1", expected_reply))
                 self.assertEqual(client.resolved[0], (repo, pr_number, "THREAD_1"))
                 self.assertEqual(updated["state"], "closed")
                 self.assertEqual(updated["status"], "CLOSED")
@@ -230,6 +239,7 @@ class NativeWorkflowTests(unittest.TestCase):
                 "files": ["src/example.py"],
                 "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
                 "fix_reply": {
+                    "summary": "Added the missing input guard.",
                     "commit_hash": "abc123",
                     "files": ["src/example.py"],
                     "why": "The input is now checked before use.",
@@ -295,6 +305,7 @@ class NativeWorkflowTests(unittest.TestCase):
                 "files": ["src/example.py"],
                 "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
                 "fix_reply": {
+                    "summary": "Added the missing input guard.",
                     "commit_hash": "abc123",
                     "files": ["src/example.py"],
                     "why": "The input is now checked before use.",
@@ -361,6 +372,7 @@ class NativeWorkflowTests(unittest.TestCase):
                 "files": ["src/example.py"],
                 "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
                 "fix_reply": {
+                    "summary": "Added the missing input guard.",
                     "commit_hash": "abc123",
                     "files": ["src/example.py"],
                     "why": "The input is now checked before use.",
@@ -373,7 +385,7 @@ class NativeWorkflowTests(unittest.TestCase):
             "Severity: `P1`\n"
             "\n"
             "What I changed:\n"
-            "- `src/example.py`: updated per CR scope\n"
+            "- `src/example.py`: Added the missing input guard.\n"
             "\n"
             "Why this addresses the CR:\n"
             "- The input is now checked before use.\n"
@@ -383,7 +395,7 @@ class NativeWorkflowTests(unittest.TestCase):
             "- `python3 -m unittest tests.test_example`\n"
             "- Result: passed\n"
             "\n"
-            "If anything still looks off, I can follow up with a focused patch.\n"
+            "This should now be safe to merge from the original P1 perspective.\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
@@ -393,6 +405,62 @@ class NativeWorkflowTests(unittest.TestCase):
                 workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
 
                 self.assertEqual(client.replies[0], expected)
+
+    def test_publish_github_thread_fix_uses_severity_specific_template_lines(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        expectations = {
+            "P1": "This should now be safe to merge from the original P1 perspective.",
+            "P2": "If you want, I can also run a broader suite before merge.",
+            "P3": "- Low-severity improvement validated for non-breaking behavior.",
+        }
+        for severity, expected_line in expectations.items():
+            with self.subTest(severity=severity):
+                repo = "owner/repo"
+                pr_number = "123"
+                item = {
+                    "item_id": "github-thread:THREAD_1",
+                    "item_kind": "github_thread",
+                    "source": "github",
+                    "thread_id": "THREAD_1",
+                    "severity": severity,
+                    "state": "publish_ready",
+                    "status": "OPEN",
+                    "blocking": True,
+                    "publish_resolution": "fix",
+                    "accepted_response": {
+                        "resolution": "fix",
+                        "note": "Fixed thread issue.",
+                        "files": ["src/example.py"],
+                        "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                        "fix_reply": {
+                            "summary": "Added the missing input guard.",
+                            "commit_hash": "abc123",
+                            "files": ["src/example.py"],
+                            "why": "The input is now checked before use.",
+                        },
+                    },
+                }
+                with tempfile.TemporaryDirectory() as tmp:
+                    with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                        self.write_session(repo, pr_number, item)
+                        client = FakeGitHubClient()
+
+                        workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                        self.assertIn(f"Severity: `{severity}`", client.replies[0])
+                        self.assertIn(expected_line, client.replies[0])
 
     def test_publish_github_thread_fix_ignores_reply_markdown_when_fix_reply_exists(self):
         from gh_address_cr.core import workflow
@@ -442,6 +510,59 @@ class NativeWorkflowTests(unittest.TestCase):
 
                 self.assertIn("Fixed in `abc123`.", client.replies[0])
                 self.assertNotIn("Legacy handwritten reply", client.replies[0])
+
+    def test_publish_github_thread_defer_uses_documented_reply_template(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "accepted_response": {
+                "resolution": "defer",
+                "note": "Needs a follow-up.",
+                "reply_markdown": "This needs a broader cleanup outside this PR.",
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+            },
+        }
+        expected = (
+            "Thanks, this is valid feedback.\n"
+            "\n"
+            "Decision:\n"
+            "- Marking as deferred (non-blocking for this PR) because: This needs a broader cleanup outside this PR.\n"
+            "\n"
+            "Follow-up plan:\n"
+            "1. Track in `<issue_or_followup_pr>`.\n"
+            "2. Scope: `<exact scope>`.\n"
+            "3. Risk before follow-up: `<low/medium/high + short reason>`.\n"
+            "\n"
+            "If you prefer, I can bring this into the current PR instead.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                self.write_session(repo, pr_number, item)
+                client = FakeGitHubClient()
+
+                workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                self.assertEqual(client.replies[0], expected)
 
     def test_publish_github_thread_response_fails_before_side_effect_without_reply_body(self):
         from gh_address_cr.core import workflow

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -1,6 +1,8 @@
 import unittest
 import json
 
+from gh_address_cr.core.reply_templates import clarify_reply, defer_reply, fix_reply
+
 from tests.helpers import ROOT
 
 
@@ -14,6 +16,7 @@ OTEL_WORKER_MJS = ROOT / "skill" / "references" / "otel-worker-better-stack" / "
 OTEL_WORKER_WRANGLER = ROOT / "skill" / "references" / "otel-worker-better-stack" / "wrangler.example.jsonc"
 OPENAI_HINT_YAML = ROOT / "skill" / "agents" / "openai.yaml"
 AGENT_FEEDBACK_ISSUE_TEMPLATE = ROOT / ".github" / "ISSUE_TEMPLATE" / "ai-agent-feedback.md"
+REPLY_TEMPLATES_DIR = ROOT / "skill" / "assets" / "reply-templates"
 
 
 def load_documentation_contracts():
@@ -114,11 +117,62 @@ class SkillDocumentationContractTest(unittest.TestCase):
         matrix_text = MODE_PRODUCER_MATRIX_MD.read_text(encoding="utf-8")
         readme_text = README_MD.read_text(encoding="utf-8")
         self.assertIn("for GitHub thread `fix`: `fix_reply`", matrix_text)
+        self.assertIn("`summary`", matrix_text)
         self.assertIn("`commit_hash`", matrix_text)
         self.assertIn("`files`", matrix_text)
         self.assertIn("for GitHub thread `clarify` or `defer`: `reply_markdown`", matrix_text)
         self.assertIn("for GitHub thread `fix`: `fix_reply`", readme_text)
+        self.assertIn("`summary`", readme_text)
         self.assertIn("for GitHub thread `clarify` or `defer`: `reply_markdown`", readme_text)
+
+    def test_skill_reply_template_assets_match_runtime_renderer_contract(self):
+        fix_cases = {
+            "fixed-p1.md": (
+                "P1",
+                [
+                    "<commit_hash>",
+                    "<file_path>",
+                    "<targeted_test_command>",
+                    "`<pass/fail + key signal>`",
+                    "`<root cause and correction>`",
+                ],
+                "`<critical-path fix>`",
+            ),
+            "fixed-p2.md": (
+                "P2",
+                [
+                    "<commit_hash>",
+                    "<file_path>",
+                    "<test_command>",
+                    "`<pass/fail + key signal>`",
+                    "`<behavioral correction>`",
+                ],
+                "`<fix summary>`",
+            ),
+            "fixed-p3.md": (
+                "P3",
+                [
+                    "<commit_hash>",
+                    "<file_path>",
+                    "<test_command>",
+                    "`<pass/fail + key signal>`",
+                    "`<clarity/consistency improvement>`",
+                ],
+                "`<small/non-breaking improvement>`",
+            ),
+        }
+        for filename, (severity, payload, summary) in fix_cases.items():
+            with self.subTest(filename=filename):
+                self.assertEqual((REPLY_TEMPLATES_DIR / filename).read_text(encoding="utf-8"), fix_reply(severity, payload, summary=summary))
+
+        self.assertEqual(
+            (REPLY_TEMPLATES_DIR / "clarify.md").read_text(encoding="utf-8"),
+            clarify_reply(["`<detailed explanation of why the current logic is correct or answers the question>`"]),
+        )
+        self.assertEqual(
+            (REPLY_TEMPLATES_DIR / "defer.md").read_text(encoding="utf-8"),
+            defer_reply(["`<reason>`"]),
+        )
 
     def test_openai_hint_requires_feedback_issue_when_skill_usage_is_blocked(self):
         text = OPENAI_HINT_YAML.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add Speckit feature 009 for GitHub CR reply template parity.
- Route `agent publish`, `generate-reply`, and legacy reply generation through the shared runtime renderer for `fix`, `clarify`, and `defer` replies.
- Align runtime output with packaged `skill/assets/reply-templates/*` contracts while preventing placeholder fix summaries from being published.

## Validation

- `ruff check src tests`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `PYTHONPATH=src PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
- `git diff --check`
