### PR TITLE
Preserve first-scene severity evidence

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,9 +103,9 @@ gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1
 gh-address-cr agent submit owner/repo 123 --input action-response.json
 gh-address-cr agent submit owner/repo 123 --input action-response.json --publish
 gh-address-cr agent submit-batch owner/repo 123 --input batch-response.json
-gh-address-cr agent evidence add owner/repo 123 --name local-verified --commit <sha> --files src/example.py --validation "python3 -m unittest tests.test_example=passed"
-gh-address-cr agent fix owner/repo 123 github-thread:THREAD_ID --commit <sha> --files src/example.py --summary "Fixed it." --why "The guarded path covers the review case." --validation "python3 -m unittest tests.test_example=passed" --publish
-gh-address-cr agent fix-all owner/repo 123 --commit <sha> --files src/shared.py --validation "python3 -m unittest tests.test_shared=passed"
+gh-address-cr agent evidence add owner/repo 123 --name local-verified --commit <sha> --files src/example.py --validation "python3 -m unittest tests.test_example=passed" [--severity P1|P2|P3 --severity-note <why>]
+gh-address-cr agent fix owner/repo 123 github-thread:THREAD_ID --commit <sha> --files src/example.py --summary "Fixed it." --why "The guarded path covers the review case." --validation "python3 -m unittest tests.test_example=passed" [--severity P1|P2|P3 --severity-note <why>] --publish
+gh-address-cr agent fix-all owner/repo 123 --commit <sha> --files src/shared.py --validation "python3 -m unittest tests.test_shared=passed" [--severity P1|P2|P3 --severity-note <why>]
 gh-address-cr agent resolve-stale owner/repo 123 --commit <sha> --files src/stale.py --validation "python3 -m unittest tests.test_stale=passed" --match-files
 gh-address-cr agent publish owner/repo 123
 gh-address-cr agent leases owner/repo 123
@@ -119,6 +119,8 @@ Classification and resolution are deliberately separate protocol phases:
 
 - `agent classify` records triage evidence on the item before a mutating fixer lease exists. If `agent next --role fixer` returns `MISSING_CLASSIFICATION`, run `agent classify ... --classification <fix|clarify|defer|reject> --note <why>` first.
 - `agent submit` consumes a fixer or verifier `ActionResponse`. Its `resolution` field is the response decision for an already leased request. If submit returns `MISSING_RESOLUTION`, add `"resolution": "fix|clarify|defer|reject"` to the response JSON and rerun `agent submit`. Use `--publish` only for accepted GitHub review-thread fix responses when the runtime should post the reply and resolve the thread in the same command.
+- Severity is evidence-backed. The runtime preserves explicit `P1`, `P2`, or `P3` markers from the producer payload or the original GitHub review-thread comment. If no trusted P-scale marker exists, severity remains unknown and publish output omits the `Severity:` line. Reviewer words such as `high`, `medium`, or `low priority` are stored only as raw priority evidence and are not converted to `P1/P2/P3`.
+- `agent fix`, `agent fix-all`, `agent resolve-stale`, and `agent evidence add` may pass `--severity P1|P2|P3` as an explicit override. If that override conflicts with first-scene severity evidence on the item, include `--severity-note <why>` or the response is rejected with `SEVERITY_OVERRIDE_NOTE_REQUIRED`.
 
 Role split:
 
@@ -440,7 +442,7 @@ If you omit the producer where it is required:
     - `summary`
     - `commit_hash`
     - `files`
-    - optional `severity`, `why`, `test_command`, `test_result`
+    - optional `severity`, `severity_note`, `why`, `test_command`, `test_result`
     - `validation_commands` may be used as default validation evidence when `test_command` / `test_result` are omitted
   - for GitHub thread `clarify` or `defer`: `reply_markdown`
   - optional `validation_commands`
@@ -536,6 +538,7 @@ Adapter contract:
 - adapter prints a JSON array to stdout
 - each finding should include `title`, `body`, `path`, `line`
 - optional fields: `severity`, `category`, `confidence`
+- `severity` is accepted only when it is an explicit `P1`, `P2`, or `P3`; missing or non-P-scale values do not create a session severity.
 
 This path does not auto-post to GitHub. It creates local session items that can be fixed and verified in the same workflow as remote review threads.
 

--- a/plugin/gh-address-cr/skills/gh-address-cr/SKILL.md
+++ b/plugin/gh-address-cr/skills/gh-address-cr/SKILL.md
@@ -76,6 +76,8 @@ If an external producer result is already available, `findings --input <path>|- 
 - Do not infer state from human prose or logs. Use only structured machine fields and the status-action map.
 - Do not post GitHub replies or resolve review threads directly. The runtime records evidence and performs deterministic side effects.
 - Do not treat `STALE` or outdated GitHub threads as clean. Outdated / `STALE` GitHub threads are still unresolved until explicitly handled.
+- Do not invent severity. Only explicit `P1`, `P2`, or `P3` evidence from the producer payload or the original GitHub review-thread comment should become session severity. Leave unknown severity unknown; reviewer `high/medium/low priority` text is raw priority evidence, not a P-scale mapping.
+- Do not override first-scene severity silently. If `agent fix`, `agent fix-all`, `agent resolve-stale`, or `agent evidence add` passes `--severity` that differs from first-scene evidence, also pass `--severity-note <why>`.
 - Do not claim completion before `gh-address-cr final-gate <owner/repo> <pr_number>` has just passed.
 - Do not create ad-hoc findings files in the project workspace when `findings --input -` can consume producer output through stdin.
 - Do not use this skill as the review engine itself; it manages intake, state, processing discipline, and gating.

--- a/plugin/gh-address-cr/skills/gh-address-cr/references/agent-protocol.md
+++ b/plugin/gh-address-cr/skills/gh-address-cr/references/agent-protocol.md
@@ -34,13 +34,13 @@ High-level commands emit structured JSON by default. Agents must consume these f
   - Validates an `ActionResponse`, lease ownership, and required evidence.
 - `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>`
   - Validates a `BatchActionResponse` for multiple leased GitHub review-thread `fix` items sharing common commit/files/validation evidence.
-- `gh-address-cr agent evidence add <owner/repo> <pr_number> --name <profile> --commit <sha> --files <paths> --validation <cmd=passed>`
+- `gh-address-cr agent evidence add <owner/repo> <pr_number> --name <profile> --commit <sha> --files <paths> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>]`
   - Records reusable commit/files/validation evidence for later `evidence_ref` use.
-- `gh-address-cr agent fix <owner/repo> <pr_number> <item_id> --commit <sha> --files <paths> --summary <text> --why <text> --validation <cmd=passed> [--publish]`
+- `gh-address-cr agent fix <owner/repo> <pr_number> <item_id> --commit <sha> --files <paths> --summary <text> --why <text> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>] [--publish]`
   - Classifies, claims, submits, and optionally publishes one straightforward GitHub-thread fix.
-- `gh-address-cr agent fix-all <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> [--publish] [--include-stale]`
+- `gh-address-cr agent fix-all <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>] [--publish] [--include-stale]`
   - Classifies, claims, and submits safe batches for matching GitHub-thread items already present in the runtime session.
-- `gh-address-cr agent resolve-stale <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> --match-files [--publish]`
+- `gh-address-cr agent resolve-stale <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> --match-files [--severity P1|P2|P3 --severity-note <why>] [--publish]`
   - Handles matching `STALE` or outdated GitHub-thread items through evidence, leases, publish, and final-gate. It never marks stale threads resolved directly.
 - `gh-address-cr agent leases <owner/repo> <pr_number>`
   - Inspects active and terminal claims.
@@ -54,6 +54,8 @@ Classification is triage-phase evidence. Resolution is response-phase evidence. 
 Allowed `ActionResponse.resolution` values are `fix`, `clarify`, `defer`, and `reject`.
 
 For GitHub thread `fix`, `fix_reply` **must be a JSON object**, not a string. Submitting a plain string may pass `agent submit` but will block `agent publish` with `MISSING_PUBLISH_REPLY`. Required fields: `commit_hash`, `files`, `summary`. Optional fields: `severity`, `why`, `test_command`, `test_result`. If `test_command` and `test_result` are omitted, `validation_commands` at the response level is used as default validation evidence.
+
+Severity is evidence-backed. The runtime stores `P1`, `P2`, or `P3` only when the marker is explicit in the producer payload or in the original GitHub review-thread comment. Missing severity remains unknown, and published fix replies omit the `Severity:` line. Reviewer `high`, `medium`, and `low priority` markers are preserved as raw priority evidence but are not mapped to P-scale severity. A fix response may include explicit `fix_reply.severity`; if it conflicts with first-scene severity evidence, include `fix_reply.severity_note` or the response is rejected with `SEVERITY_OVERRIDE_NOTE_REQUIRED`.
 
 Clarify, defer, and reject responses require `reply_markdown` and validation evidence. GitHub side-effect claims from AI agents are invalid.
 

--- a/plugin/gh-address-cr/skills/gh-address-cr/scripts/generate_reply.py
+++ b/plugin/gh-address-cr/skills/gh-address-cr/scripts/generate_reply.py
@@ -24,7 +24,7 @@ def write_text(path: Path, content: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a Markdown reply template for a CR item.")
-    parser.add_argument("--severity", default="P2", help="P1, P2, or P3 for fix mode.")
+    parser.add_argument("--severity", help="Optional P1, P2, or P3 for fix mode.")
     parser.add_argument("--mode", default="fix", choices=["fix", "clarify", "defer"])
     parser.add_argument("output_md")
     parser.add_argument("args", nargs="*")

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -76,6 +76,8 @@ If an external producer result is already available, `findings --input <path>|- 
 - Do not infer state from human prose or logs. Use only structured machine fields and the status-action map.
 - Do not post GitHub replies or resolve review threads directly. The runtime records evidence and performs deterministic side effects.
 - Do not treat `STALE` or outdated GitHub threads as clean. Outdated / `STALE` GitHub threads are still unresolved until explicitly handled.
+- Do not invent severity. Only explicit `P1`, `P2`, or `P3` evidence from the producer payload or the original GitHub review-thread comment should become session severity. Leave unknown severity unknown; reviewer `high/medium/low priority` text is raw priority evidence, not a P-scale mapping.
+- Do not override first-scene severity silently. If `agent fix`, `agent fix-all`, `agent resolve-stale`, or `agent evidence add` passes `--severity` that differs from first-scene evidence, also pass `--severity-note <why>`.
 - Do not claim completion before `gh-address-cr final-gate <owner/repo> <pr_number>` has just passed.
 - Do not create ad-hoc findings files in the project workspace when `findings --input -` can consume producer output through stdin.
 - Do not use this skill as the review engine itself; it manages intake, state, processing discipline, and gating.

--- a/skill/references/agent-protocol.md
+++ b/skill/references/agent-protocol.md
@@ -34,13 +34,13 @@ High-level commands emit structured JSON by default. Agents must consume these f
   - Validates an `ActionResponse`, lease ownership, and required evidence.
 - `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>`
   - Validates a `BatchActionResponse` for multiple leased GitHub review-thread `fix` items sharing common commit/files/validation evidence.
-- `gh-address-cr agent evidence add <owner/repo> <pr_number> --name <profile> --commit <sha> --files <paths> --validation <cmd=passed>`
+- `gh-address-cr agent evidence add <owner/repo> <pr_number> --name <profile> --commit <sha> --files <paths> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>]`
   - Records reusable commit/files/validation evidence for later `evidence_ref` use.
-- `gh-address-cr agent fix <owner/repo> <pr_number> <item_id> --commit <sha> --files <paths> --summary <text> --why <text> --validation <cmd=passed> [--publish]`
+- `gh-address-cr agent fix <owner/repo> <pr_number> <item_id> --commit <sha> --files <paths> --summary <text> --why <text> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>] [--publish]`
   - Classifies, claims, submits, and optionally publishes one straightforward GitHub-thread fix.
-- `gh-address-cr agent fix-all <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> [--publish] [--include-stale]`
+- `gh-address-cr agent fix-all <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> [--severity P1|P2|P3 --severity-note <why>] [--publish] [--include-stale]`
   - Classifies, claims, and submits safe batches for matching GitHub-thread items already present in the runtime session.
-- `gh-address-cr agent resolve-stale <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> --match-files [--publish]`
+- `gh-address-cr agent resolve-stale <owner/repo> <pr_number> --commit <sha> --files <paths> --validation <cmd=passed> --match-files [--severity P1|P2|P3 --severity-note <why>] [--publish]`
   - Handles matching `STALE` or outdated GitHub-thread items through evidence, leases, publish, and final-gate. It never marks stale threads resolved directly.
 - `gh-address-cr agent leases <owner/repo> <pr_number>`
   - Inspects active and terminal claims.
@@ -54,6 +54,8 @@ Classification is triage-phase evidence. Resolution is response-phase evidence. 
 Allowed `ActionResponse.resolution` values are `fix`, `clarify`, `defer`, and `reject`.
 
 For GitHub thread `fix`, `fix_reply` **must be a JSON object**, not a string. Submitting a plain string may pass `agent submit` but will block `agent publish` with `MISSING_PUBLISH_REPLY`. Required fields: `commit_hash`, `files`, `summary`. Optional fields: `severity`, `why`, `test_command`, `test_result`. If `test_command` and `test_result` are omitted, `validation_commands` at the response level is used as default validation evidence.
+
+Severity is evidence-backed. The runtime stores `P1`, `P2`, or `P3` only when the marker is explicit in the producer payload or in the original GitHub review-thread comment. Missing severity remains unknown, and published fix replies omit the `Severity:` line. Reviewer `high`, `medium`, and `low priority` markers are preserved as raw priority evidence but are not mapped to P-scale severity. A fix response may include explicit `fix_reply.severity`; if it conflicts with first-scene severity evidence, include `fix_reply.severity_note` or the response is rejected with `SEVERITY_OVERRIDE_NOTE_REQUIRED`.
 
 Clarify, defer, and reject responses require `reply_markdown` and validation evidence. GitHub side-effect claims from AI agents are invalid.
 

--- a/skill/scripts/generate_reply.py
+++ b/skill/scripts/generate_reply.py
@@ -24,7 +24,7 @@ def write_text(path: Path, content: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a Markdown reply template for a CR item.")
-    parser.add_argument("--severity", default="P2", help="P1, P2, or P3 for fix mode.")
+    parser.add_argument("--severity", help="Optional P1, P2, or P3 for fix mode.")
     parser.add_argument("--mode", default="fix", choices=["fix", "clarify", "defer"])
     parser.add_argument("output_md")
     parser.add_argument("args", nargs="*")

--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -36,6 +36,7 @@ from gh_address_cr.core.handoff import (
 )
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core import session as session_store
+from gh_address_cr.core.severity import apply_severity_evidence, severity_evidence
 from gh_address_cr.core import workflow
 from gh_address_cr.github.diagnostics import classify_github_failure, github_waiting_on
 from gh_address_cr.github.client import GitHubClient
@@ -957,7 +958,19 @@ def _ingest_native_findings(
         incoming_ids.add(item_id)
         existing = items.get(item_id)
         item = dict(existing) if isinstance(existing, dict) else {}
-        item.update(finding)
+        normalized_finding = dict(finding)
+        raw_severity = normalized_finding.pop("severity", None)
+        item.update(normalized_finding)
+        finding_severity = severity_evidence(
+            raw_severity,
+            source="producer_payload",
+            raw_marker=str(raw_severity).strip() if raw_severity is not None else None,
+            observed_from=source,
+        )
+        if finding_severity:
+            apply_severity_evidence(item, finding_severity)
+        elif raw_severity is not None:
+            apply_severity_evidence(item, None)
         item.setdefault("created_at", now)
         item["updated_at"] = now
         item["status"] = "OPEN"
@@ -1832,6 +1845,8 @@ def handle_agent_fix(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--file", action="append", default=[])
     parser.add_argument("--summary", required=True)
     parser.add_argument("--why", required=True)
+    parser.add_argument("--severity", choices=["P1", "P2", "P3"])
+    parser.add_argument("--severity-note", "--severity-override-note", dest="severity_note")
     parser.add_argument("--validation", "--validation-cmd", dest="validation", action="append", default=[])
     parser.add_argument("--publish", action="store_true")
     parser.add_argument("--now")
@@ -1850,6 +1865,8 @@ def handle_agent_fix(repo: str | None, passthrough: list[str]) -> int:
             validation_commands=_parse_agent_validation(parsed.validation),
             summary=parsed.summary,
             why=parsed.why,
+            severity=parsed.severity,
+            severity_note=parsed.severity_note,
             publish=parsed.publish,
             now=now_dt,
         )
@@ -1870,6 +1887,8 @@ def handle_agent_fix_all(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--commit", required=True)
     parser.add_argument("--files")
     parser.add_argument("--file", action="append", default=[])
+    parser.add_argument("--severity", choices=["P1", "P2", "P3"])
+    parser.add_argument("--severity-note", "--severity-override-note", dest="severity_note")
     parser.add_argument("--validation", "--validation-cmd", dest="validation", action="append", default=[])
     parser.add_argument("--publish", action="store_true")
     parser.add_argument("--include-stale", action="store_true")
@@ -1890,6 +1909,8 @@ def handle_agent_fix_all(repo: str | None, passthrough: list[str]) -> int:
             files=files,
             validation_commands=_parse_agent_validation(parsed.validation),
             include_stale=parsed.include_stale,
+            severity=parsed.severity,
+            severity_note=parsed.severity_note,
             publish=parsed.publish,
             now=now_dt,
         )
@@ -1910,6 +1931,8 @@ def handle_agent_resolve_stale(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--commit", required=True)
     parser.add_argument("--files")
     parser.add_argument("--file", action="append", default=[])
+    parser.add_argument("--severity", choices=["P1", "P2", "P3"])
+    parser.add_argument("--severity-note", "--severity-override-note", dest="severity_note")
     parser.add_argument("--validation", "--validation-cmd", dest="validation", action="append", default=[])
     parser.add_argument("--match-files", action="store_true")
     parser.add_argument("--publish", action="store_true")
@@ -1943,6 +1966,8 @@ def handle_agent_resolve_stale(repo: str | None, passthrough: list[str]) -> int:
             validation_commands=_parse_agent_validation(parsed.validation),
             include_stale=True,
             stale_only=True,
+            severity=parsed.severity,
+            severity_note=parsed.severity_note,
             publish=parsed.publish,
             now=now_dt,
         )
@@ -1967,6 +1992,8 @@ def handle_agent_evidence(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--why")
     parser.add_argument("--test-command")
     parser.add_argument("--test-result")
+    parser.add_argument("--severity", choices=["P1", "P2", "P3"])
+    parser.add_argument("--severity-note", "--severity-override-note", dest="severity_note")
     parser.add_argument("--now")
     parsed = parser.parse_args(_prepend_optional(repo, passthrough))
     try:
@@ -1996,6 +2023,8 @@ def handle_agent_evidence(repo: str | None, passthrough: list[str]) -> int:
                 why=parsed.why,
                 test_command=parsed.test_command,
                 test_result=parsed.test_result,
+                severity=parsed.severity,
+                severity_note=parsed.severity_note,
                 now=now_dt,
             )
     except workflow.WorkflowError as exc:

--- a/src/gh_address_cr/core/cr_loop.py
+++ b/src/gh_address_cr/core/cr_loop.py
@@ -17,6 +17,7 @@ from gh_address_cr.core.reply_templates import (
     defer_reply as render_defer_reply,
     fix_reply as render_fix_reply,
 )
+from gh_address_cr.core.severity import normalize_severity
 
 
 COMPAT_SCRIPT_DIR = Path(
@@ -541,9 +542,10 @@ def normalize_validation_commands(value: object) -> list[str]:
     return [command] if command else []
 
 
-def normalize_fix_reply_severity(value: object) -> str:
-    severity = str(value or "").strip().upper()
-    return severity if severity in {"P1", "P2", "P3"} else "P2"
+def normalize_fix_reply_severity(value: object) -> str | None:
+    if value in (None, ""):
+        return None
+    return normalize_severity(value)
 
 
 def build_github_fix_reply(action: dict, item: dict, validation_commands: object) -> tuple[str | None, str]:
@@ -566,7 +568,11 @@ def build_github_fix_reply(action: dict, item: dict, validation_commands: object
         return None, "GitHub fix actions require fix_reply.files."
 
     normalized_validation_commands = normalize_validation_commands(validation_commands)
-    severity = normalize_fix_reply_severity(fix_reply.get("severity") or item.get("severity") or "P2")
+    explicit_severity = "severity" in fix_reply
+    raw_severity = fix_reply.get("severity") if explicit_severity else item.get("severity")
+    severity = normalize_fix_reply_severity(raw_severity)
+    if explicit_severity and raw_severity not in (None, "") and severity is None:
+        return None, "GitHub fix actions require fix_reply.severity to be P1, P2, or P3 when provided."
     why = str(fix_reply.get("why") or "Addressed the CR with minimal targeted changes and regression coverage.").strip()
     test_command = str(fix_reply.get("test_command") or " && ".join(normalized_validation_commands)).strip()
     derived_test_result = "passed" if normalized_validation_commands else ""

--- a/src/gh_address_cr/core/cr_loop.py
+++ b/src/gh_address_cr/core/cr_loop.py
@@ -17,7 +17,7 @@ from gh_address_cr.core.reply_templates import (
     defer_reply as render_defer_reply,
     fix_reply as render_fix_reply,
 )
-from gh_address_cr.core.severity import normalize_severity
+from gh_address_cr.core.severity import first_scene_item_severity, normalize_severity
 
 
 COMPAT_SCRIPT_DIR = Path(
@@ -569,7 +569,7 @@ def build_github_fix_reply(action: dict, item: dict, validation_commands: object
 
     normalized_validation_commands = normalize_validation_commands(validation_commands)
     explicit_severity = "severity" in fix_reply
-    raw_severity = fix_reply.get("severity") if explicit_severity else item.get("severity")
+    raw_severity = fix_reply.get("severity") if explicit_severity else first_scene_item_severity(item)
     severity = normalize_fix_reply_severity(raw_severity)
     if explicit_severity and raw_severity not in (None, "") and severity is None:
         return None, "GitHub fix actions require fix_reply.severity to be P1, P2, or P3 when provided."

--- a/src/gh_address_cr/core/gate.py
+++ b/src/gh_address_cr/core/gate.py
@@ -18,6 +18,7 @@ from gh_address_cr.core.severity import (
     apply_severity_evidence,
     extract_review_priority_evidence,
     extract_severity_evidence,
+    first_scene_item_severity,
     severity_evidence,
 )
 from gh_address_cr.github.client import GitHubClient
@@ -313,7 +314,9 @@ def _session_with_remote_threads(
             )
         if detected_severity:
             apply_severity_evidence(item, detected_severity)
-        elif first_body is not None or raw_severity is not None:
+        elif first_scene_item_severity(item):
+            item["severity"] = first_scene_item_severity(item)
+        else:
             apply_severity_evidence(item, None)
         priority_evidence = (
             extract_review_priority_evidence(first_body, source="github_first_comment", observed_from=first_url)

--- a/src/gh_address_cr/core/gate.py
+++ b/src/gh_address_cr/core/gate.py
@@ -14,6 +14,12 @@ from gh_address_cr.core.github_thread_state import (
     is_terminal_github_thread,
 )
 from gh_address_cr.core.session import SessionError, SessionManager
+from gh_address_cr.core.severity import (
+    apply_severity_evidence,
+    extract_review_priority_evidence,
+    extract_severity_evidence,
+    severity_evidence,
+)
 from gh_address_cr.github.client import GitHubClient
 
 
@@ -288,6 +294,36 @@ def _session_with_remote_threads(
         item["line"] = thread.get("line") or item.get("line")
         item["url"] = thread.get("url") or item.get("url")
         item["body"] = thread.get("body") or item.get("body")
+        first_body = thread.get("first_body")
+        if first_body is None and thread.get("comment_source") == "first":
+            first_body = thread.get("body")
+        first_url = thread.get("first_url") or thread.get("url")
+        raw_severity = thread.get("severity")
+        detected_severity = severity_evidence(
+            raw_severity,
+            source="github_payload",
+            raw_marker=str(raw_severity).strip() if raw_severity is not None else None,
+            observed_from=thread.get("url") or first_url,
+        )
+        if detected_severity is None and first_body is not None:
+            detected_severity = extract_severity_evidence(
+                first_body,
+                source="github_first_comment",
+                observed_from=first_url,
+            )
+        if detected_severity:
+            apply_severity_evidence(item, detected_severity)
+        elif first_body is not None or raw_severity is not None:
+            apply_severity_evidence(item, None)
+        priority_evidence = (
+            extract_review_priority_evidence(first_body, source="github_first_comment", observed_from=first_url)
+            if first_body is not None
+            else None
+        )
+        if priority_evidence:
+            item["review_priority_evidence"] = priority_evidence
+        elif first_body is not None:
+            item.pop("review_priority_evidence", None)
         is_resolved = _thread_is_resolved(thread)
         is_outdated = is_stale_or_outdated_github_thread(thread)
         item["is_outdated"] = is_outdated

--- a/src/gh_address_cr/core/reply_templates.py
+++ b/src/gh_address_cr/core/reply_templates.py
@@ -9,9 +9,13 @@ SEVERITY_RISK_NOTES = {
 
 DEFAULT_FILE_SUMMARY = "updated per CR scope"
 
-def _normalize_severity(severity: str) -> str:
-    normalized = str(severity or "P2").upper()
-    return normalized if normalized in SEVERITY_RISK_NOTES else "P2"
+def _normalize_severity(severity: str | None) -> str | None:
+    if severity in (None, ""):
+        return None
+    normalized = str(severity).strip().upper()
+    if normalized not in SEVERITY_RISK_NOTES:
+        raise SystemExit(f"Invalid severity: {severity} (expected P1/P2/P3)")
+    return normalized
 
 
 def _sentence_with_period(value: str) -> str:
@@ -21,15 +25,13 @@ def _sentence_with_period(value: str) -> str:
     return text if text.endswith((".", "!", "?")) else f"{text}."
 
 
-def fix_reply(severity: str, payload: list[str], *, summary: str | None = None) -> str:
+def fix_reply(severity: str | None, payload: list[str], *, summary: str | None = None) -> str:
     if len(payload) < 4:
         raise SystemExit(
             "Usage for fix: generate_reply.py [--severity P1|P2|P3] <output_md> "
             "<commit_hash> <files_csv> <test_command> <test_result> [why]"
         )
     normalized_severity = _normalize_severity(severity)
-    if str(severity or "").upper() not in SEVERITY_RISK_NOTES:
-        raise SystemExit(f"Invalid severity: {severity} (expected P1/P2/P3)")
 
     commit_hash, files_csv, test_command, test_result, *rest = payload
     why = rest[0] if rest else "Addressed the CR with minimal targeted changes and regression coverage."
@@ -38,17 +40,17 @@ def fix_reply(severity: str, payload: list[str], *, summary: str | None = None) 
     lines = [
         f"Fixed in `{commit_hash}`.",
         "",
-        f"Severity: `{normalized_severity}`",
-        "",
         "What I changed:",
     ]
+    if normalized_severity:
+        lines[2:2] = [f"Severity: `{normalized_severity}`", ""]
     lines.extend([f"- `{path}`: {file_summary}" for path in files] or ["- No file list provided."])
+    why_lines = ["", "Why this addresses the CR:", f"- {why}"]
+    if normalized_severity:
+        why_lines.append(f"- {SEVERITY_RISK_NOTES[normalized_severity]}")
     lines.extend(
-        [
-            "",
-            "Why this addresses the CR:",
-            f"- {why}",
-            f"- {SEVERITY_RISK_NOTES[normalized_severity]}",
+        why_lines
+        + [
             "",
             "Validation:",
             f"- `{test_command}`",

--- a/src/gh_address_cr/core/session_engine.py
+++ b/src/gh_address_cr/core/session_engine.py
@@ -13,6 +13,12 @@ from pathlib import Path
 from gh_address_cr.core import paths as core_paths
 from gh_address_cr.core.handoff import ensure_handoff_state, record_producer_result
 from gh_address_cr.core import session as session_store
+from gh_address_cr.core.severity import (
+    apply_severity_evidence,
+    extract_review_priority_evidence,
+    extract_severity_evidence,
+    severity_evidence,
+)
 from gh_address_cr.intake.findings import EMPTY_FINDINGS_INPUT_MESSAGE, normalize_finding
 
 
@@ -408,6 +414,28 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
     else:
         reply_posted = existing.get("reply_posted", False) if existing else False
         reply_url = existing.get("reply_url") if existing else None
+    first_body = row.get("first_body")
+    if first_body is None and row.get("comment_source") == "first":
+        first_body = row.get("body")
+    first_url = row.get("first_url") or row.get("url")
+    raw_severity = row.get("severity")
+    detected_severity = severity_evidence(
+        raw_severity,
+        source="github_payload",
+        raw_marker=str(raw_severity).strip() if raw_severity is not None else None,
+        observed_from=row.get("url") or first_url,
+    )
+    if detected_severity is None and first_body is not None:
+        detected_severity = extract_severity_evidence(
+            first_body,
+            source="github_first_comment",
+            observed_from=first_url,
+        )
+    priority_evidence = (
+        extract_review_priority_evidence(first_body, source="github_first_comment", observed_from=first_url)
+        if first_body is not None
+        else None
+    )
     payload = {
         "item_id": item_id,
         "item_kind": "github_thread",
@@ -419,7 +447,6 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
         "end_line": row.get("end_line"),
         "title": row.get("title") or "GitHub review thread",
         "body": row.get("body"),
-        "severity": row.get("severity") or "P2",
         "confidence": row.get("confidence"),
         "category": row.get("category") or "review-thread",
         "status": status,
@@ -455,6 +482,25 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
         "created_run_id": existing.get("created_run_id") if existing else run_id,
         "updated_at": now,
     }
+    if detected_severity:
+        apply_severity_evidence(payload, detected_severity)
+    elif first_body is not None or raw_severity is not None:
+        apply_severity_evidence(payload, None)
+    elif existing:
+        existing_severity = existing.get("severity")
+        existing_evidence = existing.get("severity_evidence")
+        if existing_severity:
+            payload["severity"] = existing_severity
+        if isinstance(existing_evidence, dict):
+            payload["severity_evidence"] = dict(existing_evidence)
+    if priority_evidence:
+        payload["review_priority_evidence"] = priority_evidence
+    elif first_body is None and existing and isinstance(existing.get("review_priority_evidence"), dict):
+        payload["review_priority_evidence"] = dict(existing["review_priority_evidence"])
+    if first_body is not None:
+        payload["first_body"] = first_body
+    if row.get("latest_body") is not None:
+        payload["latest_body"] = row.get("latest_body")
     if reopened:
         set_handled_state(payload, False, run_id=None)
     elif resolved:
@@ -499,6 +545,16 @@ def add_local_finding(session: dict, finding: dict, source: str) -> tuple[str, b
         existing["scan_id"] = session.get("current_scan_id")
         existing["updated_at"] = now
         existing["repeat_count"] = existing.get("repeat_count", 0) + 1
+        finding_severity = severity_evidence(
+            finding.get("severity"),
+            source="producer_payload",
+            raw_marker=str(finding.get("severity")).strip() if finding.get("severity") is not None else None,
+            observed_from=source,
+        )
+        if finding_severity:
+            apply_severity_evidence(existing, finding_severity)
+        elif "severity" in finding:
+            apply_severity_evidence(existing, None)
         if existing.get("status") != "OPEN":
             existing["status"] = "OPEN"
             existing["blocking"] = True
@@ -515,7 +571,7 @@ def add_local_finding(session: dict, finding: dict, source: str) -> tuple[str, b
     title = finding.get("title") or "Local review finding"
     body = finding.get("body") or finding.get("issue") or ""
     status = "OPEN"
-    session["items"][item_id] = {
+    item = {
         "item_id": item_id,
         "item_kind": "local_finding",
         "source": source,
@@ -526,7 +582,6 @@ def add_local_finding(session: dict, finding: dict, source: str) -> tuple[str, b
         "end_line": finding.get("end_line"),
         "title": title,
         "body": body,
-        "severity": finding.get("severity") or "P2",
         "confidence": finding.get("confidence"),
         "category": finding.get("category") or "general",
         "status": status,
@@ -559,6 +614,15 @@ def add_local_finding(session: dict, finding: dict, source: str) -> tuple[str, b
         "created_run_id": run_id,
         "updated_at": now,
     }
+    finding_severity = severity_evidence(
+        finding.get("severity"),
+        source="producer_payload",
+        raw_marker=str(finding.get("severity")).strip() if finding.get("severity") is not None else None,
+        observed_from=source,
+    )
+    if finding_severity:
+        apply_severity_evidence(item, finding_severity)
+    session["items"][item_id] = item
     return item_id, True
 
 

--- a/src/gh_address_cr/core/session_engine.py
+++ b/src/gh_address_cr/core/session_engine.py
@@ -17,6 +17,7 @@ from gh_address_cr.core.severity import (
     apply_severity_evidence,
     extract_review_priority_evidence,
     extract_severity_evidence,
+    normalize_severity,
     severity_evidence,
 )
 from gh_address_cr.intake.findings import EMPTY_FINDINGS_INPUT_MESSAGE, normalize_finding
@@ -362,6 +363,13 @@ def history_event(event: str, note: str = "", actor: str = "system") -> dict:
     return {"ts": utc_now(), "event": event, "note": note, "actor": actor}
 
 
+def _valid_severity_evidence(item: dict) -> bool:
+    evidence = item.get("severity_evidence")
+    if not isinstance(evidence, dict):
+        return False
+    return bool(normalize_severity(evidence.get("value")))
+
+
 def clear_claim(item: dict):
     item["claimed_by"] = None
     item["claimed_at"] = None
@@ -417,7 +425,8 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
     first_body = row.get("first_body")
     if first_body is None and row.get("comment_source") == "first":
         first_body = row.get("body")
-    first_url = row.get("first_url") or row.get("url")
+    first_url = row.get("first_url") or (row.get("url") if first_body is not None else None)
+    latest_url = row.get("latest_url") or (row.get("url") if row.get("latest_body") is not None else None)
     raw_severity = row.get("severity")
     detected_severity = severity_evidence(
         raw_severity,
@@ -459,8 +468,8 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
         "published": True,
         "published_ref": row.get("url"),
         "url": row.get("url"),
-        "first_url": row.get("first_url"),
-        "latest_url": row.get("latest_url"),
+        "first_url": first_url,
+        "latest_url": latest_url,
         "is_outdated": bool(row.get("isOutdated")),
         "scan_id": session.get("current_scan_id"),
         "introduced_in_sha": row.get("introduced_in_sha"),
@@ -484,15 +493,11 @@ def upsert_github_thread(session: dict, row: dict) -> tuple[str, bool]:
     }
     if detected_severity:
         apply_severity_evidence(payload, detected_severity)
-    elif first_body is not None or raw_severity is not None:
+    elif existing and _valid_severity_evidence(existing):
+        payload["severity"] = normalize_severity(existing["severity_evidence"].get("value"))
+        payload["severity_evidence"] = dict(existing["severity_evidence"])
+    else:
         apply_severity_evidence(payload, None)
-    elif existing:
-        existing_severity = existing.get("severity")
-        existing_evidence = existing.get("severity_evidence")
-        if existing_severity:
-            payload["severity"] = existing_severity
-        if isinstance(existing_evidence, dict):
-            payload["severity_evidence"] = dict(existing_evidence)
     if priority_evidence:
         payload["review_priority_evidence"] = priority_evidence
     elif first_body is None and existing and isinstance(existing.get("review_priority_evidence"), dict):

--- a/src/gh_address_cr/core/severity.py
+++ b/src/gh_address_cr/core/severity.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+VALID_SEVERITIES = {"P1", "P2", "P3"}
+
+_EXPLICIT_P_SCALE_PATTERNS = (
+    re.compile(r"(?i)\b(?:severity|priority)\s*[:=\-]?\s*`?\[?(P[123])\]?`?\b"),
+    re.compile(r"(?i)(?<![A-Z0-9])\[?(P[123])\]?(?:\s+badge)?(?![A-Z0-9])"),
+)
+_REVIEW_PRIORITY_RE = re.compile(r"(?i)\b(high|medium|low)(?:[-_\s]+priority)?\b")
+
+
+def normalize_severity(value: Any) -> str | None:
+    normalized = str(value or "").strip().upper()
+    return normalized if normalized in VALID_SEVERITIES else None
+
+
+def severity_evidence(
+    value: Any,
+    *,
+    source: str,
+    raw_marker: str | None = None,
+    observed_from: str | None = None,
+) -> dict[str, str] | None:
+    normalized = normalize_severity(value)
+    if not normalized:
+        return None
+    evidence = {
+        "value": normalized,
+        "source": source,
+        "raw_marker": str(raw_marker or normalized).strip() or normalized,
+    }
+    if observed_from:
+        evidence["observed_from"] = observed_from
+    return evidence
+
+
+def extract_severity_evidence(
+    text: Any,
+    *,
+    source: str,
+    observed_from: str | None = None,
+) -> dict[str, str] | None:
+    body = str(text or "")
+    if not body.strip():
+        return None
+    for pattern in _EXPLICIT_P_SCALE_PATTERNS:
+        match = pattern.search(body)
+        if not match:
+            continue
+        marker = match.group(1).upper()
+        return severity_evidence(marker, source=source, raw_marker=marker, observed_from=observed_from)
+    return None
+
+
+def extract_review_priority_evidence(
+    text: Any,
+    *,
+    source: str,
+    observed_from: str | None = None,
+) -> dict[str, str] | None:
+    body = str(text or "")
+    if not body.strip():
+        return None
+    match = _REVIEW_PRIORITY_RE.search(body)
+    if not match:
+        return None
+    priority = match.group(1).lower()
+    evidence = {
+        "value": priority,
+        "source": source,
+        "raw_marker": priority,
+    }
+    if observed_from:
+        evidence["observed_from"] = observed_from
+    return evidence
+
+
+def apply_severity_evidence(item: dict[str, Any], evidence: dict[str, str] | None) -> None:
+    if not evidence:
+        item.pop("severity", None)
+        item.pop("severity_evidence", None)
+        return
+    item["severity"] = evidence["value"]
+    item["severity_evidence"] = dict(evidence)
+
+
+def first_scene_item_severity(item: dict[str, Any]) -> str | None:
+    evidence = item.get("severity_evidence")
+    if not isinstance(evidence, dict):
+        return None
+    return normalize_severity(evidence.get("value"))
+

--- a/src/gh_address_cr/core/severity.py
+++ b/src/gh_address_cr/core/severity.py
@@ -8,13 +8,20 @@ VALID_SEVERITIES = {"P1", "P2", "P3"}
 
 _EXPLICIT_P_SCALE_PATTERNS = (
     re.compile(r"(?i)\b(?:severity|priority)\s*[:=\-]?\s*`?\[?(P[123])\]?`?\b"),
-    re.compile(r"(?i)(?<![A-Z0-9])\[?(P[123])\]?(?:\s+badge)?(?![A-Z0-9])"),
+    re.compile(r"(?i)(?<![A-Z0-9])\[(P[123])\](?![A-Z0-9])"),
+    re.compile(r"(?i)(?<![A-Z0-9])(P[123])\s+badge\b"),
+    re.compile(r"(?i)\bbadge/(P[123])(?:[-_/?#&.]|$)"),
 )
-_REVIEW_PRIORITY_RE = re.compile(r"(?i)\b(high|medium|low)(?:[-_\s]+priority)?\b")
+_REVIEW_PRIORITY_PATTERNS = (
+    re.compile(r"(?i)\b(high|medium|low)[-_\s]+priority\b"),
+    re.compile(r"(?i)\bpriority\s*[:=\-]\s*(high|medium|low)\b"),
+)
 
 
 def normalize_severity(value: Any) -> str | None:
-    normalized = str(value or "").strip().upper()
+    if value is None:
+        return None
+    normalized = str(value).strip().upper()
     return normalized if normalized in VALID_SEVERITIES else None
 
 
@@ -65,10 +72,14 @@ def extract_review_priority_evidence(
     body = str(text or "")
     if not body.strip():
         return None
-    match = _REVIEW_PRIORITY_RE.search(body)
-    if not match:
+    priority = None
+    for pattern in _REVIEW_PRIORITY_PATTERNS:
+        match = pattern.search(body)
+        if match:
+            priority = match.group(1).lower()
+            break
+    if priority is None:
         return None
-    priority = match.group(1).lower()
     evidence = {
         "value": priority,
         "source": source,
@@ -93,4 +104,3 @@ def first_scene_item_severity(item: dict[str, Any]) -> str | None:
     if not isinstance(evidence, dict):
         return None
     return normalize_severity(evidence.get("value"))
-

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -38,6 +38,7 @@ from gh_address_cr.core.reply_templates import (
     defer_reply as render_defer_reply,
     fix_reply as render_fix_reply,
 )
+from gh_address_cr.core.severity import first_scene_item_severity, normalize_severity
 from gh_address_cr.evidence.ledger import EvidenceLedger, SideEffectAttempt
 from gh_address_cr.github.client import GitHubClient
 from gh_address_cr.github.diagnostics import github_waiting_on
@@ -516,6 +517,8 @@ def record_evidence_profile(
     why: str | None = None,
     test_command: str | None = None,
     test_result: str | None = None,
+    severity: str | None = None,
+    severity_note: str | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     profile_name = name.strip()
@@ -569,6 +572,15 @@ def record_evidence_profile(
         fix_reply["test_command"] = test_command.strip()
     if test_result and test_result.strip():
         fix_reply["test_result"] = test_result.strip()
+    normalized_severity = _validate_requested_severity(
+        severity,
+        status="EVIDENCE_PROFILE_REJECTED",
+        waiting_on="evidence_profile",
+    )
+    if normalized_severity:
+        fix_reply["severity"] = normalized_severity
+    if severity_note and severity_note.strip():
+        fix_reply["severity_note"] = severity_note.strip()
 
     profile = {
         "name": profile_name,
@@ -632,6 +644,8 @@ def fast_fix_item(
     validation_commands: list[dict[str, str]],
     summary: str,
     why: str,
+    severity: str | None = None,
+    severity_note: str | None = None,
     publish: bool = False,
     github_client: Any | None = None,
     now: datetime | None = None,
@@ -674,6 +688,24 @@ def fast_fix_item(
             message="agent fix requires --summary and --why.",
             payload={"item_id": item_id},
         )
+    normalized_severity = _validate_requested_severity(
+        severity,
+        status="FAST_FIX_REJECTED",
+        waiting_on="fast_fix_input",
+        payload={"item_id": item_id},
+    )
+    if normalized_severity:
+        session = session_store.load_session(repo, pr_number)
+        item = _items(session).get(item_id)
+        if isinstance(item, dict):
+            _validate_severity_override_note(
+                normalized_severity,
+                item,
+                severity_note,
+                status="FAST_FIX_REJECTED",
+                waiting_on="fast_fix_input",
+                payload={"item_id": item_id},
+            )
 
     try:
         classification = record_classification(
@@ -694,6 +726,16 @@ def fast_fix_item(
         )
         request = json.loads(Path(requested["request_path"]).read_text(encoding="utf-8"))
         response_path = session_store.workspace_dir(repo, pr_number) / f"fast-fix-response-{request['request_id']}.json"
+        fix_reply = {
+            "summary": summary,
+            "why": why,
+            "commit_hash": commit_hash.strip(),
+            "files": normalized_files,
+        }
+        if normalized_severity:
+            fix_reply["severity"] = normalized_severity
+        if severity_note and severity_note.strip():
+            fix_reply["severity_note"] = severity_note.strip()
         response = {
             "schema_version": PROTOCOL_VERSION,
             "request_id": request["request_id"],
@@ -704,12 +746,7 @@ def fast_fix_item(
             "note": summary,
             "files": normalized_files,
             "validation_commands": normalized_validation,
-            "fix_reply": {
-                "summary": summary,
-                "why": why,
-                "commit_hash": commit_hash.strip(),
-                "files": normalized_files,
-            },
+            "fix_reply": fix_reply,
         }
         response_path.write_text(json.dumps(response, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         submitted = submit_action_response(
@@ -746,6 +783,8 @@ def fast_fix_matching_threads(
     validation_commands: list[dict[str, str]],
     include_stale: bool = False,
     stale_only: bool = False,
+    severity: str | None = None,
+    severity_note: str | None = None,
     publish: bool = False,
     github_client: Any | None = None,
     now: datetime | None = None,
@@ -781,6 +820,11 @@ def fast_fix_matching_threads(
             exit_code=2,
             message=f"{command_name} requires --commit.",
         )
+    normalized_severity = _validate_requested_severity(
+        severity,
+        status=rejected_status,
+        waiting_on=input_waiting_on,
+    )
 
     session = session_store.load_session(repo, pr_number)
     github_items = [
@@ -823,6 +867,15 @@ def fast_fix_matching_threads(
             item_id = str(item["item_id"])
             why = _fast_fix_why(commit_hash, normalized_files, stale=bool(is_stale_github_thread_item(item)))
             try:
+                if normalized_severity:
+                    _validate_severity_override_note(
+                        normalized_severity,
+                        item,
+                        severity_note,
+                        status=rejected_status,
+                        waiting_on=input_waiting_on,
+                        payload={"item_id": item_id},
+                    )
                 record_classification(
                     repo,
                     pr_number,
@@ -854,6 +907,15 @@ def fast_fix_matching_threads(
         if not batch_responses:
             continue
         batch_path = session_store.workspace_dir(repo, pr_number) / f"fast-fix-all-batch-{uuid4().hex}.json"
+        common_fix_reply = {
+            "commit_hash": commit_hash.strip(),
+            "summary": f"Fixed related GitHub review threads in {commit_hash.strip()}.",
+            "files": normalized_files,
+        }
+        if normalized_severity:
+            common_fix_reply["severity"] = normalized_severity
+        if severity_note and severity_note.strip():
+            common_fix_reply["severity_note"] = severity_note.strip()
         batch_path.write_text(
             json.dumps(
                 {
@@ -863,11 +925,7 @@ def fast_fix_matching_threads(
                     "common": {
                         "files": normalized_files,
                         "validation_commands": normalized_validation,
-                        "fix_reply": {
-                            "commit_hash": commit_hash.strip(),
-                            "summary": f"Fixed related GitHub review threads in {commit_hash.strip()}.",
-                            "files": normalized_files,
-                        },
+                        "fix_reply": common_fix_reply,
                     },
                     "items": batch_responses,
                 },
@@ -1862,7 +1920,9 @@ def _publish_reply_body(item: dict[str, Any], response: dict[str, Any]) -> tuple
         return None, "MISSING_FIX_REPLY_TEST_COMMAND"
     if not test_result:
         return None, "MISSING_FIX_REPLY_TEST_RESULT"
-    severity = _normalize_fix_reply_severity(fix_reply.get("severity") or item.get("severity") or "P2")
+    severity, severity_error = _fix_reply_severity_for_publish(fix_reply, item)
+    if severity_error:
+        return None, severity_error
     why = str(fix_reply.get("why") or "Addressed the CR with targeted changes and validation evidence.").strip()
     summary = str(fix_reply.get("summary") or "").strip() or None
     try:
@@ -1933,9 +1993,106 @@ def _looks_like_validation_result(value: str) -> bool:
     return normalized in {"pass", "passed", "success", "succeeded", "ok", "fail", "failed", "error", "skipped"}
 
 
-def _normalize_fix_reply_severity(value: Any) -> str:
-    severity = str(value or "").strip().upper()
-    return severity if severity in {"P1", "P2", "P3"} else "P2"
+def _normalize_optional_fix_reply_severity(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return normalize_severity(value)
+
+
+def _validate_requested_severity(
+    value: Any,
+    *,
+    status: str,
+    waiting_on: str,
+    payload: dict[str, Any] | None = None,
+) -> str | None:
+    if value in (None, ""):
+        return None
+    normalized = _normalize_optional_fix_reply_severity(value)
+    if normalized:
+        return normalized
+    raise WorkflowError(
+        status=status,
+        reason_code="INVALID_FIX_REPLY_SEVERITY",
+        waiting_on=waiting_on,
+        exit_code=2,
+        message="Explicit severity override must be one of P1, P2, or P3.",
+        payload=payload or {},
+    )
+
+
+def _severity_override_note(fix_reply_or_note: dict[str, Any] | str | None) -> str:
+    if isinstance(fix_reply_or_note, dict):
+        return str(
+            fix_reply_or_note.get("severity_note")
+            or fix_reply_or_note.get("severity_override_note")
+            or ""
+        ).strip()
+    return str(fix_reply_or_note or "").strip()
+
+
+def _validate_severity_override_note(
+    severity: str,
+    item: dict[str, Any],
+    note: str | None,
+    *,
+    status: str,
+    waiting_on: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    first_scene_severity = first_scene_item_severity(item)
+    if not first_scene_severity or first_scene_severity == severity:
+        return
+    if _severity_override_note(note):
+        return
+    raise WorkflowError(
+        status=status,
+        reason_code="SEVERITY_OVERRIDE_NOTE_REQUIRED",
+        waiting_on=waiting_on,
+        exit_code=2,
+        message=(
+            f"Explicit severity override {severity} conflicts with first-scene severity "
+            f"{first_scene_severity}; add --severity-note explaining the override."
+        ),
+        payload=payload or {},
+    )
+
+
+def _fix_reply_explicit_severity(fix_reply: dict[str, Any]) -> tuple[str | None, str | None]:
+    if "severity" not in fix_reply or fix_reply.get("severity") in (None, ""):
+        return None, None
+    severity = _normalize_optional_fix_reply_severity(fix_reply.get("severity"))
+    if not severity:
+        return None, "INVALID_FIX_REPLY_SEVERITY"
+    return severity, None
+
+
+def _fix_reply_severity_rejection_reason(fix_reply: dict[str, Any], item: dict[str, Any]) -> str | None:
+    explicit_severity, error = _fix_reply_explicit_severity(fix_reply)
+    if error:
+        return error
+    if not explicit_severity:
+        return None
+    first_scene_severity = first_scene_item_severity(item)
+    if (
+        first_scene_severity
+        and first_scene_severity != explicit_severity
+        and not _severity_override_note(fix_reply)
+    ):
+        return "SEVERITY_OVERRIDE_NOTE_REQUIRED"
+    return None
+
+
+def _fix_reply_severity_for_publish(fix_reply: dict[str, Any], item: dict[str, Any]) -> tuple[str | None, str | None]:
+    explicit_severity, error = _fix_reply_explicit_severity(fix_reply)
+    if error:
+        return None, error
+    if explicit_severity:
+        conflict = _fix_reply_severity_rejection_reason(fix_reply, item)
+        if conflict:
+            return None, conflict
+        return explicit_severity, None
+    return normalize_severity(item.get("severity")), None
 
 
 def _release_active_triage_lease(session: dict[str, Any], item_id: str, *, agent_id: str) -> str | None:
@@ -2107,6 +2264,9 @@ def _validate_response(response: dict[str, Any], item: dict[str, Any]) -> str | 
                 return "MISSING_FIX_REPLY"
             if not isinstance(fix_reply, dict):
                 return "INVALID_FIX_REPLY"
+            severity_reason = _fix_reply_severity_rejection_reason(fix_reply, item)
+            if severity_reason:
+                return severity_reason
             _, publish_error = _publish_reply_body(item, response)
             if publish_error:
                 return publish_error

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -2052,7 +2052,7 @@ def _validate_severity_override_note(
         exit_code=2,
         message=(
             f"Explicit severity override {severity} conflicts with first-scene severity "
-            f"{first_scene_severity}; add --severity-note explaining the override."
+            f"{first_scene_severity}; add a severity note explaining the override."
         ),
         payload=payload or {},
     )
@@ -2092,7 +2092,7 @@ def _fix_reply_severity_for_publish(fix_reply: dict[str, Any], item: dict[str, A
         if conflict:
             return None, conflict
         return explicit_severity, None
-    return normalize_severity(item.get("severity")), None
+    return first_scene_item_severity(item), None
 
 
 def _release_active_triage_lease(session: dict[str, Any], item_id: str, *, agent_id: str) -> str | None:

--- a/src/gh_address_cr/github/threads.py
+++ b/src/gh_address_cr/github/threads.py
@@ -56,6 +56,10 @@ def normalize_thread(node: dict[str, Any], *, viewer_login: str | None = None) -
     first_comment = comments[0] if comments else {}
     body = latest_comment.get("body") or first_comment.get("body") or ""
     url = latest_comment.get("url") or first_comment.get("url")
+    first_body = first_comment.get("body") or ""
+    latest_body = latest_comment.get("body") or ""
+    first_url = first_comment.get("url")
+    latest_url = latest_comment.get("url")
     return {
         "item_id": f"github-thread:{thread_id}",
         "item_kind": "github_thread",
@@ -66,6 +70,11 @@ def normalize_thread(node: dict[str, Any], *, viewer_login: str | None = None) -
         "path": node.get("path"),
         "line": node.get("line"),
         "url": url,
+        "first_body": str(first_body),
+        "first_url": first_url,
+        "latest_body": str(latest_body),
+        "latest_url": latest_url,
+        "comment_source": "latest" if len(comments) > 1 else "first",
         "is_resolved": bool(node.get("isResolved", node.get("is_resolved", False))),
         "is_outdated": bool(node.get("isOutdated", node.get("is_outdated", False))),
         "reply_evidence": _viewer_reply_evidence(comments, viewer_login),

--- a/src/gh_address_cr/legacy_scripts/generate_reply.py
+++ b/src/gh_address_cr/legacy_scripts/generate_reply.py
@@ -13,7 +13,7 @@ def write_text(path: Path, content: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a Markdown reply template for a CR item.")
-    parser.add_argument("--severity", default="P2", help="P1, P2, or P3 for fix mode.")
+    parser.add_argument("--severity", help="Optional P1, P2, or P3 for fix mode.")
     parser.add_argument("--mode", default="fix", choices=["fix", "clarify", "defer"])
     parser.add_argument("output_md")
     parser.add_argument("args", nargs="*")

--- a/tests/fixtures/github_threads/outdated_thread.json
+++ b/tests/fixtures/github_threads/outdated_thread.json
@@ -33,6 +33,11 @@
       "path": "src/legacy.py",
       "line": 44,
       "url": "https://example.test/thread/outdated",
+      "first_body": "This older comment still needs explicit handling.",
+      "first_url": "https://example.test/thread/outdated",
+      "latest_body": "This older comment still needs explicit handling.",
+      "latest_url": "https://example.test/thread/outdated",
+      "comment_source": "first",
       "is_resolved": false,
       "is_outdated": true,
       "reply_evidence": null

--- a/tests/fixtures/github_threads/resolved_with_viewer_reply.json
+++ b/tests/fixtures/github_threads/resolved_with_viewer_reply.json
@@ -40,6 +40,11 @@
       "path": "src/resolved.py",
       "line": 7,
       "url": "https://example.test/thread/resolved#reply",
+      "first_body": "Please tighten this branch.",
+      "first_url": "https://example.test/thread/resolved",
+      "latest_body": "Handled in the latest patch.",
+      "latest_url": "https://example.test/thread/resolved#reply",
+      "comment_source": "latest",
       "is_resolved": true,
       "is_outdated": false,
       "reply_evidence": {

--- a/tests/fixtures/github_threads/unresolved_thread.json
+++ b/tests/fixtures/github_threads/unresolved_thread.json
@@ -33,6 +33,11 @@
       "path": "src/example.py",
       "line": 12,
       "url": "https://example.test/thread/unresolved",
+      "first_body": "Validate the input before use.",
+      "first_url": "https://example.test/thread/unresolved",
+      "latest_body": "Validate the input before use.",
+      "latest_url": "https://example.test/thread/unresolved",
+      "comment_source": "first",
       "is_resolved": false,
       "is_outdated": false,
       "reply_evidence": null

--- a/tests/fixtures/session_engine/legacy_native_session.json
+++ b/tests/fixtures/session_engine/legacy_native_session.json
@@ -68,7 +68,6 @@
       "reply_url": "https://example.test/thread/parity#reply",
       "resolution_note": "Replied and resolved in the parity fixture.",
       "scan_id": "scan-github-parity",
-      "severity": "P2",
       "source": "github",
       "start_line": null,
       "status": "CLOSED",
@@ -128,6 +127,12 @@
       "resolution_note": "Clarified by the parity fixture.",
       "scan_id": "scan-local-parity",
       "severity": "P2",
+      "severity_evidence": {
+        "observed_from": "local-agent:parity",
+        "raw_marker": "P2",
+        "source": "producer_payload",
+        "value": "P2"
+      },
       "source": "local-agent:parity",
       "start_line": null,
       "status": "CLARIFIED",

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -764,6 +764,134 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(item["state"], "publish_ready")
         self.assertEqual(item["accepted_response"]["fix_reply"]["commit_hash"], "abc123")
 
+    def test_agent_fix_fast_path_accepts_explicit_severity_override(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example.py",
+                    thread_id="PRRT_abc",
+                )
+            ]
+        )
+
+        result = self.run_runtime_module(
+            "agent",
+            "fix",
+            self.repo,
+            self.pr,
+            "github-thread:abc",
+            "--agent-id",
+            "codex-1",
+            "--commit",
+            "abc123",
+            "--files",
+            "src/example.py",
+            "--summary",
+            "Added the guard.",
+            "--why",
+            "The guarded path now covers the review case.",
+            "--severity",
+            "P1",
+            "--validation",
+            "python3 -m unittest tests.test_example=passed",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        session = self.load_session()
+        item = session["items"]["github-thread:abc"]
+        self.assertEqual(item["accepted_response"]["fix_reply"]["severity"], "P1")
+
+    def test_agent_fix_rejects_conflicting_severity_without_override_note(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/example.py",
+                    thread_id="PRRT_abc",
+                    severity="P2",
+                    severity_evidence={
+                        "value": "P2",
+                        "source": "github_first_comment",
+                        "raw_marker": "P2",
+                        "observed_from": "https://example.test/thread/abc",
+                    },
+                )
+            ]
+        )
+
+        result = self.run_runtime_module(
+            "agent",
+            "fix",
+            self.repo,
+            self.pr,
+            "github-thread:abc",
+            "--agent-id",
+            "codex-1",
+            "--commit",
+            "abc123",
+            "--files",
+            "src/example.py",
+            "--summary",
+            "Added the guard.",
+            "--why",
+            "The guarded path now covers the review case.",
+            "--severity",
+            "P1",
+            "--validation",
+            "python3 -m unittest tests.test_example=passed",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["reason_code"], "SEVERITY_OVERRIDE_NOTE_REQUIRED")
+
+    def test_agent_fix_all_batches_matching_thread_files_with_explicit_severity(self):
+        self.write_session(
+            items=[
+                open_item(
+                    "github-thread:abc",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/shared.py",
+                    thread_id="PRRT_abc",
+                ),
+                open_item(
+                    "github-thread:def",
+                    item_kind="github_thread",
+                    source="github",
+                    path="src/shared.py",
+                    thread_id="PRRT_def",
+                ),
+            ]
+        )
+
+        result = self.run_runtime_module(
+            "agent",
+            "fix-all",
+            self.repo,
+            self.pr,
+            "--agent-id",
+            "codex-1",
+            "--commit",
+            "abc123",
+            "--files",
+            "src/shared.py",
+            "--severity",
+            "P3",
+            "--validation",
+            "python3 -m unittest tests.test_shared=passed",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        session = self.load_session()
+        self.assertEqual(session["items"]["github-thread:abc"]["accepted_response"]["fix_reply"]["severity"], "P3")
+        self.assertEqual(session["items"]["github-thread:def"]["accepted_response"]["fix_reply"]["severity"], "P3")
+
     def test_agent_fix_all_batches_matching_thread_files(self):
         self.write_session(
             items=[

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -422,6 +422,12 @@ else:
                     "path": "src/template_fix.py",
                     "line": 21,
                     "severity": "P2",
+                    "severity_evidence": {
+                        "value": "P2",
+                        "source": "github_first_comment",
+                        "raw_marker": "P2",
+                        "observed_from": "https://example.test/thread/template-fix",
+                    },
                     "status": "OPEN",
                     "decision": None,
                     "blocking": True,

--- a/tests/test_cr_loop.py
+++ b/tests/test_cr_loop.py
@@ -59,6 +59,26 @@ class CRLoopCLITest(PythonScriptTestCase):
         self.assertEqual(len(selected), 1)
         self.assertEqual(selected[0]["item_id"], "local-finding:open")
 
+    def test_build_github_fix_reply_without_severity_does_not_default_to_p2(self):
+        module = self.load_module()
+
+        reply, error = module.build_github_fix_reply(
+            {
+                "fix_reply": {
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "summary": "Added the guard.",
+                    "why": "The guarded path now covers the review case.",
+                }
+            },
+            {},
+            [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+        )
+
+        self.assertEqual(error, "")
+        self.assertNotIn("Severity:", reply)
+        self.assertNotIn("Medium-severity path", reply)
+
     def test_cr_loop_mixed_adapter_accepts_adapter_command_flags(self):
         adapter = Path(self.temp_dir.name) / "adapter_with_flags.py"
         adapter.write_text(
@@ -728,7 +748,7 @@ else:
         self.assertTrue(updated["handled"])
         self.assertTrue(updated["reply_posted"])
 
-    def test_build_github_fix_reply_normalizes_unknown_severity_to_p2(self):
+    def test_build_github_fix_reply_treats_unknown_item_severity_as_unknown(self):
         module = self.load_module()
 
         reply_markdown, error = module.build_github_fix_reply(
@@ -747,7 +767,7 @@ else:
 
         self.assertEqual(error, "")
         self.assertIsNotNone(reply_markdown)
-        self.assertIn("Severity: `P2`", reply_markdown)
+        self.assertNotIn("Severity:", reply_markdown)
         self.assertIn("`python3 -m unittest tests.test_cr_loop`", reply_markdown)
 
     def test_handle_batch_github_fix_normalizes_string_validation_command(self):

--- a/tests/test_native_gate.py
+++ b/tests/test_native_gate.py
@@ -235,6 +235,44 @@ class NativeGateTests(unittest.TestCase):
         self.assertEqual(item["severity_evidence"]["source"], "github_first_comment")
         self.assertEqual(item["severity_evidence"]["observed_from"], "https://example.test/thread/p1")
 
+    def test_remote_thread_refresh_drops_legacy_unbacked_severity(self):
+        from gh_address_cr.core import gate
+
+        session = {
+            "repo": "owner/repo",
+            "pr_number": "123",
+            "items": {
+                "github-thread:THREAD_LEGACY": {
+                    "item_id": "github-thread:THREAD_LEGACY",
+                    "item_kind": "github_thread",
+                    "source": "github",
+                    "thread_id": "THREAD_LEGACY",
+                    "severity": "P2",
+                    "state": "open",
+                    "status": "OPEN",
+                }
+            },
+        }
+
+        merged = gate.session_with_remote_threads(
+            session,
+            [
+                {
+                    "id": "THREAD_LEGACY",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/severity.py",
+                    "line": 12,
+                    "body": "No explicit severity marker.",
+                    "url": "https://example.test/thread/legacy",
+                }
+            ],
+        )
+
+        item = merged["items"]["github-thread:THREAD_LEGACY"]
+        self.assertNotIn("severity", item)
+        self.assertNotIn("severity_evidence", item)
+
     def test_stale_thread_without_remote_resolution_does_not_require_reply_evidence(self):
         from gh_address_cr.core import gate
 

--- a/tests/test_native_gate.py
+++ b/tests/test_native_gate.py
@@ -202,6 +202,39 @@ class NativeGateTests(unittest.TestCase):
         self.assertEqual(item["status"], "STALE")
         self.assertTrue(item["blocking"])
 
+    def test_remote_thread_refresh_uses_first_comment_for_severity(self):
+        from gh_address_cr.core import gate
+
+        session = {
+            "repo": "owner/repo",
+            "pr_number": "123",
+            "items": {},
+        }
+
+        merged = gate.session_with_remote_threads(
+            session,
+            [
+                {
+                    "id": "THREAD_P1",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/severity.py",
+                    "line": 12,
+                    "body": "Maintainer reply says Severity: P3",
+                    "url": "https://example.test/thread/p1#latest",
+                    "first_body": "[P1] Reject unsafe fallback.",
+                    "first_url": "https://example.test/thread/p1",
+                    "latest_body": "Severity: P3",
+                    "latest_url": "https://example.test/thread/p1#latest",
+                }
+            ],
+        )
+
+        item = merged["items"]["github-thread:THREAD_P1"]
+        self.assertEqual(item["severity"], "P1")
+        self.assertEqual(item["severity_evidence"]["source"], "github_first_comment")
+        self.assertEqual(item["severity_evidence"]["observed_from"], "https://example.test/thread/p1")
+
     def test_stale_thread_without_remote_resolution_does_not_require_reply_evidence(self):
         from gh_address_cr.core import gate
 

--- a/tests/test_native_workflow.py
+++ b/tests/test_native_workflow.py
@@ -504,6 +504,54 @@ class NativeWorkflowTests(unittest.TestCase):
 
                 self.assertEqual(client.replies[0], expected)
 
+    def test_publish_github_thread_fix_without_severity_does_not_default_to_p2(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "summary": "Added the missing input guard.",
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                self.write_session(repo, pr_number, item)
+                client = FakeGitHubClient()
+
+                workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                self.assertNotIn("Severity:", client.replies[0])
+                self.assertNotIn("Medium-severity path", client.replies[0])
+
     def test_publish_github_thread_fix_uses_severity_specific_template_lines(self):
         from gh_address_cr.core import workflow
 

--- a/tests/test_native_workflow.py
+++ b/tests/test_native_workflow.py
@@ -462,6 +462,12 @@ class NativeWorkflowTests(unittest.TestCase):
             "source": "github",
             "thread_id": "THREAD_1",
             "severity": "P1",
+            "severity_evidence": {
+                "value": "P1",
+                "source": "github_first_comment",
+                "raw_marker": "P1",
+                "observed_from": "https://github.test/thread",
+            },
             "state": "publish_ready",
             "status": "OPEN",
             "blocking": True,
@@ -552,6 +558,55 @@ class NativeWorkflowTests(unittest.TestCase):
                 self.assertNotIn("Severity:", client.replies[0])
                 self.assertNotIn("Medium-severity path", client.replies[0])
 
+    def test_publish_github_thread_fix_with_legacy_unbacked_severity_does_not_default_to_p2(self):
+        from gh_address_cr.core import workflow
+
+        class FakeGitHubClient:
+            def __init__(self):
+                self.replies = []
+
+            def post_reply(self, repo, pr_number, thread_id, body):
+                self.replies.append(body)
+                return "https://github.test/reply"
+
+            def resolve_thread(self, repo, pr_number, thread_id):
+                return True
+
+        repo = "owner/repo"
+        pr_number = "123"
+        item = {
+            "item_id": "github-thread:THREAD_1",
+            "item_kind": "github_thread",
+            "source": "github",
+            "thread_id": "THREAD_1",
+            "severity": "P2",
+            "state": "publish_ready",
+            "status": "OPEN",
+            "blocking": True,
+            "publish_resolution": "fix",
+            "accepted_response": {
+                "resolution": "fix",
+                "note": "Fixed thread issue.",
+                "files": ["src/example.py"],
+                "validation_commands": [{"command": "python3 -m unittest tests.test_example", "result": "passed"}],
+                "fix_reply": {
+                    "summary": "Added the missing input guard.",
+                    "commit_hash": "abc123",
+                    "files": ["src/example.py"],
+                    "why": "The input is now checked before use.",
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"GH_ADDRESS_CR_STATE_DIR": tmp}, clear=False):
+                self.write_session(repo, pr_number, item)
+                client = FakeGitHubClient()
+
+                workflow.publish_github_thread_responses(repo, pr_number, github_client=client)
+
+                self.assertNotIn("Severity:", client.replies[0])
+                self.assertNotIn("Medium-severity path", client.replies[0])
+
     def test_publish_github_thread_fix_uses_severity_specific_template_lines(self):
         from gh_address_cr.core import workflow
 
@@ -581,6 +636,12 @@ class NativeWorkflowTests(unittest.TestCase):
                     "source": "github",
                     "thread_id": "THREAD_1",
                     "severity": severity,
+                    "severity_evidence": {
+                        "value": severity,
+                        "source": "github_first_comment",
+                        "raw_marker": severity,
+                        "observed_from": "https://github.test/thread",
+                    },
                     "state": "publish_ready",
                     "status": "OPEN",
                     "blocking": True,

--- a/tests/test_session_engine_cli.py
+++ b/tests/test_session_engine_cli.py
@@ -41,6 +41,94 @@ class SessionEngineCLITest(SessionEngineTestCase):
         self.assertEqual(item["status"], "OPEN")
         self.assertTrue(item["blocking"])
 
+    def test_sync_github_records_p_scale_severity_from_first_comment(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_P1",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Later reply says Severity: P3, but should not own the first-scene signal.",
+                    "url": "https://example.test/thread/p1#latest",
+                    "first_body": "**P1 Badge** Reject empty stdin before marking submitted.",
+                    "first_url": "https://example.test/thread/p1",
+                    "latest_body": "Severity: P3",
+                    "latest_url": "https://example.test/thread/p1#latest",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=payload, check=True)
+
+        session = self.load_session()
+        item = session["items"]["github-thread:THREAD_P1"]
+        self.assertEqual(item["severity"], "P1")
+        self.assertEqual(
+            item["severity_evidence"],
+            {
+                "value": "P1",
+                "source": "github_first_comment",
+                "raw_marker": "P1",
+                "observed_from": "https://example.test/thread/p1",
+            },
+        )
+
+    def test_sync_github_keeps_non_p_priority_as_raw_evidence_without_severity(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_MEDIUM",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "![medium](https://www.gstatic.com/codereviewagent/medium-priority.svg)",
+                    "url": "https://example.test/thread/medium",
+                    "first_body": "![medium](https://www.gstatic.com/codereviewagent/medium-priority.svg)",
+                    "first_url": "https://example.test/thread/medium",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=payload, check=True)
+
+        session = self.load_session()
+        item = session["items"]["github-thread:THREAD_MEDIUM"]
+        self.assertNotIn("severity", item)
+        self.assertEqual(item["review_priority_evidence"]["value"], "medium")
+        self.assertEqual(item["review_priority_evidence"]["source"], "github_first_comment")
+
+    def test_sync_github_does_not_promote_latest_comment_severity(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_DRIFT",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Maintainer reply with Severity: P1",
+                    "url": "https://example.test/thread/drift#latest",
+                    "first_body": "Please add a null check.",
+                    "first_url": "https://example.test/thread/drift",
+                    "latest_body": "Severity: P1",
+                    "latest_url": "https://example.test/thread/drift#latest",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=payload, check=True)
+
+        session = self.load_session()
+        item = session["items"]["github-thread:THREAD_DRIFT"]
+        self.assertNotIn("severity", item)
+        self.assertNotIn("severity_evidence", item)
+
     def test_sync_github_marks_resolved_threads_handled(self):
         self.run_engine("init", self.repo, self.pr, check=True)
         unresolved = json.dumps(
@@ -278,6 +366,35 @@ class SessionEngineCLITest(SessionEngineTestCase):
         local_items = [item for item in session["items"].values() if item["item_kind"] == "local_finding"]
         self.assertEqual(len(local_items), 1)
         self.assertEqual(local_items[0]["status"], "OPEN")
+
+    def test_ingest_local_records_structured_severity_evidence(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        payload = json.dumps(
+            [
+                {
+                    "title": "Producer severity",
+                    "body": "Producer supplied a precise severity.",
+                    "path": "src/severity.py",
+                    "line": 7,
+                    "severity": "P3",
+                }
+            ]
+        )
+
+        self.run_engine("ingest-local", self.repo, self.pr, "--source", "local-agent:test", stdin=payload, check=True)
+
+        session = self.load_session()
+        item = next(iter(session["items"].values()))
+        self.assertEqual(item["severity"], "P3")
+        self.assertEqual(
+            item["severity_evidence"],
+            {
+                "value": "P3",
+                "source": "producer_payload",
+                "raw_marker": "P3",
+                "observed_from": "local-agent:test",
+            },
+        )
 
     def test_run_local_review_ignores_whitespace_only_finding_differences(self):
         self.run_engine("init", self.repo, self.pr, check=True)

--- a/tests/test_session_engine_cli.py
+++ b/tests/test_session_engine_cli.py
@@ -66,6 +66,7 @@ class SessionEngineCLITest(SessionEngineTestCase):
         session = self.load_session()
         item = session["items"]["github-thread:THREAD_P1"]
         self.assertEqual(item["severity"], "P1")
+        self.assertEqual(item["first_url"], "https://example.test/thread/p1")
         self.assertEqual(
             item["severity_evidence"],
             {
@@ -75,6 +76,107 @@ class SessionEngineCLITest(SessionEngineTestCase):
                 "observed_from": "https://example.test/thread/p1",
             },
         )
+
+    def test_sync_github_persists_fallback_first_url_used_for_evidence(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_FALLBACK_URL",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Severity: P2",
+                    "url": "https://example.test/thread/fallback",
+                    "first_body": "Severity: P2",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=payload, check=True)
+
+        item = self.load_session()["items"]["github-thread:THREAD_FALLBACK_URL"]
+        self.assertEqual(item["first_url"], "https://example.test/thread/fallback")
+        self.assertEqual(item["severity_evidence"]["observed_from"], "https://example.test/thread/fallback")
+
+    def test_sync_github_preserves_trusted_severity_evidence_across_markerless_refresh(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        first_payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_PRESERVE",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Initial payload includes structured severity.",
+                    "url": "https://example.test/thread/preserve",
+                    "severity": "P1",
+                }
+            ]
+        )
+        second_payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_PRESERVE",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Latest reply has no severity marker.",
+                    "url": "https://example.test/thread/preserve#latest",
+                    "first_body": "Please add the guard.",
+                    "first_url": "https://example.test/thread/preserve",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=first_payload, check=True)
+        self.run_engine("sync-github", self.repo, self.pr, stdin=second_payload, check=True)
+
+        item = self.load_session()["items"]["github-thread:THREAD_PRESERVE"]
+        self.assertEqual(item["severity"], "P1")
+        self.assertEqual(item["severity_evidence"]["source"], "github_payload")
+
+    def test_sync_github_drops_legacy_unbacked_severity(self):
+        self.run_engine("init", self.repo, self.pr, check=True)
+        session = self.load_session()
+        session["items"]["github-thread:THREAD_LEGACY"] = {
+            "item_id": "github-thread:THREAD_LEGACY",
+            "item_kind": "github_thread",
+            "source": "github",
+            "origin_ref": "THREAD_LEGACY",
+            "path": "src/app.py",
+            "line": 12,
+            "body": "Legacy item",
+            "severity": "P2",
+            "status": "OPEN",
+            "blocking": True,
+            "handled": False,
+            "history": [],
+            "evidence": [],
+        }
+        self.session_file().write_text(json.dumps(session), encoding="utf-8")
+        payload = json.dumps(
+            [
+                {
+                    "id": "THREAD_LEGACY",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "path": "src/app.py",
+                    "line": 12,
+                    "body": "Refreshed without first-scene severity.",
+                    "url": "https://example.test/thread/legacy",
+                }
+            ]
+        )
+
+        self.run_engine("sync-github", self.repo, self.pr, stdin=payload, check=True)
+
+        item = self.load_session()["items"]["github-thread:THREAD_LEGACY"]
+        self.assertNotIn("severity", item)
+        self.assertNotIn("severity_evidence", item)
 
     def test_sync_github_keeps_non_p_priority_as_raw_evidence_without_severity(self):
         self.run_engine("init", self.repo, self.pr, check=True)

--- a/tests/test_severity_evidence.py
+++ b/tests/test_severity_evidence.py
@@ -1,0 +1,55 @@
+import unittest
+
+from gh_address_cr.core.severity import extract_review_priority_evidence, extract_severity_evidence, normalize_severity
+
+
+class SeverityEvidenceTests(unittest.TestCase):
+    def test_extracts_only_explicit_p_scale_severity_markers(self):
+        cases = [
+            ("Severity: P1", "P1"),
+            ("priority = `P2`", "P2"),
+            ("[P3] tighten the guard", "P3"),
+            ("P1 Badge rejects unsafe fallback", "P1"),
+            ("![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)", "P2"),
+        ]
+
+        for body, expected in cases:
+            with self.subTest(body=body):
+                evidence = extract_severity_evidence(body, source="github_first_comment")
+                self.assertIsNotNone(evidence)
+                self.assertEqual(evidence["value"], expected)
+
+    def test_ignores_p_scale_tokens_without_explicit_marker_context(self):
+        cases = [
+            "src/p1_parser.py should reject blank input.",
+            "Follow up in /p2-fix/ before release.",
+            "The P3 parser path should be refactored later.",
+        ]
+
+        for body in cases:
+            with self.subTest(body=body):
+                self.assertIsNone(extract_severity_evidence(body, source="github_first_comment"))
+
+    def test_review_priority_requires_explicit_priority_context(self):
+        cases = [
+            "![medium](https://www.gstatic.com/codereviewagent/medium-priority.svg)",
+            "high priority issue in the review output",
+            "Priority: low",
+        ]
+
+        for body in cases:
+            with self.subTest(body=body):
+                self.assertIsNotNone(extract_review_priority_evidence(body, source="github_first_comment"))
+
+        for body in ("high-level plan", "The temperature is high.", "medium sized refactor"):
+            with self.subTest(body=body):
+                self.assertIsNone(extract_review_priority_evidence(body, source="github_first_comment"))
+
+    def test_normalize_severity_does_not_treat_falsy_values_as_missing_pass_state(self):
+        self.assertIsNone(normalize_severity(False))
+        self.assertIsNone(normalize_severity(0))
+        self.assertIsNone(normalize_severity(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -203,6 +203,17 @@ class SkillDocumentationContractTest(unittest.TestCase):
 
     def test_skill_reply_template_assets_match_runtime_renderer_contract(self):
         fix_cases = {
+            "fixed.md": (
+                None,
+                [
+                    "<commit_hash>",
+                    "<file_path_1>,<file_path_2>",
+                    "<test_command>",
+                    "`<pass/fail + key output>`",
+                    "`<technical reasoning tied to the comment>`",
+                ],
+                "`<brief fix summary>`",
+            ),
             "fixed-p1.md": (
                 "P1",
                 [


### PR DESCRIPTION
## Summary
- Preserve severity only from trusted first-scene evidence: producer payload or original GitHub review-thread comment.
- Stop defaulting unknown severity to P2 in session intake and publish paths.
- Add explicit severity override support with conflict notes, plus raw reviewer priority evidence for non-P-scale markers.

## Tests
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m unittest discover -s tests
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec ruff check src tests
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python -m gh_address_cr --help
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python skill/scripts/cli.py --help
- PYENV_VERSION=3.10.19 /opt/homebrew/bin/pyenv exec python scripts/build_plugin_payload.py --check
