### PR TITLE
fix: repair action request helper protocol friction

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/008-cli-version"}
+{"feature_directory": "specs/009-action-request-friction"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,5 +84,5 @@ A task is complete only when:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-`specs/008-cli-version/plan.md`.
+`specs/009-action-request-friction/plan.md`.
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ gh-address-cr agent orchestrate {start,step,status,stop,resume,submit} owner/rep
 gh-address-cr final-gate owner/repo 123
 ```
 
+Classification and resolution are deliberately separate protocol phases:
+
+- `agent classify` records triage evidence on the item before a mutating fixer lease exists. If `agent next --role fixer` returns `MISSING_CLASSIFICATION`, run `agent classify ... --classification <fix|clarify|defer|reject> --note <why>` first.
+- `agent submit` consumes a fixer or verifier `ActionResponse`. Its `resolution` field is the response decision for an already leased request. If submit returns `MISSING_RESOLUTION`, add `"resolution": "fix|clarify|defer|reject"` to the response JSON and rerun `agent submit`.
+
 Role split:
 
 - `coordinator`: deterministic runtime CLI
@@ -249,6 +254,7 @@ Role split:
 Parallel work is lease-based. Independent items may be claimed concurrently, but overlapping file, item, thread, or GitHub side-effect conflict keys are rejected. AI agents must not post replies or resolve GitHub threads directly; accepted evidence is published by the runtime.
 After `agent submit` returns `ACTION_ACCEPTED`, follow the returned `next_action`; GitHub-thread fixes publish through `agent publish`.
 Use `agent submit-batch` only for GitHub review-thread `fix` evidence when one commit/files/validation set addresses multiple leased threads. The batch payload still references each thread's issued `request_id` and `lease_id`, and each item supplies its own `summary`/`why`; the runtime expands it into per-item accepted evidence before `agent publish`.
+The default manifest advertises `max_parallel_claims: 2`. This is a lease-safety limit, not a batch-size target. For many small review-thread fixes, claim the currently allowed active leases, repair them together when one commit covers them, submit a batch response, publish, then claim the next set.
 
 Minimal `BatchActionResponse` shape:
 
@@ -279,6 +285,22 @@ Minimal `BatchActionResponse` shape:
   ]
 }
 ```
+
+Manual helper path for an issued runtime `ActionRequest`:
+
+```bash
+python3 skill/scripts/submit_action.py <action-request.json> \
+  --agent-id codex-fixer-1 \
+  --resolution fix \
+  --note "Fixed the thread." \
+  --commit-hash abc123 \
+  --files src/example.py \
+  --validation-cmd "python3 -m unittest tests.test_example=passed"
+
+python3 -m gh_address_cr agent submit owner/repo 123 --input <generated-action-response.json>
+```
+
+The helper also accepts older loop-request artifacts with top-level `repo` and `pr_number`, but runtime `ActionRequest` files use `repository_context.repo` and `repository_context.pr_number`.
 
 Main entrypoint examples:
 
@@ -1056,6 +1078,7 @@ python3 skill/scripts/cli.py run-local-review --source local-agent:codex owner/r
 python3 skill/scripts/cli.py post-reply --repo owner/repo --pr 123 --audit-id run-YYYYMMDD <thread_id> "$GH_ADDRESS_CR_STATE_DIR/owner__repo/pr-123/reply.md"
 python3 skill/scripts/cli.py resolve-thread --repo owner/repo --pr 123 --audit-id run-YYYYMMDD <thread_id>
 python3 skill/scripts/cli.py submit-action <loop_request_path> --resolution fix --note "Fixed it" -- <resume_command>
+python3 skill/scripts/submit_action.py <action-request.json> --agent-id codex-fixer-1 --resolution fix --note "Fixed it" --files src/example.py --validation-cmd "python3 -m unittest tests.test_example=passed"
 python3 skill/scripts/cli.py final-gate --auto-clean --audit-id run-YYYYMMDD owner/repo 123
 ```
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -87,6 +87,8 @@ Use the runtime as the coordinator:
 
 - `gh-address-cr agent manifest`
   - discover supported roles, actions, formats, and protocol versions
+- `gh-address-cr agent classify <owner/repo> <pr_number> <item_id> --classification <fix|clarify|defer|reject> --note <why>`
+  - records triage classification evidence before a mutating fixer lease is issued
 - `gh-address-cr agent next <owner/repo> <pr_number> --role <role> --agent-id <id>`
   - claims one eligible item and writes an `ActionRequest`
 - `gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>`
@@ -110,9 +112,25 @@ Role boundaries:
 - publisher: deterministic runtime side-effect role
 - gatekeeper: deterministic final-gate role
 
+Classification is triage-phase evidence. Resolution is response-phase evidence. Do not satisfy `MISSING_CLASSIFICATION` by adding a `resolution` field to a response file; run `agent classify` first. Do not satisfy `MISSING_RESOLUTION` by reclassifying the item; add `resolution` to the `ActionResponse` and rerun `agent submit`.
+
 Allowed `ActionResponse.resolution` values are `fix`, `clarify`, `defer`, and `reject`.
 Fix responses require changed files and validation evidence. Clarify/defer/reject responses require `reply_markdown` and validation evidence. GitHub side-effect claims from AI agents are invalid.
-`BatchActionResponse` is limited to GitHub review-thread `fix` evidence with existing per-item leases; it is not a GitHub publishing shortcut and does not support local findings.
+`BatchActionResponse` is limited to GitHub review-thread `fix` evidence with existing per-item leases; it is not a GitHub publishing shortcut and does not support local findings. The default manifest exposes `max_parallel_claims: 2`, so claim the allowed leases, submit accepted batch evidence for those leased threads, publish, then claim the next set.
+
+If you receive an `ActionRequest` path and need a local response artifact, the helper accepts runtime request files with `repository_context.repo` and `repository_context.pr_number`:
+
+```bash
+python3 scripts/submit_action.py <action-request.json> \
+  --agent-id codex-fixer-1 \
+  --resolution fix \
+  --note "Fixed the thread." \
+  --commit-hash abc123 \
+  --files src/example.py \
+  --validation-cmd "python3 -m unittest tests.test_example=passed"
+```
+
+Then submit the generated `ActionResponse` with the runtime command printed by the helper.
 
 ## Advanced References
 

--- a/skill/scripts/submit_action.py
+++ b/skill/scripts/submit_action.py
@@ -12,10 +12,18 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    resume_cmd: list[str] = []
+    if "--" in argv:
+        separator = argv.index("--")
+        resume_cmd = argv[separator + 1 :]
+        argv = argv[:separator]
+
     parser = argparse.ArgumentParser(description="Submit an action to a blocked loop and resume.")
     parser.add_argument("loop_request", help="Path to the loop-request JSON artifact.")
-    parser.add_argument("--resolution", choices=["fix", "clarify", "defer"], required=True)
+    parser.add_argument("--resolution", choices=["fix", "clarify", "defer", "reject"], required=True)
     parser.add_argument("--note", required=True)
+    parser.add_argument("--agent-id", default="agent")
     parser.add_argument("--reply-markdown")
     parser.add_argument("--commit-hash")
     parser.add_argument("--files")
@@ -26,8 +34,173 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--validation-cmd", action="append", default=[])
     parser.add_argument("--human", action="store_true", help="Emit human-oriented text instead of machine summary.")
     parser.add_argument("--machine", action="store_true", help="Compatibility alias.")
-    parser.add_argument("resume_cmd", nargs=argparse.REMAINDER, help="Original command to resume (e.g. python3 scripts/cli.py review owner/repo 1)")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    args.resume_cmd = resume_cmd
+    return args
+
+
+def safe_item_id(item: dict) -> str:
+    return str(item.get("item_id", "unknown")).replace("/", "_").replace(":", "_")
+
+
+def request_item(req: dict) -> dict | None:
+    item = req.get("item")
+    return item if isinstance(item, dict) else None
+
+
+def repository_context(req: dict) -> tuple[str | None, str | None]:
+    context = req.get("repository_context")
+    if not isinstance(context, dict):
+        context = {}
+    repo = req.get("repo") or context.get("repo")
+    pr_number = req.get("pr_number") or context.get("pr_number")
+    return (str(repo) if repo else None, str(pr_number) if pr_number else None)
+
+
+def is_runtime_request(req: dict) -> bool:
+    return any(key in req for key in ("request_id", "lease_id", "agent_role", "repository_context"))
+
+
+def error(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 2
+
+
+def require_request_context(req: dict) -> tuple[str, str, dict] | None:
+    repo, pr_number = repository_context(req)
+    item = request_item(req)
+    if not repo or not pr_number:
+        error("request missing repository_context.repo or repository_context.pr_number")
+        return None
+    if not item:
+        error("request missing item")
+        return None
+    return repo, pr_number, item
+
+
+def require_runtime_identity(req: dict) -> bool:
+    missing = [field for field in ("request_id", "lease_id") if not req.get(field)]
+    if missing:
+        error(f"runtime ActionRequest missing {', '.join(missing)}")
+        return False
+    return True
+
+
+def parse_files(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def parse_validation_commands(values: list[str], *, legacy: bool) -> list[dict[str, str]] | list[str]:
+    if legacy:
+        return values
+    commands: list[dict[str, str]] = []
+    for value in values:
+        command, separator, result = value.rpartition("=")
+        if not separator:
+            command = value
+            result = "passed"
+        command = command.strip()
+        result = result.strip()
+        if command and result:
+            commands.append({"command": command, "result": result})
+    return commands
+
+
+def build_fix_reply(args: argparse.Namespace, files: list[str]) -> dict:
+    fields = {
+        "summary": args.note,
+        "commit_hash": args.commit_hash,
+        "files": files or None,
+        "severity": args.severity,
+        "why": args.why,
+        "test_command": args.test_command,
+        "test_result": args.test_result,
+    }
+    return {key: value for key, value in fields.items() if value}
+
+
+def validate_evidence(args: argparse.Namespace, item_kind: str, *, runtime: bool) -> bool:
+    files = parse_files(args.files)
+    if args.resolution == "fix":
+        if item_kind == "github_thread" and (not args.commit_hash or not files):
+            error("--resolution fix for github_thread requires --commit-hash and --files")
+            return False
+        if runtime and not files:
+            error("--resolution fix for runtime ActionRequest requires --files")
+            return False
+        if runtime and not args.validation_cmd:
+            error("--resolution fix for runtime ActionRequest requires --validation-cmd")
+            return False
+    else:
+        if (runtime or item_kind == "github_thread") and not args.reply_markdown:
+            target = "runtime ActionRequest" if runtime else item_kind
+            error(f"--resolution {args.resolution} for {target} requires --reply-markdown")
+            return False
+        if runtime and not args.validation_cmd:
+            error(f"--resolution {args.resolution} for runtime ActionRequest requires --validation-cmd")
+            return False
+    return True
+
+
+def build_runtime_response(req: dict, args: argparse.Namespace) -> dict:
+    files = parse_files(args.files)
+    action = {
+        "schema_version": str(req.get("schema_version") or "1.0"),
+        "request_id": str(req["request_id"]),
+        "lease_id": str(req["lease_id"]),
+        "agent_id": args.agent_id,
+        "resolution": args.resolution,
+        "note": args.note,
+        "validation_commands": parse_validation_commands(args.validation_cmd, legacy=False),
+    }
+    if files:
+        action["files"] = files
+    if args.reply_markdown:
+        action["reply_markdown"] = args.reply_markdown
+    if args.resolution == "fix":
+        action["fix_reply"] = build_fix_reply(args, files)
+    return action
+
+
+def build_legacy_action(args: argparse.Namespace) -> dict:
+    files = parse_files(args.files)
+    action = {
+        "resolution": args.resolution,
+        "note": args.note,
+    }
+    if args.reply_markdown:
+        action["reply_markdown"] = args.reply_markdown
+    if any([args.commit_hash, files, args.severity, args.why, args.test_command, args.test_result]):
+        action["fix_reply"] = {
+            "commit_hash": args.commit_hash,
+            "files": args.files,
+            "severity": args.severity,
+            "why": args.why,
+            "test_command": args.test_command,
+            "test_result": args.test_result,
+        }
+    if args.validation_cmd:
+        action["validation_commands"] = parse_validation_commands(args.validation_cmd, legacy=True)
+    return action
+
+
+def bind_runtime_input(cmd: list[str], output_path: Path) -> list[str]:
+    bound = list(cmd)
+    output = str(output_path)
+    for index, arg in enumerate(bound):
+        if arg == "--input":
+            if index + 1 < len(bound):
+                bound[index + 1] = output
+            else:
+                bound.append(output)
+            return bound
+        if arg.startswith("--input="):
+            bound[index] = f"--input={output}"
+            return bound
+    bound.extend(["--input", output])
+    return bound
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -43,69 +216,47 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: invalid JSON in {req_path}", file=sys.stderr)
         return 2
 
-    repo = req.get("repo")
-    pr_number = req.get("pr_number")
-    item = req.get("item")
-
-    if not repo or not pr_number or not item:
-        print("Error: loop-request missing repo, pr_number, or item", file=sys.stderr)
+    context = require_request_context(req)
+    if context is None:
+        return 2
+    repo, pr_number, item = context
+    runtime = is_runtime_request(req)
+    if runtime and not require_runtime_identity(req):
         return 2
 
     item_kind = item.get("item_kind")
+    if not validate_evidence(args, str(item_kind), runtime=runtime):
+        return 2
 
-    # Validation: fix for GitHub thread requires fix_reply details
-    if args.resolution == "fix" and item_kind == "github_thread":
-        if not args.commit_hash or not args.files:
-            print("Error: --resolution fix for github_thread requires --commit-hash and --files", file=sys.stderr)
-            return 2
-    # Validation: clarify/defer for GitHub thread requires reply_markdown
-    if args.resolution in {"clarify", "defer"} and item_kind == "github_thread":
-        if not args.reply_markdown:
-            print(f"Error: --resolution {args.resolution} for github_thread requires --reply-markdown", file=sys.stderr)
-            return 2
-
-    action = {
-        "resolution": args.resolution,
-        "note": args.note,
-    }
-    if args.reply_markdown:
-        action["reply_markdown"] = args.reply_markdown
-
-    if any([args.commit_hash, args.files, args.severity, args.why, args.test_command, args.test_result]):
-        action["fix_reply"] = {
-            "commit_hash": args.commit_hash,
-            "files": args.files,
-            "severity": args.severity,
-            "why": args.why,
-            "test_command": args.test_command,
-            "test_result": args.test_result,
-        }
-
-    if args.validation_cmd:
-        action["validation_commands"] = args.validation_cmd
-
-    safe_item_id = item.get("item_id", "unknown").replace("/", "_").replace(":", "_")
-    output_path = req_path.parent / f"fixer-payload-{safe_item_id}.json"
+    item_id = safe_item_id(item)
+    action = build_runtime_response(req, args) if runtime else build_legacy_action(args)
+    output_prefix = "action-response" if runtime else "fixer-payload"
+    output_path = req_path.parent / f"{output_prefix}-{item_id}.json"
 
     output_path.write_text(json.dumps(action, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    script_path = req_path.parent / f"fixer-{safe_item_id}.sh"
+    script_path = req_path.parent / f"fixer-{item_id}.sh"
     script_path.write_text(f"#!/bin/sh\ncat {shlex.quote(str(output_path))}\n", encoding="utf-8")
     os.chmod(script_path, 0o755)
 
     cmd = list(args.resume_cmd)
-    if cmd and cmd[0] == "--":
-        cmd = cmd[1:]
 
     if cmd:
-        cmd.extend(["--fixer-cmd", str(script_path)])
+        if runtime:
+            cmd = bind_runtime_input(cmd, output_path)
+        elif not runtime:
+            cmd.extend(["--fixer-cmd", str(script_path)])
         print(f"Resuming loop with submitted action '{args.resolution}'...")
         result = subprocess.run(cmd)
         return result.returncode
 
     print(f"Action '{args.resolution}' formulated for {item.get('item_id')}.")
-    print("To resume the PR session, run your original loop command and append:")
-    print(f"  --fixer-cmd \"{script_path}\"")
+    if runtime:
+        print("To submit this response, run:")
+        print(f"  gh-address-cr agent submit {repo} {pr_number} --input \"{output_path}\"")
+    else:
+        print("To resume the PR session, run your original loop command and append:")
+        print(f"  --fixer-cmd \"{script_path}\"")
     return 0
 
 

--- a/skill/scripts/submit_action.py
+++ b/skill/scripts/submit_action.py
@@ -70,7 +70,7 @@ def require_request_context(req: dict) -> tuple[str, str, dict] | None:
     repo, pr_number = repository_context(req)
     item = request_item(req)
     if not repo or not pr_number:
-        error("request missing repository_context.repo or repository_context.pr_number")
+        error("request missing repo/pr_number (either top-level repo/pr_number or repository_context.repo/pr_number)")
         return None
     if not item:
         error("request missing item")

--- a/specs/009-action-request-friction/checklists/requirements.md
+++ b/specs/009-action-request-friction/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Action Request Friction Repair
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-30  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Issue #30 network instability is explicitly out of scope except for diagnostics wording that distinguishes transport failure from protocol failure.

--- a/specs/009-action-request-friction/contracts/action-request-helper.md
+++ b/specs/009-action-request-friction/contracts/action-request-helper.md
@@ -1,0 +1,82 @@
+# Contract: Action Request Helper
+
+## Purpose
+
+The packaged helper prepares an agent response artifact from either a runtime `ActionRequest` or a legacy loop request. It must not become an authoritative workflow engine.
+
+## Runtime Request Input
+
+Required fields:
+
+```json
+{
+  "schema_version": "1.0",
+  "request_id": "req_123",
+  "lease_id": "lease_123",
+  "agent_role": "fixer",
+  "item": {
+    "item_id": "github-thread:abc",
+    "item_kind": "github_thread"
+  },
+  "repository_context": {
+    "repo": "owner/repo",
+    "pr_number": "123"
+  }
+}
+```
+
+## Runtime Response Output
+
+For runtime requests, the helper writes an `ActionResponse` JSON file:
+
+```json
+{
+  "schema_version": "1.0",
+  "request_id": "req_123",
+  "lease_id": "lease_123",
+  "agent_id": "agent",
+  "resolution": "fix",
+  "note": "Fixed the thread.",
+  "files": ["src/example.py"],
+  "validation_commands": [
+    {
+      "command": "python3 -m unittest tests.test_example",
+      "result": "passed"
+    }
+  ],
+  "fix_reply": {
+    "summary": "Fixed the thread.",
+    "commit_hash": "abc123",
+    "files": ["src/example.py"]
+  }
+}
+```
+
+## Legacy Request Input
+
+Legacy loop requests remain supported when repository identity is top-level:
+
+```json
+{
+  "repo": "owner/repo",
+  "pr_number": "123",
+  "item": {
+    "item_id": "local-finding:abc",
+    "item_kind": "local_finding"
+  }
+}
+```
+
+## Failure Contract
+
+The helper exits with code 2 and writes no response artifact when:
+
+- The request file is missing or invalid JSON.
+- Repository identity cannot be found in `repository_context` or top-level fields.
+- `item` is missing.
+- Runtime request identity is incomplete.
+- Required evidence for the selected resolution is missing.
+
+## Side-Effect Boundary
+
+The helper may write local response and shell helper artifacts. It must not post GitHub replies, resolve threads, mutate session state, or claim completion.

--- a/specs/009-action-request-friction/contracts/batch-action-response.md
+++ b/specs/009-action-request-friction/contracts/batch-action-response.md
@@ -1,0 +1,77 @@
+# Contract: Batch Action Response
+
+## Purpose
+
+`agent submit-batch` accepts shared fix evidence for multiple GitHub review threads when all included items already have active fixer leases.
+
+## Accepted Input Shape
+
+```json
+{
+  "schema_version": "1.0",
+  "agent_id": "codex-1",
+  "resolution": "fix",
+  "common": {
+    "files": ["src/example_one.py", "src/example_two.py"],
+    "validation_commands": [
+      {
+        "command": "python3 -m unittest tests.test_examples",
+        "result": "passed"
+      }
+    ],
+    "fix_reply": {
+      "commit_hash": "abc123",
+      "test_command": "python3 -m unittest tests.test_examples",
+      "test_result": "passed"
+    }
+  },
+  "items": [
+    {
+      "request_id": "req_one",
+      "lease_id": "lease_one",
+      "item_id": "github-thread:one",
+      "summary": "Fixed first thread.",
+      "why": "The first thread now uses the shared guarded path."
+    },
+    {
+      "request_id": "req_two",
+      "lease_id": "lease_two",
+      "item_id": "github-thread:two",
+      "summary": "Fixed second thread.",
+      "why": "The second thread now uses the shared guarded path."
+    }
+  ]
+}
+```
+
+## Acceptance Rules
+
+- Every item must reference an active fixer lease.
+- Every item must be a GitHub review thread.
+- Every item must use resolution `fix`.
+- Shared files and validation evidence may live under `common`.
+- Each item must provide a distinct request id, lease id, and item id.
+- Each item must provide a per-thread summary or note.
+
+## Rejection Rules
+
+The runtime rejects the whole batch without partial acceptance when any item has:
+
+- Duplicate lease id.
+- Duplicate item id.
+- Missing request id or lease id.
+- Stale, expired, or missing lease.
+- Local finding item kind.
+- Unsupported role.
+- Non-fix resolution.
+- Missing required fix evidence.
+
+## Next Action
+
+After acceptance, agents must run:
+
+```bash
+gh-address-cr agent publish owner/repo 123
+```
+
+Publishing remains serialized and runtime-owned.

--- a/specs/009-action-request-friction/data-model.md
+++ b/specs/009-action-request-friction/data-model.md
@@ -1,0 +1,106 @@
+# Data Model: Action Request Friction Repair
+
+## ActionRequest
+
+Runtime-owned work assignment issued for one item under an active lease.
+
+Fields relevant to this feature:
+
+- `schema_version`
+- `request_id`
+- `session_id`
+- `lease_id`
+- `agent_role`
+- `item`
+- `allowed_actions`
+- `required_evidence`
+- `repository_context.repo`
+- `repository_context.pr_number`
+- `resume_command`
+- `forbidden_actions`
+
+Validation rules:
+
+- `request_id`, `lease_id`, `agent_role`, `item`, and repository identity are required for runtime helper mode.
+- Repository identity may be read from `repository_context` or from legacy top-level `repo` and `pr_number`.
+- Requests that forbid direct GitHub side effects must not be converted into direct reply or resolve operations by the helper.
+
+## LegacyLoopRequest
+
+Older manual continuation artifact for loop-level workflows.
+
+Fields relevant to this feature:
+
+- `repo`
+- `pr_number`
+- `item`
+- optional command-specific continuation fields
+
+Validation rules:
+
+- Top-level `repo`, `pr_number`, and `item` are required for legacy helper mode.
+- Legacy output may remain a loop action payload when no structured request and lease identity are present.
+
+## ActionResponse
+
+Agent-produced evidence submitted back to the runtime for one request and lease.
+
+Fields relevant to this feature:
+
+- `schema_version`
+- `request_id`
+- `lease_id`
+- `agent_id`
+- `resolution`
+- `note`
+- `files`
+- `validation_commands`
+- `reply_markdown`
+- `fix_reply`
+
+Validation rules:
+
+- Fix responses require `files` and validation evidence.
+- GitHub-thread fix responses require `fix_reply`.
+- Clarify, defer, and reject responses require `reply_markdown` when required by the runtime.
+- Response identity must match the issued request and active lease.
+
+## BatchActionResponse
+
+Grouped response payload for multiple GitHub-thread fixes.
+
+Fields relevant to this feature:
+
+- `schema_version`
+- `agent_id`
+- `resolution`
+- `common.files`
+- `common.validation_commands`
+- `common.fix_reply`
+- `items[].request_id`
+- `items[].lease_id`
+- `items[].item_id`
+- `items[].summary`
+- `items[].why`
+
+Validation rules:
+
+- Only GitHub-thread fix responses are supported.
+- Each item must carry its own request and lease identity.
+- Duplicate leases, duplicate items, stale leases, local findings, and unsupported resolutions reject the batch without partial acceptance.
+
+## ClassificationEvidence
+
+Triage-phase evidence that records whether a work item should be fixed, clarified, deferred, or rejected.
+
+Fields relevant to this feature:
+
+- `classification`
+- `note`
+- `record_id`
+- `event_type`
+
+Validation rules:
+
+- Mutating fixer requests require prior classification evidence.
+- Missing classification is not the same as missing fixer resolution.

--- a/specs/009-action-request-friction/plan.md
+++ b/specs/009-action-request-friction/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Action Request Friction Repair
+
+**Branch**: `codex/010-agent-contract-friction` | **Date**: 2026-04-30 | **Spec**: [specs/009-action-request-friction/spec.md](specs/009-action-request-friction/spec.md)
+**Input**: Feature specification from `/specs/009-action-request-friction/spec.md`
+
+## Summary
+
+Repair the agent-facing workflow friction reported in issue #30 by making the packaged `submit_action.py` helper consume runtime `ActionRequest` artifacts directly, clarifying classification-vs-resolution failure guidance, and documenting the existing batch evidence flow for small GitHub-thread fixes. Runtime state, lease validation, publishing, and final-gate behavior remain owned by deterministic code.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+  
+**Primary Dependencies**: `argparse`, `json`, `subprocess`, `unittest`  
+**Storage**: PR-scoped cache artifacts under `GH_ADDRESS_CR_STATE_DIR` or platform cache directory  
+**Testing**: `unittest`, `ruff`  
+**Target Platform**: Darwin (macOS), Linux  
+**Project Type**: CLI tool plus packaged skill adapter  
+**Performance Goals**: Helper response generation remains local and completes in under 1s for normal request files  
+**Constraints**: Preserve public CLI compatibility, keep the skill as a thin adapter, do not bypass active leases, do not mutate GitHub directly from helper scripts  
+**Scale/Scope**: One PR session at a time; multiple small GitHub-thread fixes may be submitted through existing batch evidence contracts while respecting active claim limits  
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Control plane ownership**: PASS. The plan keeps session state, lease acceptance, GitHub side effects, reply evidence, and final-gate behavior inside `src/gh_address_cr/`. The packaged helper only parses request artifacts and writes response artifacts.
+- **Public CLI contract**: PASS. Existing high-level commands and agent protocol commands remain stable. The plan clarifies next-action guidance for `agent classify`, `agent submit`, and `agent submit-batch`.
+- **Evidence-first handling**: PASS. The plan preserves classification before mutating fixer requests, requires validation/files for fixes, requires reply-ready evidence for GitHub-thread fixes, and leaves final closure to `final-gate`.
+- **Packaged skill boundary**: PASS. Changes under `skill/` are adapter/helper behavior and skill-root documentation. Runtime workflow logic stays in `src/gh_address_cr/`.
+- **External intake replaceability**: PASS. No change to normalized findings intake or review producer coupling.
+- **Fail-fast verification**: PASS. Tests will cover runtime ActionRequest parsing, malformed request rejection, missing classification guidance, missing resolution guidance, and batch all-or-nothing behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-action-request-friction/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── action-request-helper.md
+│   └── batch-action-response.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── gh_address_cr/
+    ├── cli.py
+    ├── core/
+    │   └── workflow.py
+    └── legacy_scripts/
+        └── submit_action.py
+
+skill/
+├── SKILL.md
+└── scripts/
+    └── submit_action.py
+
+tests/
+├── test_control_plane_workflow.py
+└── test_submit_action_helper.py
+```
+
+**Structure Decision**: Use the existing single Python project layout. Keep runtime-owned workflow changes under `src/gh_address_cr/`, packaged helper compatibility under `skill/scripts/`, mirrored legacy helper compatibility under `src/gh_address_cr/legacy_scripts/`, and executable regression coverage under `tests/`.
+
+## Complexity Tracking
+
+> **No Constitution Check violations.**

--- a/specs/009-action-request-friction/quickstart.md
+++ b/specs/009-action-request-friction/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Action Request Friction Repair
+
+## 1. Verify helper accepts runtime ActionRequest
+
+1. Create a PR-session fixture with one classified item.
+2. Run:
+
+```bash
+python3 -m gh_address_cr agent next owner/repo 123 --role fixer --agent-id codex-1
+```
+
+3. Pass the emitted request path to:
+
+```bash
+python3 skill/scripts/submit_action.py <request-path> \
+  --agent-id codex-1 \
+  --resolution fix \
+  --note "Fixed validation." \
+  --files src/example.py \
+  --validation-cmd "python3 -m unittest tests.test_example=passed"
+```
+
+4. Submit the generated response with:
+
+```bash
+python3 -m gh_address_cr agent submit owner/repo 123 --input <generated-response>
+```
+
+Expected result: `ACTION_ACCEPTED`.
+
+## 2. Verify classification and resolution guidance
+
+Trigger missing classification:
+
+```bash
+python3 -m gh_address_cr agent next owner/repo 123 --role fixer
+```
+
+Expected result: the summary explains that triage classification evidence is missing and points to `agent classify`.
+
+Trigger missing resolution:
+
+```bash
+python3 -m gh_address_cr agent submit owner/repo 123 --input response-without-resolution.json
+```
+
+Expected result: the summary explains that fixer response field `resolution` is missing and points to `agent submit` payload requirements.
+
+## 3. Verify batch evidence path
+
+1. Claim two GitHub-thread fixer leases.
+2. Create a `BatchActionResponse` with common commit/files/validation evidence and per-thread summaries.
+3. Run:
+
+```bash
+python3 -m gh_address_cr agent submit-batch owner/repo 123 --input batch-response.json
+```
+
+Expected result: `BATCH_ACTION_ACCEPTED`, with `accepted_count` matching the number of items.
+
+4. Mutate one item to use a stale lease and rerun the batch command.
+
+Expected result: `BATCH_ACTION_REJECTED`, with no item accepted.

--- a/specs/009-action-request-friction/research.md
+++ b/specs/009-action-request-friction/research.md
@@ -1,0 +1,37 @@
+# Research: Action Request Friction Repair
+
+## Decision: Accept runtime `repository_context` in helper request parsing
+
+**Rationale**: Runtime-generated `ActionRequest` artifacts carry `repo` and `pr_number` under `repository_context`. Requiring top-level fields creates a protocol split between the deterministic runtime and packaged skill helper.
+
+**Alternatives considered**:
+
+- Change runtime to duplicate top-level fields. Rejected because it broadens the runtime schema for a helper compatibility issue.
+- Deprecate the helper immediately. Rejected because the helper remains documented for manual continuation and is useful when agents need a response artifact generator.
+
+## Decision: Generate formal `ActionResponse` artifacts for runtime requests
+
+**Rationale**: `agent submit` expects response fields such as `request_id`, `lease_id`, and `agent_id`. A helper that emits only legacy loop action fields cannot safely satisfy the structured agent protocol.
+
+**Alternatives considered**:
+
+- Resume only old loop commands with `--fixer-cmd`. Rejected because issue #30 is specifically about runtime `agent next` requests.
+- Submit directly from the helper. Rejected because helper direct mutation would blur adapter and runtime ownership.
+
+## Decision: Keep classification and resolution distinct in wording and reason guidance
+
+**Rationale**: Classification is triage evidence recorded before a mutating lease. Resolution is the fixer/verifier response decision. Using precise next-action text reduces retries without weakening the state machine.
+
+**Alternatives considered**:
+
+- Allow fixer requests to infer classification from resolution. Rejected because it bypasses the evidence-first triage gate.
+- Rename protocol fields. Rejected because it would be a breaking public contract change.
+
+## Decision: Treat `submit-batch` as the low-overhead path, not a lease bypass
+
+**Rationale**: Existing runtime behavior already supports shared evidence for multiple GitHub-thread fixes. The correct repair is guidance and tests that make this path discoverable while preserving active lease requirements and all-or-nothing rejection.
+
+**Alternatives considered**:
+
+- Raise `max_parallel_claims` above 2. Rejected for this issue because the safety tradeoff needs a broader scheduling policy decision.
+- Add batch support for local findings. Rejected because local finding handling can require different response and closure semantics.

--- a/specs/009-action-request-friction/spec.md
+++ b/specs/009-action-request-friction/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Action Request Friction Repair
+
+**Feature Branch**: `codex/010-agent-contract-friction`  
+**Created**: 2026-04-30  
+**Status**: Verified
+**Input**: User description: "Fix issue #30: `submit_action.py` fails on runtime `ActionRequest.repository_context`, classification and resolution guidance is ambiguous, and small PR review fixes need a lower-overhead batch evidence path without weakening lease safety."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Submit Runtime Action Requests (Priority: P1)
+
+An agent receives a runtime-generated action request and uses the packaged skill helper to prepare and submit evidence without manually editing the request JSON.
+
+**Why this priority**: The reported schema mismatch blocks the manual continuation path and forces unsafe hand edits to runtime artifacts.
+
+**Independent Test**: Can be tested by issuing a runtime action request, passing that exact request file to the helper, and verifying that the generated response contains the issued request and lease identity plus repository context.
+
+**Acceptance Scenarios**:
+
+1. **Given** a runtime action request with repository details under repository context, **When** the helper is invoked with fix evidence, **Then** it prepares a valid response without requiring top-level repository fields.
+2. **Given** a legacy loop request with top-level repository fields, **When** the helper is invoked, **Then** it remains accepted for backward compatibility.
+3. **Given** a malformed request without repository context or top-level repository fields, **When** the helper is invoked, **Then** it fails loudly before writing a response.
+
+---
+
+### User Story 2 - Understand Classification and Submission Fields (Priority: P2)
+
+An agent can follow the workflow without confusing triage classification with fixer resolution, and error messages point to the correct command and field.
+
+**Why this priority**: Ambiguous field names caused repeated attempts and state-machine friction during the reported PR repair.
+
+**Independent Test**: Can be tested by triggering missing-classification and missing-response-field failures and verifying that each failure names the missing workflow phase, field, and next command.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unclassified work item, **When** a fixer request is attempted, **Then** the system reports that triage classification evidence is missing and shows the classify command shape.
+2. **Given** an action response missing resolution, **When** submission is attempted, **Then** the system reports that fixer resolution is missing and shows the response field shape.
+3. **Given** a help or reference path, **When** an agent reads the protocol guidance, **Then** classification and resolution are described as separate phases with separate payloads.
+
+---
+
+### User Story 3 - Batch Small GitHub Thread Fixes (Priority: P3)
+
+An agent handling several small GitHub review-thread fixes can use a documented batch response flow when one commit and validation set address multiple leased threads.
+
+**Why this priority**: The existing strict lease model is correct, but small PRs with many minor threads need a lower-overhead path that does not bypass leases or evidence.
+
+**Independent Test**: Can be tested by claiming multiple GitHub-thread fixer leases, submitting one batch response with shared evidence, and verifying that every included item is accepted or the whole batch is rejected without partial mutation.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple active GitHub-thread fixer leases, **When** the agent submits one batch response with shared commit, files, validation, and per-thread summaries, **Then** all included responses are accepted for publishing.
+2. **Given** a batch response that includes a local finding, duplicate lease, stale lease, or non-fix resolution, **When** the batch is submitted, **Then** the batch is rejected without accepting any item.
+3. **Given** the agent manifest or README guidance, **When** an agent wants to process several small fixes, **Then** the documented path explains `submit-batch`, lease requirements, and the max-claim limit rationale.
+
+### Edge Cases
+
+- Runtime requests may carry repository details only in `repository_context`, while older loop requests may still carry `repo` and `pr_number` at the top level.
+- The helper may be invoked without a resume command; it still must write a reusable response artifact and print the correct next command.
+- GitHub thread fixes require reply-ready evidence, while clarify, defer, and reject paths require human-readable reply text.
+- Batch submission must not partially accept earlier items when a later item is stale or invalid.
+- Network instability from `gh` is out of scope for this feature except that guidance should distinguish transport failure from protocol failure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The helper MUST accept runtime action requests that store repository identity under repository context.
+- **FR-002**: The helper MUST continue to accept legacy loop requests with top-level repository identity.
+- **FR-003**: The helper MUST include request identity, lease identity, agent identity, resolution, note, validation evidence, and fix or reply evidence in generated response artifacts.
+- **FR-004**: The helper MUST fail before writing response artifacts when required request context or evidence is missing.
+- **FR-005**: Missing-classification failures MUST identify classification as triage evidence and point to the classification command.
+- **FR-006**: Missing-resolution or missing-response-field failures MUST identify resolution as fixer response evidence and point to the response payload contract.
+- **FR-007**: Public guidance MUST describe classification and resolution as separate workflow phases with distinct commands and payload fields.
+- **FR-008**: Public guidance MUST document when `submit-batch` is appropriate, including the requirement for active leases, GitHub-thread fix-only scope, shared evidence, and per-item summaries.
+- **FR-009**: Batch response behavior MUST preserve all-or-nothing rejection for invalid local findings, stale leases, duplicate leases, duplicate items, and unsupported resolutions.
+- **FR-010**: The agent manifest MUST continue to expose batch response capability and max-claim constraints without suggesting that agents may mutate items without leases.
+
+### Constitution Alignment *(mandatory)*
+
+- **Control Plane Impact**: Runtime state, leases, evidence acceptance, GitHub side effects, and final-gate authority remain owned by deterministic runtime code. The helper only prepares response artifacts or delegates back to public commands.
+- **CLI / Agent Contract Impact**: The stable public surfaces remain `review`, `agent classify`, `agent next`, `agent submit`, `agent submit-batch`, `agent publish`, and `final-gate`. This feature clarifies payload compatibility and error guidance without replacing the Status-to-Action Map.
+- **Evidence Requirements**: Fix evidence must include files and validation; GitHub-thread fixes must include reply-ready fix evidence; clarify, defer, and reject responses must include reply markdown where required; final completion remains proven by `final-gate`.
+- **Packaged Skill Boundary**: Skill-owned helper code may parse request files and create response artifacts, but authoritative session transitions, leases, publishing, and gating stay in `src/gh_address_cr/`.
+- **External Intake Replaceability**: The feature does not change the normalized findings contract or couple review production to a specific producer.
+- **Fail-Fast Behavior**: Missing request context, missing request/lease identity, unsupported item kind, missing GitHub-thread fix evidence, missing reply text, stale leases, and invalid batch shapes must fail loudly.
+
+### Key Entities *(include if feature involves data)*
+
+- **Action Request**: Runtime-issued work request containing request identity, lease identity, role, work item, required evidence, repository context, forbidden actions, and resume command.
+- **Action Response**: Agent-produced evidence payload containing request identity, lease identity, agent identity, resolution, note, files, validation commands, and optional fix or reply evidence.
+- **Batch Action Response**: Grouped evidence payload for multiple GitHub-thread fix responses that share commit/files/validation evidence while keeping per-item request and lease identity.
+- **Classification Evidence**: Triage-phase record that declares whether an item should be fixed, clarified, deferred, or rejected.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A runtime-generated action request from `agent next` can be passed to the helper without manual JSON editing and produces a valid response artifact on the first attempt.
+- **SC-002**: Missing classification and missing resolution failures are distinguishable by status, reason code, and next-action text.
+- **SC-003**: Batch response documentation and tests cover at least two accepted GitHub-thread items and at least one all-or-nothing rejection scenario.
+- **SC-004**: Existing unit tests, linting, and CLI smoke checks pass after the repair.
+
+## Assumptions
+
+- The reported network `TLS handshake timeout` is a transport issue outside this protocol repair.
+- `max_parallel_claims: 2` remains the default safety constraint for now; the feature improves batch guidance and helper compatibility rather than raising the limit.
+- `submit_action.py` remains a helper, not a new authoritative state machine.
+- Existing `agent submit-batch` runtime behavior is the preferred low-overhead path for multiple small GitHub-thread fixes.

--- a/specs/009-action-request-friction/tasks.md
+++ b/specs/009-action-request-friction/tasks.md
@@ -1,0 +1,128 @@
+# Tasks: Action Request Friction Repair
+
+**Input**: Design documents from `/specs/009-action-request-friction/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required for helper schema compatibility, runtime error guidance, batch all-or-nothing behavior, and documentation/skill contract consistency.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm active feature context and baseline behavior before changing code.
+
+- [x] T001 Run baseline `python3 -m unittest discover -s tests` and record current status for TDD gate
+- [x] T002 [P] Inspect current helper and runtime protocol surfaces in `skill/scripts/submit_action.py`, `src/gh_address_cr/legacy_scripts/submit_action.py`, `src/gh_address_cr/core/workflow.py`, and `README.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add regression tests before implementation.
+
+- [x] T003 [P] Add helper tests for runtime `ActionRequest.repository_context` parsing and legacy top-level request compatibility in `tests/test_submit_action_helper.py`
+- [x] T004 [P] Add helper malformed-request tests for missing repository context, missing item, and missing runtime request identity in `tests/test_submit_action_helper.py`
+- [x] T005 [P] Add runtime workflow tests for missing classification and missing resolution guidance in `tests/test_control_plane_workflow.py`
+- [x] T006 [P] Extend batch response tests for all-or-nothing invalid mixed item rejection in `tests/test_control_plane_workflow.py`
+
+**Checkpoint**: Required regression tests exist and fail before implementation.
+
+---
+
+## Phase 3: User Story 1 - Submit Runtime Action Requests (Priority: P1)
+
+**Goal**: The helper accepts runtime-generated request artifacts and writes valid structured response artifacts.
+
+**Independent Test**: `python3 -m unittest tests.test_submit_action_helper`
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Implement request context extraction and runtime-vs-legacy request detection in `skill/scripts/submit_action.py`
+- [x] T008 [US1] Generate structured `ActionResponse` artifacts for runtime requests in `skill/scripts/submit_action.py`
+- [x] T009 [US1] Mirror helper compatibility changes in `src/gh_address_cr/legacy_scripts/submit_action.py`
+- [x] T010 [US1] Ensure helper output and no-resume instructions point to `gh-address-cr agent submit` for runtime requests in `skill/scripts/submit_action.py` and `src/gh_address_cr/legacy_scripts/submit_action.py`
+
+**Checkpoint**: Runtime ActionRequest and legacy loop request helper tests pass.
+
+---
+
+## Phase 4: User Story 2 - Understand Classification and Submission Fields (Priority: P2)
+
+**Goal**: Agents receive unambiguous guidance for triage classification and fixer resolution failures.
+
+**Independent Test**: Targeted workflow tests in `tests/test_control_plane_workflow.py`
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Update missing classification `WorkflowError` next-action payload in `src/gh_address_cr/core/workflow.py`
+- [x] T012 [US2] Update missing response field handling for `resolution` guidance in `src/gh_address_cr/core/workflow.py`
+- [x] T013 [US2] Document classification-vs-resolution phases in `README.md` and `skill/SKILL.md`
+
+**Checkpoint**: Classification and resolution guidance tests pass independently.
+
+---
+
+## Phase 5: User Story 3 - Batch Small GitHub Thread Fixes (Priority: P3)
+
+**Goal**: The batch path is discoverable and proven safe for multiple small GitHub-thread fixes.
+
+**Independent Test**: Batch workflow tests in `tests/test_control_plane_workflow.py`
+
+### Implementation for User Story 3
+
+- [x] T014 [US3] Preserve all-or-nothing batch rejection behavior while covering mixed invalid items in `src/gh_address_cr/core/workflow.py`
+- [x] T015 [US3] Clarify `submit-batch` usage, constraints, and max-claim rationale in `README.md`
+- [x] T016 [US3] Clarify packaged skill guidance for small thread batches in `skill/SKILL.md`
+
+**Checkpoint**: Batch acceptance and rejection tests pass independently.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate contracts, docs, and complete the speckit feature.
+
+- [x] T017 [P] Verify repo-root vs skill-root path language in `README.md`, `skill/SKILL.md`, and `specs/009-action-request-friction/contracts/`
+- [x] T018 Run `ruff check src tests`
+- [x] T019 Run `python3 -m unittest discover -s tests`
+- [x] T020 Run CLI smoke checks `python3 -m gh_address_cr --help` and `python3 skill/scripts/cli.py --help`
+- [x] T021 Sync spec status to Verified only after tests, lint, and spec coverage pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks implementation.
+- **User Story 1 (Phase 3)**: Depends on Foundational tests.
+- **User Story 2 (Phase 4)**: Depends on Foundational tests.
+- **User Story 3 (Phase 5)**: Depends on Foundational tests.
+- **Polish (Phase 6)**: Depends on selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1**: Highest priority because it removes the blocking schema mismatch.
+- **US2**: Can be implemented after tests are in place; no dependency on US1 code.
+- **US3**: Mostly documentation and regression proof around existing batch runtime behavior; can be implemented after tests are in place.
+
+### Parallel Opportunities
+
+- T003, T004, T005, and T006 can be written in parallel because they cover separate test surfaces.
+- US2 documentation updates and US3 documentation updates can be reviewed independently after runtime wording is settled.
+- T018, T019, and T020 are sequential final gates because later claims depend on fresh output.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete setup and failing tests.
+2. Complete US1 to remove the blocking request schema mismatch.
+3. Validate `tests.test_submit_action_helper`.
+
+### Incremental Delivery
+
+1. Add US2 wording and guidance once helper compatibility is green.
+2. Add US3 batch documentation and safety regression coverage.
+3. Run full lint, unit tests, and CLI smoke checks.

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -180,6 +180,12 @@ def issue_action_request(
         )
 
     if role in MUTATING_ROLES and not _has_classification_evidence(item):
+        next_action = (
+            f"Missing triage classification evidence for {item_id}. Run "
+            f"`gh-address-cr agent classify {repo} {pr_number} {item_id} "
+            "--classification <fix|clarify|defer|reject> --note <why>` "
+            "before requesting a fixer lease."
+        )
         ledger.append_event(
             session_id=str(session["session_id"]),
             item_id=item_id,
@@ -195,8 +201,8 @@ def issue_action_request(
             reason_code="MISSING_CLASSIFICATION",
             waiting_on="classification",
             exit_code=5,
-            message="Record classification evidence before issuing a mutating fixer request.",
-            payload={"item_id": item_id},
+            message=next_action,
+            payload={"item_id": item_id, "next_action": next_action},
         )
 
     lease_id = f"lease_{uuid4().hex}"
@@ -841,14 +847,30 @@ def _raise_response_rejected(
     _record_response_rejected(session, ledger, response, reason_code, item_id=item_id)
     is_batch = status == "BATCH_ACTION_REJECTED"
     payload_name = "BatchActionResponse" if is_batch else "ActionResponse"
+    message = _response_rejection_message(
+        payload_name,
+        reason_code,
+        repo=str(session.get("repo") or ""),
+        pr_number=str(session.get("pr_number") or ""),
+    )
     raise WorkflowError(
         status=status,
         reason_code=reason_code,
         waiting_on="batch_action_response" if is_batch else "action_response",
         exit_code=5,
-        message=f"{payload_name} rejected: {reason_code}",
+        message=message,
         payload={"item_id": item_id, "lease_id": lease_id or response.get("lease_id")},
     )
+
+
+def _response_rejection_message(payload_name: str, reason_code: str, *, repo: str, pr_number: str) -> str:
+    if reason_code == "MISSING_RESOLUTION":
+        return (
+            f"{payload_name} rejected: missing fixer response field \"resolution\". "
+            "Add \"resolution\": \"fix|clarify|defer|reject\" to the ActionResponse JSON and rerun "
+            f"`gh-address-cr agent submit {repo} {pr_number} --input <response.json>`."
+        )
+    return f"{payload_name} rejected: {reason_code}"
 
 
 def _batch_acceptance_payload(response: dict[str, Any], prepared: dict[str, Any], record: Any) -> dict[str, Any]:

--- a/src/gh_address_cr/legacy_scripts/submit_action.py
+++ b/src/gh_address_cr/legacy_scripts/submit_action.py
@@ -12,10 +12,18 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    resume_cmd: list[str] = []
+    if "--" in argv:
+        separator = argv.index("--")
+        resume_cmd = argv[separator + 1 :]
+        argv = argv[:separator]
+
     parser = argparse.ArgumentParser(description="Submit an action to a blocked loop and resume.")
     parser.add_argument("loop_request", help="Path to the loop-request JSON artifact.")
-    parser.add_argument("--resolution", choices=["fix", "clarify", "defer"], required=True)
+    parser.add_argument("--resolution", choices=["fix", "clarify", "defer", "reject"], required=True)
     parser.add_argument("--note", required=True)
+    parser.add_argument("--agent-id", default="agent")
     parser.add_argument("--reply-markdown")
     parser.add_argument("--commit-hash")
     parser.add_argument("--files")
@@ -26,12 +34,173 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--validation-cmd", action="append", default=[])
     parser.add_argument("--human", action="store_true", help="Emit human-oriented text instead of machine summary.")
     parser.add_argument("--machine", action="store_true", help="Compatibility alias.")
-    parser.add_argument(
-        "resume_cmd",
-        nargs=argparse.REMAINDER,
-        help="Original command to resume (e.g. python3 scripts/cli.py review owner/repo 1)",
-    )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    args.resume_cmd = resume_cmd
+    return args
+
+
+def safe_item_id(item: dict) -> str:
+    return str(item.get("item_id", "unknown")).replace("/", "_").replace(":", "_")
+
+
+def request_item(req: dict) -> dict | None:
+    item = req.get("item")
+    return item if isinstance(item, dict) else None
+
+
+def repository_context(req: dict) -> tuple[str | None, str | None]:
+    context = req.get("repository_context")
+    if not isinstance(context, dict):
+        context = {}
+    repo = req.get("repo") or context.get("repo")
+    pr_number = req.get("pr_number") or context.get("pr_number")
+    return (str(repo) if repo else None, str(pr_number) if pr_number else None)
+
+
+def is_runtime_request(req: dict) -> bool:
+    return any(key in req for key in ("request_id", "lease_id", "agent_role", "repository_context"))
+
+
+def error(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 2
+
+
+def require_request_context(req: dict) -> tuple[str, str, dict] | None:
+    repo, pr_number = repository_context(req)
+    item = request_item(req)
+    if not repo or not pr_number:
+        error("request missing repository_context.repo or repository_context.pr_number")
+        return None
+    if not item:
+        error("request missing item")
+        return None
+    return repo, pr_number, item
+
+
+def require_runtime_identity(req: dict) -> bool:
+    missing = [field for field in ("request_id", "lease_id") if not req.get(field)]
+    if missing:
+        error(f"runtime ActionRequest missing {', '.join(missing)}")
+        return False
+    return True
+
+
+def parse_files(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def parse_validation_commands(values: list[str], *, legacy: bool) -> list[dict[str, str]] | list[str]:
+    if legacy:
+        return values
+    commands: list[dict[str, str]] = []
+    for value in values:
+        command, separator, result = value.rpartition("=")
+        if not separator:
+            command = value
+            result = "passed"
+        command = command.strip()
+        result = result.strip()
+        if command and result:
+            commands.append({"command": command, "result": result})
+    return commands
+
+
+def build_fix_reply(args: argparse.Namespace, files: list[str]) -> dict:
+    fields = {
+        "summary": args.note,
+        "commit_hash": args.commit_hash,
+        "files": files or None,
+        "severity": args.severity,
+        "why": args.why,
+        "test_command": args.test_command,
+        "test_result": args.test_result,
+    }
+    return {key: value for key, value in fields.items() if value}
+
+
+def validate_evidence(args: argparse.Namespace, item_kind: str, *, runtime: bool) -> bool:
+    files = parse_files(args.files)
+    if args.resolution == "fix":
+        if item_kind == "github_thread" and (not args.commit_hash or not files):
+            error("--resolution fix for github_thread requires --commit-hash and --files")
+            return False
+        if runtime and not files:
+            error("--resolution fix for runtime ActionRequest requires --files")
+            return False
+        if runtime and not args.validation_cmd:
+            error("--resolution fix for runtime ActionRequest requires --validation-cmd")
+            return False
+    else:
+        if (runtime or item_kind == "github_thread") and not args.reply_markdown:
+            target = "runtime ActionRequest" if runtime else item_kind
+            error(f"--resolution {args.resolution} for {target} requires --reply-markdown")
+            return False
+        if runtime and not args.validation_cmd:
+            error(f"--resolution {args.resolution} for runtime ActionRequest requires --validation-cmd")
+            return False
+    return True
+
+
+def build_runtime_response(req: dict, args: argparse.Namespace) -> dict:
+    files = parse_files(args.files)
+    action = {
+        "schema_version": str(req.get("schema_version") or "1.0"),
+        "request_id": str(req["request_id"]),
+        "lease_id": str(req["lease_id"]),
+        "agent_id": args.agent_id,
+        "resolution": args.resolution,
+        "note": args.note,
+        "validation_commands": parse_validation_commands(args.validation_cmd, legacy=False),
+    }
+    if files:
+        action["files"] = files
+    if args.reply_markdown:
+        action["reply_markdown"] = args.reply_markdown
+    if args.resolution == "fix":
+        action["fix_reply"] = build_fix_reply(args, files)
+    return action
+
+
+def build_legacy_action(args: argparse.Namespace) -> dict:
+    files = parse_files(args.files)
+    action = {
+        "resolution": args.resolution,
+        "note": args.note,
+    }
+    if args.reply_markdown:
+        action["reply_markdown"] = args.reply_markdown
+    if any([args.commit_hash, files, args.severity, args.why, args.test_command, args.test_result]):
+        action["fix_reply"] = {
+            "commit_hash": args.commit_hash,
+            "files": args.files,
+            "severity": args.severity,
+            "why": args.why,
+            "test_command": args.test_command,
+            "test_result": args.test_result,
+        }
+    if args.validation_cmd:
+        action["validation_commands"] = parse_validation_commands(args.validation_cmd, legacy=True)
+    return action
+
+
+def bind_runtime_input(cmd: list[str], output_path: Path) -> list[str]:
+    bound = list(cmd)
+    output = str(output_path)
+    for index, arg in enumerate(bound):
+        if arg == "--input":
+            if index + 1 < len(bound):
+                bound[index + 1] = output
+            else:
+                bound.append(output)
+            return bound
+        if arg.startswith("--input="):
+            bound[index] = f"--input={output}"
+            return bound
+    bound.extend(["--input", output])
+    return bound
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -47,69 +216,47 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: invalid JSON in {req_path}", file=sys.stderr)
         return 2
 
-    repo = req.get("repo")
-    pr_number = req.get("pr_number")
-    item = req.get("item")
-
-    if not repo or not pr_number or not item:
-        print("Error: loop-request missing repo, pr_number, or item", file=sys.stderr)
+    context = require_request_context(req)
+    if context is None:
+        return 2
+    repo, pr_number, item = context
+    runtime = is_runtime_request(req)
+    if runtime and not require_runtime_identity(req):
         return 2
 
     item_kind = item.get("item_kind")
+    if not validate_evidence(args, str(item_kind), runtime=runtime):
+        return 2
 
-    # Validation: fix for GitHub thread requires fix_reply details
-    if args.resolution == "fix" and item_kind == "github_thread":
-        if not args.commit_hash or not args.files:
-            print("Error: --resolution fix for github_thread requires --commit-hash and --files", file=sys.stderr)
-            return 2
-    # Validation: clarify/defer for GitHub thread requires reply_markdown
-    if args.resolution in {"clarify", "defer"} and item_kind == "github_thread":
-        if not args.reply_markdown:
-            print(f"Error: --resolution {args.resolution} for github_thread requires --reply-markdown", file=sys.stderr)
-            return 2
-
-    action = {
-        "resolution": args.resolution,
-        "note": args.note,
-    }
-    if args.reply_markdown:
-        action["reply_markdown"] = args.reply_markdown
-
-    if any([args.commit_hash, args.files, args.severity, args.why, args.test_command, args.test_result]):
-        action["fix_reply"] = {
-            "commit_hash": args.commit_hash,
-            "files": args.files,
-            "severity": args.severity,
-            "why": args.why,
-            "test_command": args.test_command,
-            "test_result": args.test_result,
-        }
-
-    if args.validation_cmd:
-        action["validation_commands"] = args.validation_cmd
-
-    safe_item_id = item.get("item_id", "unknown").replace("/", "_").replace(":", "_")
-    output_path = req_path.parent / f"fixer-payload-{safe_item_id}.json"
+    item_id = safe_item_id(item)
+    action = build_runtime_response(req, args) if runtime else build_legacy_action(args)
+    output_prefix = "action-response" if runtime else "fixer-payload"
+    output_path = req_path.parent / f"{output_prefix}-{item_id}.json"
 
     output_path.write_text(json.dumps(action, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    script_path = req_path.parent / f"fixer-{safe_item_id}.sh"
+    script_path = req_path.parent / f"fixer-{item_id}.sh"
     script_path.write_text(f"#!/bin/sh\ncat {shlex.quote(str(output_path))}\n", encoding="utf-8")
     os.chmod(script_path, 0o755)
 
     cmd = list(args.resume_cmd)
-    if cmd and cmd[0] == "--":
-        cmd = cmd[1:]
 
     if cmd:
-        cmd.extend(["--fixer-cmd", str(script_path)])
+        if runtime:
+            cmd = bind_runtime_input(cmd, output_path)
+        elif not runtime:
+            cmd.extend(["--fixer-cmd", str(script_path)])
         print(f"Resuming loop with submitted action '{args.resolution}'...")
         result = subprocess.run(cmd)
         return result.returncode
 
     print(f"Action '{args.resolution}' formulated for {item.get('item_id')}.")
-    print("To resume the PR session, run your original loop command and append:")
-    print(f'  --fixer-cmd "{script_path}"')
+    if runtime:
+        print("To submit this response, run:")
+        print(f"  gh-address-cr agent submit {repo} {pr_number} --input \"{output_path}\"")
+    else:
+        print("To resume the PR session, run your original loop command and append:")
+        print(f"  --fixer-cmd \"{script_path}\"")
     return 0
 
 

--- a/src/gh_address_cr/legacy_scripts/submit_action.py
+++ b/src/gh_address_cr/legacy_scripts/submit_action.py
@@ -70,7 +70,7 @@ def require_request_context(req: dict) -> tuple[str, str, dict] | None:
     repo, pr_number = repository_context(req)
     item = request_item(req)
     if not repo or not pr_number:
-        error("request missing repository_context.repo or repository_context.pr_number")
+        error("request missing repo/pr_number (either top-level repo/pr_number or repository_context.repo/pr_number)")
         return None
     if not item:
         error("request missing item")

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -75,6 +75,8 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "REQUEST_REJECTED")
         self.assertEqual(payload["reason_code"], "MISSING_CLASSIFICATION")
+        self.assertIn("triage classification", payload["next_action"])
+        self.assertIn("gh-address-cr agent classify", payload["next_action"])
         session = self.load_session()
         self.assertEqual(session["leases"], {})
         self.assertEqual(session["items"]["local-finding:1"]["state"], "open")
@@ -233,6 +235,49 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(session["items"]["local-finding:1"]["state"], "claimed")
         self.assertEqual(session["leases"][request["lease_id"]]["status"], "active")
         self.assertIn("response_rejected", [row["event_type"] for row in self.ledger_rows()])
+
+    def test_agent_submit_missing_resolution_guides_fixer_response_payload(self):
+        self.write_session(
+            items=[
+                open_item(
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified",
+                    }
+                )
+            ]
+        )
+        issued = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1"
+        )
+        self.assertEqual(issued.returncode, 0, issued.stderr)
+        request = json.loads(Path(json.loads(issued.stdout)["request_path"]).read_text(encoding="utf-8"))
+        response_path = self.workspace_dir() / "missing-resolution-response.json"
+        response_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "request_id": request["request_id"],
+                    "lease_id": request["lease_id"],
+                    "agent_id": "codex-1",
+                    "note": "Fixed validation.",
+                    "files": ["src/example.py"],
+                    "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_runtime_module("agent", "submit", self.repo, self.pr, "--input", str(response_path))
+
+        self.assertEqual(result.returncode, 5)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ACTION_REJECTED")
+        self.assertEqual(payload["reason_code"], "MISSING_RESOLUTION")
+        self.assertIn("fixer response", payload["next_action"])
+        self.assertIn('"resolution"', payload["next_action"])
+        self.assertIn("gh-address-cr agent submit", payload["next_action"])
 
     def test_agent_submit_moves_github_thread_fix_to_publish_ready_without_side_effects(self):
         self.write_session(
@@ -455,6 +500,89 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(session["items"]["local-finding:1"]["state"], "claimed")
         self.assertEqual(session["leases"][request["lease_id"]]["status"], "active")
         self.assertIn("response_rejected", [row["event_type"] for row in self.ledger_rows()])
+
+    def test_agent_submit_batch_rejects_mixed_invalid_item_without_partial_acceptance(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example_one.py",
+                    line=10,
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_1",
+                    },
+                    thread_id="PRRT_abc",
+                ),
+                open_item(
+                    classification_evidence={
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "record_id": "ev_classified_2",
+                    }
+                ),
+            ]
+        )
+        first = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1")
+        second = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--agent-id", "codex-1")
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        first_request = json.loads(Path(json.loads(first.stdout)["request_path"]).read_text(encoding="utf-8"))
+        second_request = json.loads(Path(json.loads(second.stdout)["request_path"]).read_text(encoding="utf-8"))
+        batch_path = self.workspace_dir() / "mixed-invalid-batch-action-response.json"
+        batch_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "agent_id": "codex-1",
+                    "resolution": "fix",
+                    "common": {
+                        "files": ["src/example_one.py", "src/example.py"],
+                        "validation_commands": [
+                            {"command": "python3 -m unittest tests.test_examples", "result": "passed"}
+                        ],
+                        "fix_reply": {
+                            "commit_hash": "abc123",
+                            "test_command": "python3 -m unittest tests.test_examples",
+                            "test_result": "passed",
+                        },
+                    },
+                    "items": [
+                        {
+                            "request_id": first_request["request_id"],
+                            "lease_id": first_request["lease_id"],
+                            "item_id": "github-thread:abc",
+                            "summary": "Fixed first thread.",
+                            "why": "The first thread now validates the input before use.",
+                        },
+                        {
+                            "request_id": second_request["request_id"],
+                            "lease_id": second_request["lease_id"],
+                            "item_id": "local-finding:1",
+                            "summary": "Fixed local finding.",
+                            "why": "The local finding should not be accepted in a batch.",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(batch_path))
+
+        self.assertEqual(result.returncode, 5)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BATCH_ACTION_REJECTED")
+        self.assertEqual(payload["reason_code"], "BATCH_UNSUPPORTED_ITEM_KIND")
+        session = self.load_session()
+        self.assertEqual(session["items"]["github-thread:abc"]["state"], "claimed")
+        self.assertEqual(session["items"]["local-finding:1"]["state"], "claimed")
+        self.assertEqual(session["leases"][first_request["lease_id"]]["status"], "active")
+        self.assertEqual(session["leases"][second_request["lease_id"]]["status"], "active")
+        self.assertNotIn("response_accepted", [row["event_type"] for row in self.ledger_rows()])
 
     def test_agent_submit_batch_missing_file_reports_batch_waiting_on(self):
         self.write_session(items=[])

--- a/tests/test_submit_action_helper.py
+++ b/tests/test_submit_action_helper.py
@@ -1,0 +1,245 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from tests.helpers import PythonScriptTestCase, ROOT, SRC_ROOT
+
+
+HELPER_SCRIPTS = (
+    ROOT / "skill" / "scripts" / "submit_action.py",
+    SRC_ROOT / "gh_address_cr" / "legacy_scripts" / "submit_action.py",
+)
+
+
+def runtime_request(**overrides):
+    payload = {
+        "schema_version": "1.0",
+        "request_id": "req_123",
+        "session_id": "session_123",
+        "lease_id": "lease_123",
+        "agent_role": "fixer",
+        "item": {
+            "item_id": "github-thread:abc",
+            "item_kind": "github_thread",
+            "title": "Example thread",
+            "body": "Please fix this.",
+            "state": "claimed",
+        },
+        "allowed_actions": ["fix", "clarify", "defer", "reject"],
+        "required_evidence": ["note", "files", "validation_commands", "fix_reply"],
+        "repository_context": {"repo": "octo/example", "pr_number": "77"},
+        "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
+        "resume_command": "gh-address-cr agent submit octo/example 77 --input response.json",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class SubmitActionHelperTest(PythonScriptTestCase):
+    def write_request(self, name, payload):
+        self.workspace_dir().mkdir(parents=True, exist_ok=True)
+        path = self.workspace_dir() / name
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+
+    def run_helper(self, script: Path, *args):
+        return subprocess.run(
+            [sys.executable, str(script), *args],
+            text=True,
+            capture_output=True,
+            cwd=self.cwd,
+            env=self.env,
+        )
+
+    def test_runtime_action_request_repository_context_generates_action_response(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request_path = self.write_request("action-request.json", runtime_request())
+
+                result = self.run_helper(
+                    script,
+                    str(request_path),
+                    "--agent-id",
+                    "codex-1",
+                    "--resolution",
+                    "fix",
+                    "--note",
+                    "Fixed the thread.",
+                    "--commit-hash",
+                    "abc123",
+                    "--files",
+                    "src/example.py",
+                    "--why",
+                    "The guarded path now handles this case.",
+                    "--test-command",
+                    "python3 -m unittest tests.test_example",
+                    "--test-result",
+                    "passed",
+                    "--validation-cmd",
+                    "python3 -m unittest tests.test_example=passed",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                response_path = self.workspace_dir() / "action-response-github-thread_abc.json"
+                response = json.loads(response_path.read_text(encoding="utf-8"))
+                self.assertEqual(response["request_id"], "req_123")
+                self.assertEqual(response["lease_id"], "lease_123")
+                self.assertEqual(response["agent_id"], "codex-1")
+                self.assertEqual(response["resolution"], "fix")
+                self.assertEqual(response["files"], ["src/example.py"])
+                self.assertEqual(
+                    response["validation_commands"],
+                    [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                )
+                self.assertEqual(response["fix_reply"]["commit_hash"], "abc123")
+                self.assertIn("gh-address-cr agent submit octo/example 77 --input", result.stdout)
+
+    def test_runtime_action_request_reject_generates_reply_response(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request_path = self.write_request(
+                    "reject-action-request.json",
+                    runtime_request(
+                        item={
+                            "item_id": "local-finding:abc",
+                            "item_kind": "local_finding",
+                            "title": "Not a defect",
+                            "body": "The suggested change would break compatibility.",
+                            "state": "claimed",
+                        },
+                        required_evidence=["note", "reply_markdown", "validation_commands"],
+                    ),
+                )
+
+                result = self.run_helper(
+                    script,
+                    str(request_path),
+                    "--agent-id",
+                    "codex-1",
+                    "--resolution",
+                    "reject",
+                    "--note",
+                    "Rejected because the current behavior is intentional.",
+                    "--reply-markdown",
+                    "The current behavior is intentional and covered by the compatibility contract.",
+                    "--validation-cmd",
+                    "python3 -m unittest tests.test_example=passed",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                response_path = self.workspace_dir() / "action-response-local-finding_abc.json"
+                response = json.loads(response_path.read_text(encoding="utf-8"))
+                self.assertEqual(response["resolution"], "reject")
+                self.assertEqual(response["agent_id"], "codex-1")
+                self.assertEqual(
+                    response["reply_markdown"],
+                    "The current behavior is intentional and covered by the compatibility contract.",
+                )
+                self.assertEqual(
+                    response["validation_commands"],
+                    [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                )
+
+    def test_runtime_resume_command_replaces_placeholder_input_path(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request_path = self.write_request("resume-action-request.json", runtime_request())
+                verifier = (
+                    "import json, pathlib, sys; "
+                    "input_path = pathlib.Path(sys.argv[sys.argv.index('--input') + 1]); "
+                    "assert input_path.name == 'action-response-github-thread_abc.json', input_path; "
+                    "payload = json.loads(input_path.read_text(encoding='utf-8')); "
+                    "assert payload['request_id'] == 'req_123'"
+                )
+
+                result = self.run_helper(
+                    script,
+                    str(request_path),
+                    "--agent-id",
+                    "codex-1",
+                    "--resolution",
+                    "fix",
+                    "--note",
+                    "Fixed the thread.",
+                    "--commit-hash",
+                    "abc123",
+                    "--files",
+                    "src/example.py",
+                    "--validation-cmd",
+                    "python3 -m unittest tests.test_example=passed",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    verifier,
+                    "agent",
+                    "submit",
+                    "octo/example",
+                    "77",
+                    "--input",
+                    "response.json",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_legacy_top_level_loop_request_still_generates_loop_action_payload(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request_path = self.write_request(
+                    "loop-request.json",
+                    {
+                        "repo": "octo/example",
+                        "pr_number": "77",
+                        "item": {"item_id": "local-finding:abc", "item_kind": "local_finding"},
+                    },
+                )
+
+                result = self.run_helper(
+                    script,
+                    str(request_path),
+                    "--resolution",
+                    "fix",
+                    "--note",
+                    "Fixed local finding.",
+                    "--files",
+                    "src/example.py",
+                    "--validation-cmd",
+                    "python3 -m unittest tests.test_example",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                payload_path = self.workspace_dir() / "fixer-payload-local-finding_abc.json"
+                payload = json.loads(payload_path.read_text(encoding="utf-8"))
+                self.assertNotIn("request_id", payload)
+                self.assertEqual(payload["resolution"], "fix")
+                self.assertEqual(payload["note"], "Fixed local finding.")
+
+    def test_runtime_action_request_missing_repository_context_fails_loudly_without_artifact(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request = runtime_request(repository_context={})
+                request_path = self.write_request("missing-repository-context.json", request)
+
+                result = self.run_helper(script, str(request_path), "--resolution", "fix", "--note", "Fixed.")
+
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("repository_context.repo", result.stderr)
+                self.assertFalse((self.workspace_dir() / "action-response-github-thread_abc.json").exists())
+
+    def test_runtime_action_request_missing_identity_fails_loudly_without_artifact(self):
+        for script in HELPER_SCRIPTS:
+            with self.subTest(script=script):
+                request = runtime_request()
+                request.pop("request_id")
+                request_path = self.write_request("missing-request-id.json", request)
+
+                result = self.run_helper(script, str(request_path), "--resolution", "fix", "--note", "Fixed.")
+
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("request_id", result.stderr)
+                self.assertFalse((self.workspace_dir() / "action-response-github-thread_abc.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submit_action_helper.py
+++ b/tests/test_submit_action_helper.py
@@ -224,7 +224,8 @@ class SubmitActionHelperTest(PythonScriptTestCase):
                 result = self.run_helper(script, str(request_path), "--resolution", "fix", "--note", "Fixed.")
 
                 self.assertEqual(result.returncode, 2)
-                self.assertIn("repository_context.repo", result.stderr)
+                self.assertIn("top-level repo/pr_number", result.stderr)
+                self.assertIn("repository_context.repo/pr_number", result.stderr)
                 self.assertFalse((self.workspace_dir() / "action-response-github-thread_abc.json").exists())
 
     def test_runtime_action_request_missing_identity_fails_loudly_without_artifact(self):


### PR DESCRIPTION
## 背景
在 `submit_action` 路径里，Action Request Helper 协议在部分调用形态下存在摩擦，导致行为不够一致，影响批处理与工作流衔接。

## 变更摘要
- 修复 Action Request Helper 协议适配逻辑，统一请求处理路径。
- 调整工作流层与 legacy 脚本层的协作边界，保证行为一致性。
- 补充控制平面工作流覆盖，新增 helper 专项测试。
- 同步更新文档与规范工件（spec/plan/tasks/contracts/quickstart 等），确保实现与契约一致。

## 主要改动文件
- `skill/scripts/submit_action.py`
- `src/gh_address_cr/legacy_scripts/submit_action.py`
- `src/gh_address_cr/core/workflow.py`
- `tests/test_submit_action_helper.py`（新增）
- `tests/test_control_plane_workflow.py`
- `README.md`, `skill/SKILL.md`, `AGENTS.md`
- `specs/009-action-request-friction/*`（新增/更新规范与契约文档）

## 验证
已执行与本次改动强相关的单测：
- `python3 -m unittest tests.test_submit_action_helper tests.test_control_plane_workflow`
- 结果：`Ran 22 tests in 2.502s, OK`

## 影响评估
- 兼容性：保持现有 CLI/协议外部入口不变，侧重修复内部协作与协议一致性。
- 风险点：主要在 helper 适配与工作流联动逻辑，已通过新增与扩展测试覆盖。

## 备注
若评审希望，我可以再补一轮全量验证（`ruff check src tests` 与完整 `python3 -m unittest discover -s tests`）结果到该 PR。
