### PR TITLE
fix: make Homebrew resource refresh non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,7 @@ jobs:
           cp homebrew-tap/Formula/gh-address-cr.rb "$tap_path/Formula/gh-address-cr.rb"
 
       - name: Update Python resources
+        continue-on-error: true
         env:
           PACKAGE_VERSION: ${{ needs.build-release-package.outputs.package_version }}
         run: brew update-python-resources --package-name gh-address-cr --version "$PACKAGE_VERSION" RbBtSn0w/tap/gh-address-cr

--- a/scripts/release/render_homebrew_formula.py
+++ b/scripts/release/render_homebrew_formula.py
@@ -14,7 +14,7 @@ from urllib.request import urlopen
 
 DEFAULT_PACKAGE_NAME = "gh-address-cr"
 DEFAULT_PYPI_BASE_URL = "https://pypi.org/pypi/"
-DEFAULT_PYTHON_DEPENDENCY = "python@3.13"
+DEFAULT_PYTHON_DEPENDENCY = "python@3.14"
 DEFAULT_PYTHON_RESOURCES = (
     {
         "name": "packaging",

--- a/scripts/release/render_homebrew_formula.py
+++ b/scripts/release/render_homebrew_formula.py
@@ -15,6 +15,13 @@ from urllib.request import urlopen
 DEFAULT_PACKAGE_NAME = "gh-address-cr"
 DEFAULT_PYPI_BASE_URL = "https://pypi.org/pypi/"
 DEFAULT_PYTHON_DEPENDENCY = "python@3.13"
+DEFAULT_PYTHON_RESOURCES = (
+    {
+        "name": "packaging",
+        "url": "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz",
+        "sha256": "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661",
+    },
+)
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -116,13 +123,27 @@ def formula_class_name(package_name: str) -> str:
     return "".join(part.capitalize() for part in parts if part)
 
 
+def render_resources(resources: tuple[dict[str, str], ...]) -> str:
+    blocks = []
+    for resource in resources:
+        blocks.append(
+            f'''  resource "{resource["name"]}" do
+    url "{resource["url"]}"
+    sha256 "{resource["sha256"]}"
+  end'''
+        )
+    return "\n\n".join(blocks)
+
+
 def render_formula(
     *,
     class_name: str,
     url: str,
     sha256: str,
     python_dependency: str,
+    resources: tuple[dict[str, str], ...] = DEFAULT_PYTHON_RESOURCES,
 ) -> str:
+    resource_blocks = render_resources(resources)
     return f'''class {class_name} < Formula
   include Language::Python::Virtualenv
 
@@ -133,6 +154,8 @@ def render_formula(
   license "MIT"
 
   depends_on "{python_dependency}"
+
+{resource_blocks}
 
   def install
     virtualenv_install_with_resources
@@ -194,6 +217,7 @@ def main() -> int:
                 "version": args.version,
                 "url": url,
                 "sha256": sha256,
+                "resources": [resource["name"] for resource in DEFAULT_PYTHON_RESOURCES],
                 "output": str(args.output),
             },
             sort_keys=True,

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -544,7 +544,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("include Language::Python::Virtualenv", formula)
         self.assertIn('url "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.tar.gz"', formula)
         self.assertIn('sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"', formula)
-        self.assertIn('depends_on "python@3.13"', formula)
+        self.assertIn('depends_on "python@3.14"', formula)
         self.assertIn('resource "packaging" do', formula)
         self.assertIn('url "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"', formula)
         self.assertIn('sha256 "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"', formula)

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -502,6 +502,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("Formula/gh-address-cr.rb", text)
         self.assertIn('HOMEBREW_NO_INSTALL_FROM_API: "1"', text)
         self.assertIn("Sync rendered Homebrew formula into tapped clone", text)
+        self.assertIn("continue-on-error: true", text)
         self.assertIn(
             'brew update-python-resources --package-name gh-address-cr --version "$PACKAGE_VERSION" RbBtSn0w/tap/gh-address-cr',
             text,
@@ -536,6 +537,7 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertEqual(payload["status"], "RENDERED")
         self.assertEqual(payload["version"], "1.2.3")
         self.assertEqual(payload["sha256"], "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+        self.assertEqual(payload["resources"], ["packaging"])
 
         formula = output.read_text(encoding="utf-8")
         self.assertIn("class GhAddressCr < Formula", formula)
@@ -543,6 +545,9 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn('url "https://files.pythonhosted.org/packages/source/g/gh-address-cr/gh_address_cr-1.2.3.tar.gz"', formula)
         self.assertIn('sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"', formula)
         self.assertIn('depends_on "python@3.13"', formula)
+        self.assertIn('resource "packaging" do', formula)
+        self.assertIn('url "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"', formula)
+        self.assertIn('sha256 "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"', formula)
         self.assertIn("virtualenv_install_with_resources", formula)
         self.assertIn('shell_output("#{bin}/gh-address-cr --version")', formula)
         self.assertIn('shell_output("#{bin}/gh-address-cr agent manifest")', formula)


### PR DESCRIPTION
## Summary

- Add a default Homebrew `packaging` resource to the formula renderer so a freshly published PyPI release can still be audited and installed when `brew update-python-resources` cannot resolve same-day uploads.
- Move the default formula dependency to `python@3.14`, matching the current Homebrew Python whose bundled pip supports Homebrew's resource install flags.
- Keep `brew update-python-resources` in the release workflow, but make that refresh best-effort so audit/install/test still run against the renderer-provided resources.
- Extend packaging workflow tests to cover the bundled resource and non-blocking resource refresh contract.

## Verification

- `ruff check src tests scripts/release/render_homebrew_formula.py`
- `python3 -m unittest tests.test_runtime_packaging.RuntimePackagingTest.test_homebrew_formula_renderer_uses_pypi_sdist_contract tests.test_runtime_packaging.RuntimePackagingTest.test_homebrew_formula_renderer_prefers_tar_gz_when_pypi_lists_multiple_sdists tests.test_runtime_packaging.RuntimePackagingTest.test_release_workflow_updates_homebrew_tap_after_pypi_publish`
- `GH_ADDRESS_CR_STATE_DIR=/private/tmp/gh-address-cr-unittest python3 -m unittest discover -s tests`
- `python3 -m gh_address_cr --help`
- `python3 skill/scripts/cli.py --help`
- `ruby -c /opt/homebrew/Library/Taps/rbbtsn0w/homebrew-tap/Formula/gh-address-cr.rb`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew audit --formula --strict RbBtSn0w/tap/gh-address-cr`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew install --build-from-source RbBtSn0w/tap/gh-address-cr`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew test RbBtSn0w/tap/gh-address-cr`

## Notes

The merged main release published PyPI `2.4.2`, but `publish-homebrew` failed before committing to `RbBtSn0w/homebrew-tap` because `brew update-python-resources` could not resolve the just-uploaded package under Homebrew's upload-time cutoff. This patch preserves that refresh step while preventing it from blocking formula validation and tap commit. The current tap has also been manually repaired for `2.4.2`.
