### PR TITLE
fix: reapply superpowers handler removal to main

### DIFF
--- a/src/gh_address_cr/cli.py
+++ b/src/gh_address_cr/cli.py
@@ -2092,53 +2092,6 @@ def handle_agent_orchestrate(repo: str | None, passthrough: list[str]) -> int:
     return harness.handle_agent_orchestrate(repo, passthrough)
 
 
-def handle_superpowers_command(args: argparse.Namespace) -> int:
-    if args.repo != "check":
-        print(f"Unknown superpowers subcommand: {args.repo}. Did you mean 'check'?", file=sys.stderr)
-        return 2
-
-    # Simple scanner for superpowers bridge verification
-    required_skills = [
-        "verification-before-completion",
-        "test-driven-development",
-        "systematic-debugging",
-        "receiving-code-review",
-        "finishing-a-development-branch",
-    ]
-    optional_skills = [
-        "fail-fast-loud",
-        "dispatching-parallel-agents",
-        "code-review",
-    ]
-
-    global_root = Path.home() / ".agents" / "skills"
-
-    lines = [
-        "# Superpowers Bridge Report",
-        "",
-        "This report verifies the presence of required and optional skills for the gh-address-cr control plane.",
-        "",
-        "## Required Skills",
-        "",
-    ]
-
-    for skill in required_skills:
-        global_path = global_root / skill
-        status = "✅ Found" if global_path.is_dir() else "❌ Missing"
-        lines.append(f"- **{skill}**: {status} (at {global_path})")
-
-    lines.extend(["", "## Optional Skills", ""])
-    for skill in optional_skills:
-        global_path = global_root / skill
-        status = "✅ Found" if global_path.is_dir() else "⚪ Missing"
-        lines.append(f"- **{skill}**: {status} (at {global_path})")
-
-    content = "\n".join(lines) + "\n"
-    Path("superpowers-bridge-report.md").write_text(content, encoding="utf-8")
-    sys.stdout.write(content)
-    return 0
-
-
 def handle_final_gate(repo: str | None, pr_number: str | None, passthrough: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="gh-address-cr final-gate")
     auto_group = parser.add_mutually_exclusive_group()
@@ -2609,9 +2562,6 @@ def main(argv: list[str] | None = None) -> int:
             print(alias_help(args.command), end="")
             return 0
         return handle_doctor_command(args)
-
-    if args.command == "superpowers":
-        return handle_superpowers_command(args)
 
     if args.command == "final-gate":
         if args.machine or args.human or getattr(args, "lean", False) or getattr(args, "summary", False):

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -78,7 +78,6 @@ class PythonWrapperCLITest(PythonScriptTestCase):
         self.assertIn("adapter", result.stdout)
         self.assertIn("review-to-findings", result.stdout)
         self.assertIn("gh-address-cr review", result.stdout)
-        self.assertNotIn("superpowers", result.stdout)
         self.assertNotIn("cli.py review", result.stdout)
         self.assertNotIn("cr-loop", result.stdout)
         self.assertNotIn("control-plane", result.stdout)
@@ -125,12 +124,6 @@ class PythonWrapperCLITest(PythonScriptTestCase):
         self.assertIn("submit-feedback --category", result.stdout)
         self.assertNotIn("review-to-findings owner/repo 123 --input review.md", result.stdout)
 
-    def test_cli_unknown_command_hint_omits_hidden_superpowers_command(self):
-        result = self.run_cmd([sys.executable, str(CLI_PY), "unknown-command"])
-
-        self.assertEqual(result.returncode, 2)
-        self.assertIn("Supported commands:", result.stderr)
-        self.assertNotIn("superpowers", result.stderr)
 
     def test_cli_submit_feedback_passthrough_dry_run(self):
         result = self.run_cmd(

--- a/tests/test_runtime_packaging.py
+++ b/tests/test_runtime_packaging.py
@@ -185,7 +185,6 @@ class RuntimePackagingTest(PythonScriptTestCase):
         self.assertIn("submit-feedback", payload["public_commands"])
         self.assertIn("agent", payload["public_commands"])
         self.assertIn("version", payload["public_commands"])
-        self.assertNotIn("superpowers", payload["public_commands"])
         validate_capability_manifest(payload)
         self.assertIn("coordinator", payload["roles"])
         self.assertIn("triage", payload["roles"])


### PR DESCRIPTION
## Summary
- Reapply the already-reviewed PR #69 change onto `main`.
- Remove the obsolete `superpowers` CLI handler and its command-surface tests from the current release line.
- Avoid bringing over stale version or changelog state from `origin/013-remove-legacy-compat`.

## Root cause
PR #68 was squash-merged into `main`, producing merge commit `1848e34` and release `v2.9.0`. PR #69 was then merged into `013-remove-legacy-compat` instead of `main`, so Git clients show the old feature branch above `main` by commit time while the actual #69 fix is absent from `main`.

This PR cherry-picks only commit `0335064`'s code/test delta onto `main`.

## Verification
- `ruff check src tests`
- `python3 -m unittest discover -s tests`
- `python3 -m gh_address_cr --help`
