### PR TITLE
fix: preserve source-scoped producer handoff

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,12 @@ The session state is stored in a PR-scoped workspace under the user cache direct
 - loop requests: `loop-request-*.json`
 - validation records: `validation-*.json`
 
+`session.json` owns command-to-command handoff state. In addition to local and
+GitHub work items, `handoff.producer_results` records source-scoped producer
+submissions so a later plain `review` command can continue the same PR session
+after `findings --input <path>|- --source <producer>` succeeds, including
+explicit empty `[]` results.
+
 If `gh-address-cr final-gate --auto-clean` passes, the current PR workspace is archived before deletion under:
 
 - archive root: `archive/<owner>__<repo>/pr-<pr>/<run_id>/`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -312,7 +312,7 @@ Prompt patterns:
 写出 `producer-request.md`、`incoming-findings.json`、`incoming-findings.md`。
 
 如果你自己就是外部 review producer，就在当前任务里直接生成 findings JSON，
-写入 `incoming-findings.json`，或者通过 `findings --input - --source <producer>` 交给同一 PR session；或者生成固定格式的 `finding` blocks`，
+写入 `incoming-findings.json`，或者通过 `findings --input - --source <producer>` 交给同一 PR session；或者生成固定格式的 `finding` blocks，
 写入 `incoming-findings.md`。不要只输出普通 Markdown 审查报告。
 
 收到 handoff 或 source-scoped findings ingest 成功后，重新运行同一条 `review` 命令，继续处理 session、GitHub review threads、fix 和 final-gate，直到通过。

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,6 +37,7 @@ Fail-fast contract:
 - If findings are absent, `review` returns `WAITING_FOR_EXTERNAL_REVIEW` and writes a standard producer handoff request instead of waiting on `stdin`.
 - External producer output must be findings JSON or fixed `finding` blocks.
 - `findings` still requires explicit findings JSON input.
+- A successful `findings --input <path>|- --source <producer>` run records a source-scoped producer result in the PR session, including empty `[]` results.
 - `review-to-findings` does not accept arbitrary Markdown. It only accepts the fixed `finding` block format.
 - `review`, `threads`, and `adapter` also fail immediately when `gh` is missing from `PATH`.
 - For `adapter`, wrapper `--human` and `--machine` belong before `adapter`. Arguments after `<adapter_cmd...>` are passed through to the adapter command unchanged.
@@ -239,7 +240,9 @@ Automatic external review handoff:
 - preferred handoff file: `incoming-findings.json`
 - fallback handoff file: `incoming-findings.md`
 - `incoming-findings.md` must contain fixed `finding` blocks
+- automation may also satisfy the same session handoff with `findings --input <path>|- --source <producer> [--sync]`
 - rerun the same `review` command after writing one of the handoff files
+- rerun the same `review` command after a successful source-scoped `findings` ingest
 - plain narrative Markdown is not accepted
 
 Producer contract:
@@ -248,6 +251,7 @@ Producer contract:
 - it accepts output from any external review producer
 - the producer may be another skill, a command, or another review tool
 - the only required contract is findings JSON or fixed `finding` blocks
+- `[]` is a valid explicit producer result; an empty file or empty stdin is not
 
 Minimal user prompt:
 
@@ -267,11 +271,13 @@ $gh-address-cr review <PR_URL>
 // - incoming-findings.json
 // - incoming-findings.md
 
-// If you are also the review producer, write findings JSON to incoming-findings.json
-// or fixed `finding` blocks to incoming-findings.md now.
+// If you are also the review producer, write findings JSON to incoming-findings.json,
+// feed it through `findings --input - --source <producer>`, or write fixed
+// `finding` blocks to incoming-findings.md now.
 // Do not write a plain Markdown-only review report.
 
-// After any external review producer fills a handoff file, rerun the same command
+// After any external review producer fills a handoff file or successfully ingests
+// source-scoped findings, rerun the same command
 $gh-address-cr review <PR_URL>
 
 // If review returns BLOCKED, inspect loop-request-*.json, apply fix/clarify/defer,
@@ -306,10 +312,10 @@ Prompt patterns:
 写出 `producer-request.md`、`incoming-findings.json`、`incoming-findings.md`。
 
 如果你自己就是外部 review producer，就在当前任务里直接生成 findings JSON，
-写入 `incoming-findings.json`；或者生成固定格式的 `finding` blocks`，
+写入 `incoming-findings.json`，或者通过 `findings --input - --source <producer>` 交给同一 PR session；或者生成固定格式的 `finding` blocks`，
 写入 `incoming-findings.md`。不要只输出普通 Markdown 审查报告。
 
-收到 handoff 后，重新运行同一条 `review` 命令，继续处理 session、GitHub review threads、fix 和 final-gate，直到通过。
+收到 handoff 或 source-scoped findings ingest 成功后，重新运行同一条 `review` 命令，继续处理 session、GitHub review threads、fix 和 final-gate，直到通过。
 ```
 
 Ready-to-use prompt variants:
@@ -330,9 +336,10 @@ Ready-to-use prompt variants:
 按照 producer-request.md 的要求交接：
 - 优先把 findings JSON 写入 incoming-findings.json
 - 如果只能输出固定格式的 `finding` blocks，就写入 incoming-findings.md
+- 自动化路径也可以用 `findings --input - --sync --source code-review` 交接；`[]` 表示明确的空结果
 - 不要只输出普通 Markdown 审查报告
 
-写入 handoff 文件后，重新运行同一条 $gh-address-cr review 命令，
+写入 handoff 文件或成功 ingest source-scoped findings 后，重新运行同一条 $gh-address-cr review 命令，
 继续处理 session、GitHub threads、fix、reply/resolve 和 final-gate，直到通过。
 ```
 
@@ -346,9 +353,10 @@ Ready-to-use prompt variants:
 按照 producer-request.md 的要求交接：
 - 优先把 findings JSON 写入 incoming-findings.json
 - 如果只能输出固定格式的 `finding` blocks，就写入 incoming-findings.md
+- 自动化路径也可以用 `findings --input - --sync --source <producer>` 交接；`[]` 表示明确的空结果
 - 不要只输出普通 Markdown 审查报告
 
-写入 handoff 文件后，重新运行同一条 $gh-address-cr review 命令，
+写入 handoff 文件或成功 ingest source-scoped findings 后，重新运行同一条 $gh-address-cr review 命令，
 继续处理 session、GitHub threads、fix、reply/resolve 和 final-gate，直到通过。
 ```
 
@@ -358,7 +366,7 @@ Ready-to-use prompt variants:
 The public user flow above does not require manual `--input`, producer selection, or mode routing.
 The following commands remain available for explicit integrations, repository-root automation, and debugging.
 
-`findings --sync` requires an explicit `--source` so missing local findings stay scoped to one producer.
+`findings --sync` requires an explicit `--source` so missing local findings stay scoped to one producer. Successful `findings --input <path>|- --source <producer>` runs also record a source-scoped producer result so the next plain `review` continues the same PR session instead of returning to `WAITING_FOR_EXTERNAL_REVIEW`.
 
 For explicit automation or repository-root invocation, the main command is:
 
@@ -391,7 +399,7 @@ $gh-address-cr address <PR_URL> --lean
 $gh-address-cr review --auto-simple <PR_URL>
 $gh-address-cr threads <PR_URL> --lean
 $gh-address-cr findings <PR_URL> --input findings.json
-$gh-address-cr findings <PR_URL> --input - --sync
+$gh-address-cr findings <PR_URL> --input - --sync --source <producer>
 $gh-address-cr adapter <PR_URL> <adapter_cmd...>
 $gh-address-cr review-to-findings <owner/repo> <pr_number> --input -
 $gh-address-cr --human adapter <owner/repo> <pr_number> <adapter_cmd...>

--- a/plugin/gh-address-cr/skills/gh-address-cr/SKILL.md
+++ b/plugin/gh-address-cr/skills/gh-address-cr/SKILL.md
@@ -69,6 +69,8 @@ If the runtime is missing or incompatible, the shim must fail loudly before sess
 
 If `review` returns `BLOCKED`, inspect the loop request artifact, apply `fix`, `clarify`, `defer`, or `reject` through runtime evidence, then rerun the same `review` command.
 
+If an external producer result is already available, `findings --input <path>|- --source <producer> [--sync]` may satisfy the same PR session handoff as `incoming-findings.json`. A successful ingest records the producer result in session state; `[]` is an explicit empty result, while empty stdin is not.
+
 ## Common Mistakes
 
 - Do not infer state from human prose or logs. Use only structured machine fields and the status-action map.
@@ -86,6 +88,8 @@ If `review` returns `BLOCKED`, inspect the loop request artifact, apply `fix`, `
 For GitHub review threads, reply and resolve are both mandatory. A GitHub thread is not terminally clean unless reply evidence exists with a concrete reply URL from the current authenticated GitHub login.
 
 `producer=code-review` must emit findings JSON before session handling starts. Local findings become terminal only with a note and required evidence.
+
+Source-scoped `findings` ingestion is a session handoff edge. After it succeeds, rerun `review <owner/repo> <pr_number>` to continue GitHub thread handling and final-gate work.
 
 ## Reference Surface
 

--- a/plugin/gh-address-cr/skills/gh-address-cr/references/mode-producer-matrix.md
+++ b/plugin/gh-address-cr/skills/gh-address-cr/references/mode-producer-matrix.md
@@ -44,11 +44,11 @@ Typical invocation:
 
 ```text
 <review-command> <PR_URL> --output findings.json
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source code-review
 
 # If the upstream tool only emits Markdown review blocks:
 <review-command> <PR_URL> | $gh-address-cr review-to-findings <owner/repo> <pr_number> > findings.json
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source code-review
 ```
 
 ### `local json`
@@ -96,6 +96,9 @@ $gh-address-cr review <PR_URL> --input findings.json
 # If findings are not available yet and you want the external handoff flow:
 $gh-address-cr review <PR_URL>
 # Populate incoming-findings.json or incoming-findings.md, then rerun the same command.
+# Or ingest source-scoped findings with:
+$gh-address-cr findings <owner/repo> <pr_number> --input - --sync --source code-review
+# `[]` is a valid explicit empty producer result; empty stdin is not.
 ```
 
 ### `mixed json`
@@ -112,7 +115,8 @@ $gh-address-cr review <PR_URL>
 Typical invocation:
 
 ```text
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source json
+$gh-address-cr review <owner/repo> <pr_number>
 ```
 
 ### `mixed adapter`

--- a/plugin/gh-address-cr/skills/gh-address-cr/scripts/ingest_findings.py
+++ b/plugin/gh-address-cr/skills/gh-address-cr/scripts/ingest_findings.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 SESSION_ENGINE = SCRIPT_DIR / "session_engine.py"
+EMPTY_FINDINGS_INPUT_MESSAGE = "Findings input is empty. Use [] for an explicit empty producer result."
 
 
 def load_payload(input_path: str) -> str:
@@ -133,7 +134,11 @@ def main() -> int:
         print("`--sync` requires an explicit --source so missing findings stay scoped to one producer.", file=sys.stderr)
         return 2
 
-    findings = [normalize_finding(record) for record in parse_records(load_payload(args.input))]
+    raw = load_payload(args.input)
+    if not raw.strip():
+        print(EMPTY_FINDINGS_INPUT_MESSAGE, file=sys.stderr)
+        return 2
+    findings = [normalize_finding(record) for record in parse_records(raw)]
 
     subprocess.run(
         [sys.executable, str(SESSION_ENGINE), "init", args.repo, args.pr_number],

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -69,6 +69,8 @@ If the runtime is missing or incompatible, the shim must fail loudly before sess
 
 If `review` returns `BLOCKED`, inspect the loop request artifact, apply `fix`, `clarify`, `defer`, or `reject` through runtime evidence, then rerun the same `review` command.
 
+If an external producer result is already available, `findings --input <path>|- --source <producer> [--sync]` may satisfy the same PR session handoff as `incoming-findings.json`. A successful ingest records the producer result in session state; `[]` is an explicit empty result, while empty stdin is not.
+
 ## Common Mistakes
 
 - Do not infer state from human prose or logs. Use only structured machine fields and the status-action map.
@@ -86,6 +88,8 @@ If `review` returns `BLOCKED`, inspect the loop request artifact, apply `fix`, `
 For GitHub review threads, reply and resolve are both mandatory. A GitHub thread is not terminally clean unless reply evidence exists with a concrete reply URL from the current authenticated GitHub login.
 
 `producer=code-review` must emit findings JSON before session handling starts. Local findings become terminal only with a note and required evidence.
+
+Source-scoped `findings` ingestion is a session handoff edge. After it succeeds, rerun `review <owner/repo> <pr_number>` to continue GitHub thread handling and final-gate work.
 
 ## Reference Surface
 

--- a/skill/references/mode-producer-matrix.md
+++ b/skill/references/mode-producer-matrix.md
@@ -44,11 +44,11 @@ Typical invocation:
 
 ```text
 <review-command> <PR_URL> --output findings.json
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source code-review
 
 # If the upstream tool only emits Markdown review blocks:
 <review-command> <PR_URL> | $gh-address-cr review-to-findings <owner/repo> <pr_number> > findings.json
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source code-review
 ```
 
 ### `local json`
@@ -96,6 +96,9 @@ $gh-address-cr review <PR_URL> --input findings.json
 # If findings are not available yet and you want the external handoff flow:
 $gh-address-cr review <PR_URL>
 # Populate incoming-findings.json or incoming-findings.md, then rerun the same command.
+# Or ingest source-scoped findings with:
+$gh-address-cr findings <owner/repo> <pr_number> --input - --sync --source code-review
+# `[]` is a valid explicit empty producer result; empty stdin is not.
 ```
 
 ### `mixed json`
@@ -112,7 +115,8 @@ $gh-address-cr review <PR_URL>
 Typical invocation:
 
 ```text
-$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync
+$gh-address-cr findings <owner/repo> <pr_number> --input findings.json --sync --source json
+$gh-address-cr review <owner/repo> <pr_number>
 ```
 
 ### `mixed adapter`

--- a/skill/scripts/ingest_findings.py
+++ b/skill/scripts/ingest_findings.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 SESSION_ENGINE = SCRIPT_DIR / "session_engine.py"
+EMPTY_FINDINGS_INPUT_MESSAGE = "Findings input is empty. Use [] for an explicit empty producer result."
 
 
 def load_payload(input_path: str) -> str:
@@ -133,7 +134,11 @@ def main() -> int:
         print("`--sync` requires an explicit --source so missing findings stay scoped to one producer.", file=sys.stderr)
         return 2
 
-    findings = [normalize_finding(record) for record in parse_records(load_payload(args.input))]
+    raw = load_payload(args.input)
+    if not raw.strip():
+        print(EMPTY_FINDINGS_INPUT_MESSAGE, file=sys.stderr)
+        return 2
+    findings = [normalize_finding(record) for record in parse_records(raw)]
 
     subprocess.run(
         [sys.executable, str(SESSION_ENGINE), "init", args.repo, args.pr_number],

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -30,6 +30,10 @@ from gh_address_cr.core.github_thread_state import (
     is_resolved_github_thread,
     is_stale_or_outdated_github_thread,
 )
+from gh_address_cr.core.handoff import (
+    ensure_handoff_state as _ensure_handoff_state,
+    record_producer_result,
+)
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core import session as session_store
 from gh_address_cr.core import workflow
@@ -37,7 +41,9 @@ from gh_address_cr.github.diagnostics import classify_github_failure, github_wai
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.errors import GitHubError
 from gh_address_cr.intake.findings import (
+    EMPTY_FINDINGS_INPUT_MESSAGE,
     FindingsFormatError,
+    canonical_findings_payload,
     normalize_finding as native_normalize_finding,
     normalize_findings_payload,
     parse_finding_blocks as native_parse_finding_blocks,
@@ -328,10 +334,6 @@ def ensure_external_review_handoff(repo: str, pr_number: str) -> Path:
     _write_if_missing(incoming_json)
     _write_if_missing(incoming_md)
     return request_path
-
-
-def canonical_findings_payload(findings: list[dict]) -> str:
-    return json.dumps(findings, sort_keys=True, separators=(",", ":"))
 
 
 def last_consumed_handoff_sha256(repo: str, pr_number: str) -> str | None:
@@ -797,14 +799,12 @@ def preflight_high_level(args: argparse.Namespace) -> int | None:
             )
         if normalized_input:
             if handoff_sha256 and handoff_sha256 == last_consumed_handoff_sha256(repo, pr_number):
-                args.review_continue_without_input = True
                 return None
             args.args = [*args.args, "--input", normalized_input]
             if handoff_sha256:
                 args.args.extend(["--handoff-sha256", handoff_sha256])
             return None
         if has_submitted_producer_result(repo, pr_number):
-            args.review_continue_without_input = True
             return None
         request_path = ensure_external_review_handoff(repo, pr_number)
         return output_preflight_error(
@@ -879,19 +879,6 @@ def _ensure_native_session_fields(session: dict) -> None:
     session.setdefault("metrics", {})
 
 
-def _ensure_handoff_state(session: dict) -> dict:
-    handoff = session.get("handoff")
-    if not isinstance(handoff, dict):
-        handoff = {}
-        session["handoff"] = handoff
-    handoff.setdefault("last_consumed_sha256", None)
-    producer_results = handoff.get("producer_results")
-    if not isinstance(producer_results, dict):
-        producer_results = {}
-        handoff["producer_results"] = producer_results
-    return handoff
-
-
 def _set_loop_state(
     session: dict,
     *,
@@ -951,6 +938,8 @@ def _ingest_native_findings(
     scan_id: str | None = None,
     handoff_sha256: str | None = None,
 ) -> list[dict]:
+    if not raw.strip():
+        raise FindingsFormatError(EMPTY_FINDINGS_INPUT_MESSAGE)
     format_source = "adapter" if source == "adapter" else "json"
     findings = []
     for finding in normalize_findings_payload(format_source, raw):
@@ -993,18 +982,14 @@ def _ingest_native_findings(
                 item["handled_at"] = now
                 item["updated_at"] = now
     handoff = _ensure_handoff_state(session)
-    producer_results = handoff["producer_results"]
-    payload_sha256 = handoff_sha256 or hashlib.sha256(
-        canonical_findings_payload(findings).encode("utf-8")
-    ).hexdigest()
-    producer_results[source] = {
-        "status": "submitted",
-        "source": source,
-        "findings_count": len(findings),
-        "payload_sha256": payload_sha256,
-        "sync_enabled": bool(sync),
-        "submitted_at": now,
-    }
+    record_producer_result(
+        session,
+        source=source,
+        findings=findings,
+        sync_enabled=bool(sync),
+        submitted_at=now,
+        payload_sha256=handoff_sha256 or None,
+    )
     if handoff_sha256:
         handoff["last_consumed_sha256"] = handoff_sha256
     return findings

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -343,6 +343,20 @@ def last_consumed_handoff_sha256(repo: str, pr_number: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def has_submitted_producer_result(repo: str, pr_number: str) -> bool:
+    session = load_session_payload(repo, pr_number)
+    handoff = session.get("handoff") if isinstance(session, dict) else None
+    if not isinstance(handoff, dict):
+        return False
+    producer_results = handoff.get("producer_results")
+    if not isinstance(producer_results, dict):
+        return False
+    return any(
+        isinstance(result, dict) and result.get("status") == "submitted"
+        for result in producer_results.values()
+    )
+
+
 def normalize_review_handoff(repo: str, pr_number: str) -> tuple[str | None, str | None, str | None]:
     incoming_json = incoming_findings_json_file(repo, pr_number)
     incoming_md = incoming_findings_markdown_file(repo, pr_number)
@@ -789,6 +803,9 @@ def preflight_high_level(args: argparse.Namespace) -> int | None:
             if handoff_sha256:
                 args.args.extend(["--handoff-sha256", handoff_sha256])
             return None
+        if has_submitted_producer_result(repo, pr_number):
+            args.review_continue_without_input = True
+            return None
         request_path = ensure_external_review_handoff(repo, pr_number)
         return output_preflight_error(
             args,
@@ -845,7 +862,7 @@ def _ensure_native_session_fields(session: dict) -> None:
     session.setdefault("items", {})
     session.setdefault("leases", {})
     session.setdefault("history", [])
-    session.setdefault("handoff", {"last_consumed_sha256": None})
+    _ensure_handoff_state(session)
     session.setdefault(
         "loop_state",
         {
@@ -860,6 +877,19 @@ def _ensure_native_session_fields(session: dict) -> None:
         },
     )
     session.setdefault("metrics", {})
+
+
+def _ensure_handoff_state(session: dict) -> dict:
+    handoff = session.get("handoff")
+    if not isinstance(handoff, dict):
+        handoff = {}
+        session["handoff"] = handoff
+    handoff.setdefault("last_consumed_sha256", None)
+    producer_results = handoff.get("producer_results")
+    if not isinstance(producer_results, dict):
+        producer_results = {}
+        handoff["producer_results"] = producer_results
+    return handoff
 
 
 def _set_loop_state(
@@ -962,8 +992,20 @@ def _ingest_native_findings(
                 item["handled"] = True
                 item["handled_at"] = now
                 item["updated_at"] = now
+    handoff = _ensure_handoff_state(session)
+    producer_results = handoff["producer_results"]
+    payload_sha256 = handoff_sha256 or hashlib.sha256(
+        canonical_findings_payload(findings).encode("utf-8")
+    ).hexdigest()
+    producer_results[source] = {
+        "status": "submitted",
+        "source": source,
+        "findings_count": len(findings),
+        "payload_sha256": payload_sha256,
+        "sync_enabled": bool(sync),
+        "submitted_at": now,
+    }
     if handoff_sha256:
-        handoff = session.setdefault("handoff", {})
         handoff["last_consumed_sha256"] = handoff_sha256
     return findings
 
@@ -1482,6 +1524,12 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
     _set_loop_state(session, run_id=run_id, status="PASSED", iteration=1, max_iterations=parsed.max_iterations)
     _recalc_native_metrics(session)
     session_store.save_session(repo, pr_number, session)
+    next_action = "No action required."
+    if command == "findings":
+        next_action = (
+            f"Run `gh-address-cr review {repo} {pr_number}` to continue PR orchestration, "
+            "including GitHub thread handling and final-gate checks."
+        )
     summary = _native_summary(
         command=command,
         repo=repo,
@@ -1489,7 +1537,7 @@ def handle_native_high_level(command: str, passthrough_args: list[str], *, human
         status="PASSED",
         reason_code="PASSED",
         waiting_on=None,
-        next_action="No action required.",
+        next_action=next_action,
         exit_code=0,
         session=session,
         include_threads=auto_simple,

--- a/src/gh_address_cr/core/handoff.py
+++ b/src/gh_address_cr/core/handoff.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from gh_address_cr.intake.findings import canonical_findings_payload
+
+
+def ensure_handoff_state(session: dict[str, Any]) -> dict[str, Any]:
+    handoff = session.get("handoff")
+    if not isinstance(handoff, dict):
+        handoff = {}
+        session["handoff"] = handoff
+    handoff.setdefault("last_consumed_sha256", None)
+    producer_results = handoff.get("producer_results")
+    if not isinstance(producer_results, dict):
+        producer_results = {}
+        handoff["producer_results"] = producer_results
+    return handoff
+
+
+def record_producer_result(
+    session: dict[str, Any],
+    *,
+    source: str,
+    findings: list[dict[str, Any]],
+    sync_enabled: bool,
+    submitted_at: str,
+    payload_sha256: str | None = None,
+) -> dict[str, Any]:
+    handoff = ensure_handoff_state(session)
+    producer_results = handoff["producer_results"]
+    result = {
+        "status": "submitted",
+        "source": source,
+        "findings_count": len(findings),
+        "payload_sha256": payload_sha256
+        or hashlib.sha256(canonical_findings_payload(findings).encode("utf-8")).hexdigest(),
+        "sync_enabled": bool(sync_enabled),
+        "submitted_at": submitted_at,
+    }
+    producer_results[source] = result
+    return result

--- a/src/gh_address_cr/core/session_engine.py
+++ b/src/gh_address_cr/core/session_engine.py
@@ -11,8 +11,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from gh_address_cr.core import paths as core_paths
+from gh_address_cr.core.handoff import ensure_handoff_state, record_producer_result
 from gh_address_cr.core import session as session_store
-from gh_address_cr.intake.findings import normalize_finding
+from gh_address_cr.intake.findings import EMPTY_FINDINGS_INPUT_MESSAGE, normalize_finding
 
 
 def state_dir() -> Path:
@@ -204,43 +205,6 @@ def ensure_loop_state(session: dict):
     loop_state.setdefault("last_completed_at", None)
 
 
-def ensure_handoff_state(session: dict):
-    handoff = session.get("handoff")
-    if not isinstance(handoff, dict):
-        handoff = {}
-        session["handoff"] = handoff
-    handoff.setdefault("last_consumed_sha256", None)
-    producer_results = handoff.get("producer_results")
-    if not isinstance(producer_results, dict):
-        handoff["producer_results"] = {}
-
-
-def canonical_findings_payload(findings: list[dict]) -> str:
-    return json.dumps(findings, sort_keys=True, separators=(",", ":"))
-
-
-def record_producer_result(
-    session: dict,
-    *,
-    source: str,
-    findings: list[dict],
-    sync_enabled: bool,
-    payload_sha256: str | None = None,
-) -> None:
-    ensure_handoff_state(session)
-    handoff = session["handoff"]
-    producer_results = handoff["producer_results"]
-    producer_results[source] = {
-        "status": "submitted",
-        "source": source,
-        "findings_count": len(findings),
-        "payload_sha256": payload_sha256
-        or hashlib.sha256(canonical_findings_payload(findings).encode("utf-8")).hexdigest(),
-        "sync_enabled": bool(sync_enabled),
-        "submitted_at": utc_now(),
-    }
-
-
 def current_run_id(session: dict, explicit_run_id: str | None = None) -> str | None:
     if explicit_run_id:
         return explicit_run_id
@@ -398,16 +362,19 @@ def clear_claim(item: dict):
     item["lease_expires_at"] = None
 
 
-def read_records_from_stdin() -> list[dict]:
-    raw = sys.stdin.read().strip()
-    if not raw:
+def read_records_from_stdin(*, require_payload: bool = False) -> list[dict]:
+    raw = sys.stdin.read()
+    payload = raw.strip()
+    if not payload:
+        if require_payload:
+            raise SystemExit(EMPTY_FINDINGS_INPUT_MESSAGE)
         return []
-    if raw.startswith("["):
-        payload = json.loads(raw)
-        if not isinstance(payload, list):
+    if payload.startswith("["):
+        data = json.loads(payload)
+        if not isinstance(data, list):
             raise SystemExit("Expected a JSON array.")
-        return payload
-    return [json.loads(line) for line in raw.splitlines() if line.strip()]
+        return data
+    return [json.loads(line) for line in payload.splitlines() if line.strip()]
 
 
 def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
@@ -693,7 +660,7 @@ def cmd_sync_github(args):
 
 def cmd_ingest_local(args):
     session = load_session(args.repo, args.pr_number)
-    findings = [normalize_finding(record) for record in read_records_from_stdin()]
+    findings = [normalize_finding(record) for record in read_records_from_stdin(require_payload=True)]
     session["current_scan_id"] = args.scan_id or utc_now()
     run_id = current_run_id(session)
     incoming_ids = {local_finding_item_id(args.source, finding) for finding in findings}
@@ -738,6 +705,7 @@ def cmd_ingest_local(args):
         source=args.source,
         findings=findings,
         sync_enabled=bool(args.sync),
+        submitted_at=utc_now(),
         payload_sha256=args.handoff_sha256 or None,
     )
     save_session(session)

--- a/src/gh_address_cr/core/session_engine.py
+++ b/src/gh_address_cr/core/session_engine.py
@@ -185,6 +185,7 @@ def default_session(repo: str, pr_number: str) -> dict:
         },
         "handoff": {
             "last_consumed_sha256": None,
+            "producer_results": {},
         },
         "items": {},
         "history": [],
@@ -204,8 +205,40 @@ def ensure_loop_state(session: dict):
 
 
 def ensure_handoff_state(session: dict):
-    handoff = session.setdefault("handoff", {})
+    handoff = session.get("handoff")
+    if not isinstance(handoff, dict):
+        handoff = {}
+        session["handoff"] = handoff
     handoff.setdefault("last_consumed_sha256", None)
+    producer_results = handoff.get("producer_results")
+    if not isinstance(producer_results, dict):
+        handoff["producer_results"] = {}
+
+
+def canonical_findings_payload(findings: list[dict]) -> str:
+    return json.dumps(findings, sort_keys=True, separators=(",", ":"))
+
+
+def record_producer_result(
+    session: dict,
+    *,
+    source: str,
+    findings: list[dict],
+    sync_enabled: bool,
+    payload_sha256: str | None = None,
+) -> None:
+    ensure_handoff_state(session)
+    handoff = session["handoff"]
+    producer_results = handoff["producer_results"]
+    producer_results[source] = {
+        "status": "submitted",
+        "source": source,
+        "findings_count": len(findings),
+        "payload_sha256": payload_sha256
+        or hashlib.sha256(canonical_findings_payload(findings).encode("utf-8")).hexdigest(),
+        "sync_enabled": bool(sync_enabled),
+        "submitted_at": utc_now(),
+    }
 
 
 def current_run_id(session: dict, explicit_run_id: str | None = None) -> str | None:
@@ -700,6 +733,13 @@ def cmd_ingest_local(args):
             synced += 1
     if args.handoff_sha256:
         session["handoff"]["last_consumed_sha256"] = args.handoff_sha256
+    record_producer_result(
+        session,
+        source=args.source,
+        findings=findings,
+        sync_enabled=bool(args.sync),
+        payload_sha256=args.handoff_sha256 or None,
+    )
     save_session(session)
     active_local_items = sum(
         1 for item in session["items"].values() if item["item_kind"] == "local_finding" and item.get("blocking")

--- a/src/gh_address_cr/intake/findings.py
+++ b/src/gh_address_cr/intake/findings.py
@@ -24,6 +24,11 @@ FIELD_ALIASES = {
     "description": "body",
 }
 ALLOWED_FIELDS = {"title", "path", "line", "body", "severity", "category", "confidence", "head_sha"}
+EMPTY_FINDINGS_INPUT_MESSAGE = "Findings input is empty. Use [] for an explicit empty producer result."
+
+
+def canonical_findings_payload(findings: list[dict[str, Any]]) -> str:
+    return json.dumps(findings, sort_keys=True, separators=(",", ":"))
 
 
 def parse_records(raw: str) -> list[dict[str, Any]]:

--- a/src/gh_address_cr/legacy_scripts/ingest_findings.py
+++ b/src/gh_address_cr/legacy_scripts/ingest_findings.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from gh_address_cr.intake.findings import (
+    EMPTY_FINDINGS_INPUT_MESSAGE,
     normalize_finding as native_normalize_finding,
     parse_records as native_parse_records,
 )
@@ -138,7 +139,11 @@ def main() -> int:
         )
         return 2
 
-    findings = [native_normalize_finding(record) for record in native_parse_records(load_payload(args.input))]
+    raw = load_payload(args.input)
+    if not raw.strip():
+        print(EMPTY_FINDINGS_INPUT_MESSAGE, file=sys.stderr)
+        return 2
+    findings = [native_normalize_finding(record) for record in native_parse_records(raw)]
 
     subprocess.run(
         [sys.executable, str(SESSION_ENGINE), "init", args.repo, args.pr_number],

--- a/tests/fixtures/session_engine/legacy_native_session.json
+++ b/tests/fixtures/session_engine/legacy_native_session.json
@@ -2,7 +2,17 @@
   "created_at": "2026-04-24T12:00:00+00:00",
   "current_scan_id": "scan-local-parity",
   "handoff": {
-    "last_consumed_sha256": "handoff-parity-sha"
+    "last_consumed_sha256": "handoff-parity-sha",
+    "producer_results": {
+      "local-agent:parity": {
+        "findings_count": 1,
+        "payload_sha256": "handoff-parity-sha",
+        "source": "local-agent:parity",
+        "status": "submitted",
+        "submitted_at": "2026-04-24T12:00:00+00:00",
+        "sync_enabled": false
+      }
+    }
   },
   "history": [],
   "items": {

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -1002,6 +1002,31 @@ else:
         self.assertEqual(second_summary["reason_code"], "PASSED")
         self.assertNotEqual(second_summary["reason_code"], "WAITING_FOR_EXTERNAL_REVIEW")
 
+    def test_cli_findings_rejects_blank_input_without_producer_result(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(CLI_PY),
+                "findings",
+                self.repo,
+                self.pr,
+                "--input",
+                "-",
+                "--sync",
+                "--source",
+                "code-review",
+            ],
+            stdin=" \n\t",
+        )
+        self.assertEqual(result.returncode, 2)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["reason_code"], "INVALID_FINDINGS_INPUT")
+        self.assertIn("Use [] for an explicit empty producer result", summary["next_action"])
+
+        session = json.loads(self.session_file().read_text(encoding="utf-8"))
+        self.assertNotIn("code-review", session["handoff"]["producer_results"])
+
     def test_cli_review_continues_after_non_empty_synced_findings_result(self):
         self.install_fake_gh_for_threads([])
 
@@ -1687,6 +1712,24 @@ else:
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("requires an explicit --source", result.stderr)
+
+    def test_ingest_findings_rejects_blank_input_without_session_mutation(self):
+        result = self.run_cmd(
+            [
+                sys.executable,
+                str(INGEST_FINDINGS_PY),
+                "--source",
+                "local-agent:test",
+                "--input",
+                "-",
+                self.repo,
+                self.pr,
+            ],
+            stdin=" \n\t",
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Use [] for an explicit empty producer result", result.stderr)
+        self.assertFalse(self.session_file().exists())
 
     def test_cli_dispatches_run_once(self):
         gh = self.bin_dir / "gh"

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -962,6 +962,93 @@ else:
         self.assertEqual(summary["reason_code"], "PASSED")
         self.assertIsNone(summary["waiting_on"])
 
+    def test_cli_review_continues_after_empty_synced_findings_result(self):
+        self.install_fake_gh_for_threads([])
+
+        first = self.run_cmd([sys.executable, str(CLI_PY), "review", self.repo, self.pr])
+        self.assertEqual(first.returncode, 6)
+        first_summary = json.loads(first.stdout)
+        self.assertEqual(first_summary["status"], "WAITING_FOR_EXTERNAL_REVIEW")
+
+        synced = self.run_cmd(
+            [
+                sys.executable,
+                str(CLI_PY),
+                "findings",
+                self.repo,
+                self.pr,
+                "--input",
+                "-",
+                "--sync",
+                "--source",
+                "code-review",
+            ],
+            stdin="[]\n",
+        )
+        self.assertEqual(synced.returncode, 0, synced.stderr)
+        synced_summary = json.loads(synced.stdout)
+        self.assertIn(f"gh-address-cr review {self.repo} {self.pr}", synced_summary["next_action"])
+
+        session = json.loads(self.session_file().read_text(encoding="utf-8"))
+        producer_result = session["handoff"]["producer_results"]["code-review"]
+        self.assertEqual(producer_result["status"], "submitted")
+        self.assertEqual(producer_result["findings_count"], 0)
+        self.assertTrue(producer_result["sync_enabled"])
+
+        second = self.run_cmd([sys.executable, str(CLI_PY), "review", self.repo, self.pr])
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_summary = json.loads(second.stdout)
+        self.assertEqual(second_summary["status"], "PASSED")
+        self.assertEqual(second_summary["reason_code"], "PASSED")
+        self.assertNotEqual(second_summary["reason_code"], "WAITING_FOR_EXTERNAL_REVIEW")
+
+    def test_cli_review_continues_after_non_empty_synced_findings_result(self):
+        self.install_fake_gh_for_threads([])
+
+        first = self.run_cmd([sys.executable, str(CLI_PY), "review", self.repo, self.pr])
+        self.assertEqual(first.returncode, 6)
+
+        synced = self.run_cmd(
+            [
+                sys.executable,
+                str(CLI_PY),
+                "findings",
+                self.repo,
+                self.pr,
+                "--input",
+                "-",
+                "--sync",
+                "--source",
+                "code-review",
+            ],
+            stdin=json.dumps(
+                [
+                    {
+                        "title": "Missing guard",
+                        "body": "The producer found a blocking issue.",
+                        "path": "src/example.py",
+                        "line": 12,
+                        "severity": "P2",
+                        "category": "correctness",
+                    }
+                ]
+            )
+            + "\n",
+        )
+        self.assertEqual(synced.returncode, 5, synced.stderr)
+
+        session = json.loads(self.session_file().read_text(encoding="utf-8"))
+        producer_result = session["handoff"]["producer_results"]["code-review"]
+        self.assertEqual(producer_result["status"], "submitted")
+        self.assertEqual(producer_result["findings_count"], 1)
+
+        second = self.run_cmd([sys.executable, str(CLI_PY), "review", self.repo, self.pr])
+        self.assertEqual(second.returncode, 5, second.stderr)
+        second_summary = json.loads(second.stdout)
+        self.assertEqual(second_summary["status"], "BLOCKED")
+        self.assertEqual(second_summary["reason_code"], "WAITING_FOR_FIX")
+        self.assertEqual(second_summary["item_kind"], "local_finding")
+
     def test_cli_review_auto_converts_handoff_finding_blocks(self):
         gh = self.bin_dir / "gh"
         gh.write_text(

--- a/tests/test_session_engine_cli.py
+++ b/tests/test_session_engine_cli.py
@@ -436,6 +436,24 @@ class SessionEngineCLITest(SessionEngineTestCase):
         self.assertEqual(producer_result["findings_count"], 0)
         self.assertTrue(producer_result["sync_enabled"])
 
+    def test_ingest_local_rejects_blank_stdin_without_producer_result(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+
+        result = self.run_engine(
+            "ingest-local",
+            self.repo,
+            self.pr,
+            "--source",
+            "local-agent:test",
+            "--sync",
+            stdin=" \n\t",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Use [] for an explicit empty producer result", result.stderr)
+
+        session = self.load_session()
+        self.assertNotIn("local-agent:test", session["handoff"]["producer_results"])
+
     def test_ingest_local_sync_keeps_identical_findings_scoped_per_source(self):
         self.run_engine("init", self.repo, self.pr, check=True)
         payload = json.dumps(

--- a/tests/test_session_engine_cli.py
+++ b/tests/test_session_engine_cli.py
@@ -415,6 +415,27 @@ class SessionEngineCLITest(SessionEngineTestCase):
         self.assertEqual(close_item["status"], "CLOSED")
         self.assertTrue(close_item["handled"])
 
+    def test_ingest_local_records_empty_synced_producer_result(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+
+        result = self.run_engine(
+            "ingest-local",
+            self.repo,
+            self.pr,
+            "--source",
+            "local-agent:test",
+            "--sync",
+            stdin="[]",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        session = self.load_session()
+        producer_result = session["handoff"]["producer_results"]["local-agent:test"]
+        self.assertEqual(producer_result["status"], "submitted")
+        self.assertEqual(producer_result["source"], "local-agent:test")
+        self.assertEqual(producer_result["findings_count"], 0)
+        self.assertTrue(producer_result["sync_enabled"])
+
     def test_ingest_local_sync_keeps_identical_findings_scoped_per_source(self):
         self.run_engine("init", self.repo, self.pr, check=True)
         payload = json.dumps(

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -427,6 +427,8 @@ class SkillDocumentationContractTest(unittest.TestCase):
         self.assertIn("incoming-findings.json", readme_text)
         self.assertIn("incoming-findings.md", readme_text)
         self.assertIn("WAITING_FOR_EXTERNAL_REVIEW", readme_text)
+        self.assertIn("source-scoped producer result", readme_text)
+        self.assertIn("`[]` is a valid explicit producer result", readme_text)
         self.assertIn("如果你自己就是外部 review producer", readme_text)
         self.assertIn("不要只输出普通 Markdown 审查报告", readme_text)
         self.assertIn("Ready-to-use prompt variants:", readme_text)


### PR DESCRIPTION
## Summary
- Add a source-scoped producer result marker under `session.handoff.producer_results` whenever findings input is successfully ingested, including explicit empty `[]` payloads.
- Teach plain `review` to continue the existing PR session when a producer result has already been submitted through `findings --input <path>|- --source <producer>`.
- Update docs, skill payload, plugin payload, and regression coverage for the command-to-command handoff contract.

## Requirement Breakdown
- `findings --input - --sync --source code-review` with `[]` must be treated as an explicit empty producer result.
- A following plain `review <repo> <pr>` must not return `WAITING_FOR_EXTERNAL_REVIEW` solely because canonical handoff files are still empty.
- Non-empty findings ingested through `findings` must likewise be visible to a following plain `review`, which should continue to local finding handling.
- Empty stdin remains invalid; only parsed findings JSON, including `[]`, records a producer result.

## Validation
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec ruff check src tests scripts/build_plugin_payload.py`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr agent manifest`
- `PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python scripts/build_plugin_payload.py --check`
- Manual reproduction of issue #62 path: initial `review` returned `WAITING_FOR_EXTERNAL_REVIEW`, `findings --input - --sync --source code-review` with `[]` returned `PASSED` and recorded `producer_results.code-review`, and the next plain `review` returned `PASSED`.

Fixes #62
