### PR TITLE
fix: use monotonic duration for telemetry metrics

### DIFF
--- a/src/gh_address_cr/core/cr_loop.py
+++ b/src/gh_address_cr/core/cr_loop.py
@@ -182,6 +182,7 @@ def run_cmd(
 
     _ = retries
     start_time = time.time()
+    start_monotonic = time.monotonic()
     try:
         result = subprocess.run(
             cmd,
@@ -192,9 +193,11 @@ def run_cmd(
             timeout=timeout,
         )
         end_time = time.time()
+        duration_seconds = time.monotonic() - start_monotonic
         exit_code = result.returncode
     except subprocess.TimeoutExpired as exc:
         end_time = time.time()
+        duration_seconds = time.monotonic() - start_monotonic
         exit_code = 124
         result = subprocess.CompletedProcess(
             args=cmd,
@@ -208,6 +211,7 @@ def run_cmd(
             command=command_label(cmd),
             start_time=start_time,
             end_time=end_time,
+            duration_seconds=duration_seconds,
             exit_code=exit_code,
         )
     except Exception as telemetry_exc:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -49,12 +49,15 @@ class ExecutionMetric:
     start_time: float
     end_time: float
     exit_code: int
+    duration_seconds: float | None = None
     is_retry: bool = False
     pid: int = 0
     execution_id: str = ""
 
     @property
     def duration(self) -> float:
+        if self.duration_seconds is not None:
+            return self.duration_seconds
         return self.end_time - self.start_time
 
     @property
@@ -155,6 +158,7 @@ class SessionTelemetry:
                 start_time=float(payload["start_time"]),
                 end_time=float(payload["end_time"]),
                 exit_code=int(payload["exit_code"]),
+                duration_seconds=float(payload["duration"]) if "duration" in payload else None,
                 is_retry=bool(payload.get("is_retry", False)),
                 pid=int(payload.get("pid", 0)),
                 execution_id=str(payload.get("execution_id") or ""),
@@ -168,6 +172,7 @@ class SessionTelemetry:
         start_time: float,
         end_time: float,
         exit_code: int,
+        duration_seconds: float | None = None,
         pid: int | None = None,
         execution_id: str | None = None,
     ) -> None:
@@ -182,6 +187,7 @@ class SessionTelemetry:
             start_time=start_time,
             end_time=end_time,
             exit_code=exit_code,
+            duration_seconds=duration_seconds,
             is_retry=is_retry,
             pid=pid if pid is not None else os.getpid(),
             execution_id=execution_id if execution_id is not None else uuid.uuid4().hex,

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -293,6 +293,22 @@ class TestTelemetry(unittest.TestCase):
 
         self.assertIsNone(mock_run.call_args.kwargs["timeout"])
 
+    @patch("subprocess.run")
+    def test_run_cmd_uses_monotonic_duration_when_wall_clock_moves_backwards(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=["ls"], returncode=0, stdout="ok", stderr="")
+
+        from gh_address_cr.core.cr_loop import run_cmd
+
+        with patch("time.time", side_effect=[1000.0, 900.0]), patch("time.monotonic", side_effect=[10.0, 12.0]):
+            run_cmd(["ls"])
+
+        tracker = SessionTelemetry.get_instance()
+        self.assertEqual(len(tracker.metrics), 1)
+        metric = tracker.metrics[0]
+        self.assertEqual(metric.start_time, 1000.0)
+        self.assertEqual(metric.end_time, 900.0)
+        self.assertEqual(metric.duration, 2.0)
+
     @patch("sys.stderr")
     @patch("gh_address_cr.core.telemetry.SessionTelemetry.record")
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary
- Keep telemetry `start_time`/`end_time` as wall-clock audit fields while measuring `duration` from a monotonic clock in `run_cmd`.
- Persist and restore the explicit `duration` value so summaries and efficiency checks are not affected by local clock jumps.
- Add a regression test for wall-clock time moving backwards during command execution.

## Root cause
Squash merge commits use the GitHub-created merge commit timestamp, so that value can differ from the original local commit time. Separately, the runtime telemetry path measured duration from wall-clock timestamps. If the local clock moved backwards, telemetry could export negative or inverted durations, making command timing appear out of order.

## Verification
- `ruff check src tests`
- `python3 -m unittest discover -s tests`
- `python3 -m gh_address_cr --help`
