### PR TITLE
[codex] add Homebrew release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,17 @@ jobs:
         if: steps.package-version.outputs.released == 'true'
         run: twine check dist/*
 
+      - name: Render Homebrew formula from local sdist
+        if: steps.package-version.outputs.released == 'true'
+        env:
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
+        run: |
+          sdist="$(ls dist/*.tar.gz | head -n 1)"
+          python scripts/release/render_homebrew_formula.py \
+            --version "$PACKAGE_VERSION" \
+            --sdist-path "$sdist" \
+            --output /tmp/gh-address-cr.rb
+
       - name: Upload package artifacts
         if: steps.package-version.outputs.released == 'true'
         uses: actions/upload-artifact@v4
@@ -187,3 +198,91 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+  publish-homebrew:
+    needs: [build-release-package, publish-pypi]
+    runs-on: macos-latest
+    if: >-
+      needs.build-release-package.outputs.released == 'true' &&
+      needs.build-release-package.outputs.publish_target == 'pypi'
+    env:
+      HOMEBREW_NO_INSTALL_FROM_API: "1"
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Verify Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is required to update RbBtSn0w/homebrew-tap."
+            exit 1
+          fi
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: RbBtSn0w/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Render Homebrew formula from PyPI
+        env:
+          PACKAGE_VERSION: ${{ needs.build-release-package.outputs.package_version }}
+        run: |
+          python scripts/release/render_homebrew_formula.py \
+            --version "$PACKAGE_VERSION" \
+            --output homebrew-tap/Formula/gh-address-cr.rb \
+            --retries 12 \
+            --retry-delay 10
+
+      - name: Tap local formula
+        run: brew tap RbBtSn0w/tap "$PWD/homebrew-tap"
+
+      - name: Sync rendered Homebrew formula into tapped clone
+        run: |
+          tap_path="$(brew --repository RbBtSn0w/tap)"
+          mkdir -p "$tap_path/Formula"
+          cp homebrew-tap/Formula/gh-address-cr.rb "$tap_path/Formula/gh-address-cr.rb"
+
+      - name: Update Python resources
+        env:
+          PACKAGE_VERSION: ${{ needs.build-release-package.outputs.package_version }}
+        run: brew update-python-resources --package-name gh-address-cr --version "$PACKAGE_VERSION" RbBtSn0w/tap/gh-address-cr
+
+      - name: Audit Homebrew formula
+        run: brew audit --formula --strict RbBtSn0w/tap/gh-address-cr
+
+      - name: Install Homebrew formula from source
+        run: brew install --build-from-source RbBtSn0w/tap/gh-address-cr
+
+      - name: Test Homebrew formula
+        run: brew test RbBtSn0w/tap/gh-address-cr
+
+      - name: Sync audited Homebrew formula
+        run: |
+          tap_path="$(brew --repository RbBtSn0w/tap)"
+          cp "$tap_path/Formula/gh-address-cr.rb" homebrew-tap/Formula/gh-address-cr.rb
+
+      - name: Commit Homebrew tap update
+        working-directory: homebrew-tap
+        env:
+          PACKAGE_VERSION: ${{ needs.build-release-package.outputs.package_version }}
+        run: |
+          if [ -z "$(git status --short -- Formula/gh-address-cr.rb)" ]; then
+            echo "Homebrew formula already matches gh-address-cr ${PACKAGE_VERSION}."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/gh-address-cr.rb
+          git commit -m "gh-address-cr ${PACKAGE_VERSION}"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,11 @@ We welcome contributions! Please follow these guidelines:
     -   Git tag (`vX.Y.Z`)
     -   GitHub Release
     -   `CHANGELOG.md` update committed back to `main`
+    -   Python runtime package to PyPI through Trusted Publishing
+    -   Homebrew tap update to `RbBtSn0w/homebrew-tap` after the PyPI sdist is available
+-   `workflow_dispatch` `dry-run` and `testpypi` targets validate package build and Homebrew formula rendering, but they do not push tap changes.
+-   Production Homebrew publishing requires the `HOMEBREW_TAP_TOKEN` secret with `contents: write` access to `RbBtSn0w/homebrew-tap`.
+-   If `semantic-release` generates no new version, both PyPI and Homebrew publishing must skip explicitly instead of pretending to publish.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ python -m gh_address_cr --help
 
 These commands install the Python runtime package. They do not install or update the packaged skill adapter under `skill/`.
 
+### Install with Homebrew
+
+Use this path when you want the stable `gh-address-cr` executable through Homebrew on macOS or Linuxbrew. Homebrew installs the same released runtime package from the PyPI sdist through the `RbBtSn0w/homebrew-tap` formula.
+
+```bash
+brew tap RbBtSn0w/tap
+brew install gh-address-cr
+gh-address-cr --help
+gh-address-cr agent manifest
+```
+
+Upgrade and test the installed formula with:
+
+```bash
+brew upgrade gh-address-cr
+brew test gh-address-cr
+```
+
+The Homebrew tap installs the runtime CLI only. It does not install or update the packaged skill adapter under `skill/`.
+
 ### GitHub-direct runtime validation install
 
 Use this path only for pre-release validation of the current repository state before a PyPI release is available.
@@ -1263,7 +1283,9 @@ If `gh-address-cr final-gate` fails:
 - Unsupported Python: use Python 3.10 or newer through `pipx`, `uv tool`, or a local virtual environment.
 - Missing PyPI package: `gh-address-cr` may not have been published yet. Use the GitHub-direct runtime validation install for pre-release validation.
 - Missing Trusted Publishing: production PyPI publishing must use GitHub OIDC with the PyPI project `gh-address-cr`, repository `RbBtSn0w/gh-address-cr`, workflow `.github/workflows/release.yml`, no GitHub environment constraint, and `id-token: write`.
+- Missing Homebrew tap token: production Homebrew publishing requires `HOMEBREW_TAP_TOKEN`, a fine-grained GitHub token with `contents: write` access to `RbBtSn0w/homebrew-tap`.
 - Stale artifact version: release-built wheel and sdist metadata must match the semantic-release version. If a publish partially succeeds, inspect PyPI before retrying because uploaded files are immutable.
+- Homebrew tap update failure: inspect the `publish-homebrew` job after confirming PyPI upload succeeded. The job renders `Formula/gh-address-cr.rb` from the PyPI sdist, runs `brew update-python-resources`, `brew audit --formula --strict`, `brew install --build-from-source`, and `brew test` before pushing the tap update.
 - Installed smoke domain failure: `agent orchestrate status` may report a missing session and `final-gate` may report `Final gate failed to evaluate: error connecting to api.github.com` when GitHub state or network access is unavailable. These are acceptable smoke outcomes only when there is no traceback, missing import, or missing console entrypoint.
 - Skill install confusion: `npx skills add ... --skill skill` installs the packaged skill adapter only. It does not install the runtime CLI package.
 - Skill-shim migration confusion: if `python3 skill/scripts/cli.py` works from a checkout but `gh-address-cr` is unavailable, install or reinstall the runtime CLI with `pipx` or `uv tool`.
@@ -1276,10 +1298,13 @@ This repo includes a `semantic-release` workflow:
 - Input: Conventional Commits history
 - Output: semantic version tag (`vX.Y.Z`) + GitHub Release + `CHANGELOG.md`
 - Python package release: `pyproject.toml` and `src/gh_address_cr/__init__.py` are synchronized to the semantic-release version before wheel/sdist build.
-- Stable package registry: PyPI is the only documented stable runtime CLI package registry.
+- Stable Python package registry: PyPI remains the authoritative Python runtime package registry.
+- Homebrew tap: production PyPI releases update `RbBtSn0w/homebrew-tap` after the PyPI sdist is available. Homebrew is the documented macOS/Linuxbrew CLI installation channel.
 - GitHub Releases remain release-note, tag, source-archive, and optional provenance surfaces; they are not the primary Python package registry.
-- Dry-run/staging validation: use the `workflow_dispatch` `dry-run` or `testpypi` target before enabling production PyPI publishing.
+- Dry-run/staging validation: use the `workflow_dispatch` `dry-run` or `testpypi` target before enabling production PyPI publishing. These targets build the package and render a local-sdist Homebrew formula but do not write the tap.
 - Production PyPI publishing: requires PyPI Trusted Publishing and package-name ownership. It runs without a GitHub deployment environment approval gate; do not use long-lived PyPI API tokens unless a separate explicit release-policy change approves that fallback.
+- Production Homebrew publishing: requires `HOMEBREW_TAP_TOKEN` with write access to `RbBtSn0w/homebrew-tap`. The workflow validates the formula with `brew update-python-resources`, `brew audit --formula --strict`, source install, and `brew test` before pushing.
+- No-release runs: if semantic-release finds no qualifying commit and does not create a tag, PyPI and Homebrew publishing both skip explicitly.
 - Failed or partial publish recovery: inspect the PyPI project state and release artifacts before retrying; immutable package files may require a follow-up semantic-release version.
 
 Commit format examples:

--- a/scripts/release/render_homebrew_formula.py
+++ b/scripts/release/render_homebrew_formula.py
@@ -66,11 +66,11 @@ def fetch_pypi_json(package_name: str, version: str, base_url: str, retries: int
     for attempt in range(1, retries + 1):
         try:
             with urlopen(url, timeout=30) as response:
-                payload = json.loads(response.read().decode("utf-8"))
+                payload = json.load(response)
             if not isinstance(payload, dict):
                 raise SystemExit("PyPI JSON must be an object")
             return payload
-        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
             last_error = exc
             if attempt < retries:
                 time.sleep(retry_delay)
@@ -89,10 +89,10 @@ def select_sdist_from_pypi(payload: dict, version: str) -> tuple[str, str]:
         raise SystemExit("PyPI metadata missing urls array")
 
     sdists = [item for item in urls if isinstance(item, dict) and item.get("packagetype") == "sdist"]
-    if len(sdists) != 1:
-        raise SystemExit(f"expected exactly one sdist for {version}, found {len(sdists)}")
+    if not sdists:
+        raise SystemExit(f"expected at least one sdist for {version}")
 
-    sdist = sdists[0]
+    sdist = next((item for item in sdists if str(item.get("url") or "").endswith(".tar.gz")), sdists[0])
     url = str(sdist.get("url") or "")
     sha256 = str((sdist.get("digests") or {}).get("sha256") or "")
     if not url:
@@ -103,7 +103,11 @@ def select_sdist_from_pypi(payload: dict, version: str) -> tuple[str, str]:
 def source_from_local_sdist(path: Path) -> tuple[str, str]:
     if not path.is_file():
         raise SystemExit(f"sdist does not exist: {path}")
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    sha256_hash = hashlib.sha256()
+    with path.open("rb") as handle:
+        for byte_block in iter(lambda: handle.read(1024 * 1024), b""):
+            sha256_hash.update(byte_block)
+    digest = sha256_hash.hexdigest()
     return path.resolve().as_uri(), digest
 
 

--- a/scripts/release/render_homebrew_formula.py
+++ b/scripts/release/render_homebrew_formula.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+
+DEFAULT_PACKAGE_NAME = "gh-address-cr"
+DEFAULT_PYPI_BASE_URL = "https://pypi.org/pypi/"
+DEFAULT_PYTHON_DEPENDENCY = "python@3.13"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render the gh-address-cr Homebrew formula from PyPI sdist metadata.")
+    parser.add_argument("--version", required=True, help="Released package version without a leading v.")
+    parser.add_argument("--package-name", default=DEFAULT_PACKAGE_NAME, help="PyPI package name.")
+    parser.add_argument("--pypi-base-url", default=DEFAULT_PYPI_BASE_URL, help="Base PyPI JSON URL.")
+    parser.add_argument("--pypi-json", type=Path, help="Read PyPI JSON from a local fixture instead of the network.")
+    parser.add_argument("--sdist-path", type=Path, help="Use a local sdist path for render smoke validation.")
+    parser.add_argument("--sdist-url", help="Use an explicit sdist URL.")
+    parser.add_argument("--sha256", help="SHA-256 for --sdist-url.")
+    parser.add_argument("--output", type=Path, required=True, help="Formula output path.")
+    parser.add_argument("--retries", type=int, default=1, help="PyPI JSON fetch attempts.")
+    parser.add_argument("--retry-delay", type=float, default=5.0, help="Seconds between PyPI JSON fetch attempts.")
+    parser.add_argument("--python-dependency", default=DEFAULT_PYTHON_DEPENDENCY, help="Homebrew Python dependency.")
+    return parser.parse_args()
+
+
+def validate_version(version: str) -> str:
+    if version.startswith("v"):
+        raise SystemExit("version must not include a leading v")
+    if not re.match(r"^[0-9]+(?:\.[0-9]+)*(?:[a-zA-Z0-9_.!+-]+)?$", version):
+        raise SystemExit(f"unsupported version: {version}")
+    return version
+
+
+def validate_sha256(value: str) -> str:
+    normalized = value.lower()
+    if not SHA256_RE.match(normalized):
+        raise SystemExit(f"unsupported sha256: {value}")
+    return normalized
+
+
+def read_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise SystemExit("PyPI JSON must be an object")
+    return payload
+
+
+def fetch_pypi_json(package_name: str, version: str, base_url: str, retries: int, retry_delay: float) -> dict:
+    if retries < 1:
+        raise SystemExit("retries must be at least 1")
+
+    url = urljoin(base_url.rstrip("/") + "/", f"{package_name}/{version}/json")
+    last_error: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            with urlopen(url, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict):
+                raise SystemExit("PyPI JSON must be an object")
+            return payload
+        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last_error = exc
+            if attempt < retries:
+                time.sleep(retry_delay)
+
+    raise SystemExit(f"failed to fetch PyPI metadata for {package_name} {version}: {last_error}")
+
+
+def select_sdist_from_pypi(payload: dict, version: str) -> tuple[str, str]:
+    info = payload.get("info") or {}
+    payload_version = str(info.get("version") or version)
+    if payload_version != version:
+        raise SystemExit(f"PyPI metadata version {payload_version} does not match {version}")
+
+    urls = payload.get("urls")
+    if not isinstance(urls, list):
+        raise SystemExit("PyPI metadata missing urls array")
+
+    sdists = [item for item in urls if isinstance(item, dict) and item.get("packagetype") == "sdist"]
+    if len(sdists) != 1:
+        raise SystemExit(f"expected exactly one sdist for {version}, found {len(sdists)}")
+
+    sdist = sdists[0]
+    url = str(sdist.get("url") or "")
+    sha256 = str((sdist.get("digests") or {}).get("sha256") or "")
+    if not url:
+        raise SystemExit("sdist metadata missing url")
+    return url, validate_sha256(sha256)
+
+
+def source_from_local_sdist(path: Path) -> tuple[str, str]:
+    if not path.is_file():
+        raise SystemExit(f"sdist does not exist: {path}")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return path.resolve().as_uri(), digest
+
+
+def formula_class_name(package_name: str) -> str:
+    parts = re.split(r"[-_.]+", package_name)
+    return "".join(part.capitalize() for part in parts if part)
+
+
+def render_formula(
+    *,
+    class_name: str,
+    url: str,
+    sha256: str,
+    python_dependency: str,
+) -> str:
+    return f'''class {class_name} < Formula
+  include Language::Python::Virtualenv
+
+  desc "Deterministic PR review-resolution control plane runtime"
+  homepage "https://github.com/RbBtSn0w/gh-address-cr"
+  url "{url}"
+  sha256 "{sha256}"
+  license "MIT"
+
+  depends_on "{python_dependency}"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{{bin}}/gh-address-cr --version")
+    assert_match "\\"runtime_version\\"", shell_output("#{{bin}}/gh-address-cr agent manifest")
+  end
+end
+'''
+
+
+def resolve_source(args: argparse.Namespace) -> tuple[str, str]:
+    explicit_count = sum(
+        1
+        for enabled in (
+            args.pypi_json is not None,
+            args.sdist_path is not None,
+            args.sdist_url is not None or args.sha256 is not None,
+        )
+        if enabled
+    )
+    if explicit_count > 1:
+        raise SystemExit("choose only one source: --pypi-json, --sdist-path, or --sdist-url/--sha256")
+    if (args.sdist_url is None) != (args.sha256 is None):
+        raise SystemExit("--sdist-url and --sha256 must be provided together")
+
+    if args.pypi_json is not None:
+        return select_sdist_from_pypi(read_json(args.pypi_json), args.version)
+    if args.sdist_path is not None:
+        return source_from_local_sdist(args.sdist_path)
+    if args.sdist_url is not None and args.sha256 is not None:
+        return args.sdist_url, validate_sha256(args.sha256)
+    return select_sdist_from_pypi(
+        fetch_pypi_json(args.package_name, args.version, args.pypi_base_url, args.retries, args.retry_delay),
+        args.version,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    args.version = validate_version(args.version)
+
+    url, sha256 = resolve_source(args)
+    formula = render_formula(
+        class_name=formula_class_name(args.package_name),
+        url=url,
+        sha256=sha256,
+        python_dependency=args.python_dependency,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(formula, encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "status": "RENDERED",
+                "version": args.version,
+                "url": url,
+                "sha256": sha256,
+                "output": str(args.output),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/release/pypi_gh_address_cr_1_2_3.json
+++ b/tests/fixtures/release/pypi_gh_address_cr_1_2_3.json
@@ -1,0 +1,24 @@
+{
+  "info": {
+    "name": "gh-address-cr",
+    "version": "1.2.3"
+  },
+  "urls": [
+    {
+      "filename": "gh_address_cr-1.2.3-py3-none-any.whl",
+      "packagetype": "bdist_wheel",
+      "url": "https://files.pythonhosted.org/packages/py3/g/gh-address-cr/gh_address_cr-1.2.3-py3-none-any.whl",
+      "digests": {
+        "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    },
+    {
+      "filename": "gh_address_cr-1.2.3.tar.gz",
+      "packagetype": "sdist",
+      "url": "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.tar.gz",
+      "digests": {
+        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      }
+    }
+  ]
+}

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -548,6 +548,58 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn('shell_output("#{bin}/gh-address-cr agent manifest")', formula)
         self.assertNotIn("whl", formula)
 
+    def test_homebrew_formula_renderer_prefers_tar_gz_when_pypi_lists_multiple_sdists(self):
+        fixture = Path(self.temp_dir.name) / "multiple-sdists.json"
+        output = Path(self.temp_dir.name) / "gh-address-cr.rb"
+        fixture.write_text(
+            json.dumps(
+                {
+                    "info": {"name": "gh-address-cr", "version": "1.2.3"},
+                    "urls": [
+                        {
+                            "filename": "gh_address_cr-1.2.3.zip",
+                            "packagetype": "sdist",
+                            "url": "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.zip",
+                            "digests": {
+                                "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            },
+                        },
+                        {
+                            "filename": "gh_address_cr-1.2.3.tar.gz",
+                            "packagetype": "sdist",
+                            "url": "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.tar.gz",
+                            "digests": {
+                                "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                            },
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HOMEBREW_FORMULA_RENDERER),
+                "--version",
+                "1.2.3",
+                "--pypi-json",
+                str(fixture),
+                "--output",
+                str(output),
+            ],
+            text=True,
+            capture_output=True,
+            cwd=self.cwd,
+            env=self.env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["url"].endswith(".tar.gz"))
+        self.assertEqual(payload["sha256"], "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
     def test_readme_documents_runtime_distribution_paths_separately_from_skill_install(self):
         text = README.read_text(encoding="utf-8")
 

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -19,7 +19,10 @@ RELEASE_CONFIG = ROOT / "release.config.cjs"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 README = ROOT / "README.md"
+CONTRIBUTING = ROOT / "CONTRIBUTING.md"
 VERSION_SYNC_SCRIPT = ROOT / "scripts" / "set_package_version.py"
+HOMEBREW_FORMULA_RENDERER = ROOT / "scripts" / "release" / "render_homebrew_formula.py"
+PYPI_JSON_FIXTURE = ROOT / "tests" / "fixtures" / "release" / "pypi_gh_address_cr_1_2_3.json"
 
 
 class RuntimePackagingTest(PythonScriptTestCase):
@@ -474,6 +477,8 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("python -m build", text)
         self.assertIn("twine check dist/*", text)
         self.assertIn("Verify package version", text)
+        self.assertIn("Render Homebrew formula from local sdist", text)
+        self.assertIn("scripts/release/render_homebrew_formula.py", text)
         self.assertIn("pypa/gh-action-pypi-publish", text)
         self.assertIn("repository-url: https://test.pypi.org/legacy/", text)
         self.assertNotIn("environment: pypi", text)
@@ -486,12 +491,74 @@ class RuntimePackagingTest(PythonScriptTestCase):
             ),
         )
 
+    def test_release_workflow_updates_homebrew_tap_after_pypi_publish(self):
+        text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("publish-homebrew:", text)
+        self.assertIn("needs: [build-release-package, publish-pypi]", text)
+        self.assertIn("needs.build-release-package.outputs.publish_target == 'pypi'", text)
+        self.assertIn("HOMEBREW_TAP_TOKEN", text)
+        self.assertIn("RbBtSn0w/homebrew-tap", text)
+        self.assertIn("Formula/gh-address-cr.rb", text)
+        self.assertIn('HOMEBREW_NO_INSTALL_FROM_API: "1"', text)
+        self.assertIn("Sync rendered Homebrew formula into tapped clone", text)
+        self.assertIn(
+            'brew update-python-resources --package-name gh-address-cr --version "$PACKAGE_VERSION" RbBtSn0w/tap/gh-address-cr',
+            text,
+        )
+        self.assertIn("brew audit --formula --strict RbBtSn0w/tap/gh-address-cr", text)
+        self.assertIn("brew install --build-from-source RbBtSn0w/tap/gh-address-cr", text)
+        self.assertIn("brew test RbBtSn0w/tap/gh-address-cr", text)
+        self.assertIn("git status --short -- Formula/gh-address-cr.rb", text)
+
+    def test_homebrew_formula_renderer_uses_pypi_sdist_contract(self):
+        output = Path(self.temp_dir.name) / "gh-address-cr.rb"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HOMEBREW_FORMULA_RENDERER),
+                "--version",
+                "1.2.3",
+                "--pypi-json",
+                str(PYPI_JSON_FIXTURE),
+                "--output",
+                str(output),
+            ],
+            text=True,
+            capture_output=True,
+            cwd=self.cwd,
+            env=self.env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "RENDERED")
+        self.assertEqual(payload["version"], "1.2.3")
+        self.assertEqual(payload["sha256"], "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+        formula = output.read_text(encoding="utf-8")
+        self.assertIn("class GhAddressCr < Formula", formula)
+        self.assertIn("include Language::Python::Virtualenv", formula)
+        self.assertIn('url "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.tar.gz"', formula)
+        self.assertIn('sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"', formula)
+        self.assertIn('depends_on "python@3.13"', formula)
+        self.assertIn("virtualenv_install_with_resources", formula)
+        self.assertIn('shell_output("#{bin}/gh-address-cr --version")', formula)
+        self.assertIn('shell_output("#{bin}/gh-address-cr agent manifest")', formula)
+        self.assertNotIn("whl", formula)
+
     def test_readme_documents_runtime_distribution_paths_separately_from_skill_install(self):
         text = README.read_text(encoding="utf-8")
 
         self.assertIn("Install the released runtime CLI", text)
         self.assertIn("pipx install gh-address-cr", text)
         self.assertIn("uv tool install gh-address-cr", text)
+        self.assertIn("Install with Homebrew", text)
+        self.assertIn("brew tap RbBtSn0w/tap", text)
+        self.assertIn("brew install gh-address-cr", text)
+        self.assertIn("brew upgrade gh-address-cr", text)
+        self.assertIn("brew test gh-address-cr", text)
         self.assertIn("GitHub-direct runtime validation install", text)
         self.assertIn("pipx install git+https://github.com/RbBtSn0w/gh-address-cr.git", text)
         self.assertIn("Local editable development install", text)
@@ -502,6 +569,16 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("does not install the runtime CLI package", text)
         self.assertIn("Upgrade from skill-shim usage", text)
         self.assertIn("reinstall the runtime CLI with `pipx` or `uv tool`", text)
+        self.assertIn("Homebrew tap", text)
+
+    def test_contributing_documents_homebrew_release_policy(self):
+        text = CONTRIBUTING.read_text(encoding="utf-8")
+
+        self.assertIn("Homebrew tap update to `RbBtSn0w/homebrew-tap`", text)
+        self.assertIn("after the PyPI sdist is available", text)
+        self.assertIn("HOMEBREW_TAP_TOKEN", text)
+        self.assertIn("dry-run` and `testpypi` targets validate package build and Homebrew formula rendering", text)
+        self.assertIn("both PyPI and Homebrew publishing must skip explicitly", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a Homebrew tap publishing step after production PyPI releases.
- Adds a PyPI sdist-based formula renderer for `gh-address-cr`.
- Documents Homebrew installation, tap token requirements, and release recovery behavior.

## Test Plan

- `ruff check src tests scripts/release/render_homebrew_formula.py`
- `GH_ADDRESS_CR_STATE_DIR=/private/tmp/gh-address-cr-skill-tests-pr-20260517 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `PYTHONPATH=src /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `/opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
