### PR TITLE
refactor: implement formal TelemetryAdapter and registry pattern

### DIFF
--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -582,7 +582,19 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     rejected_count = parse_result.rejected_count
     unsafe_seen = parse_result.unsafe_seen
     malformed_seen = parse_result.malformed_seen
-    diagnostics = [str(diag) for diag in parse_result.diagnostics]
+
+    diagnostics: list[str] = []
+    for diag in parse_result.diagnostics:
+        diag_str = str(diag)
+        if (
+            _contains_control_character(diag_str)
+            or _contains_token_marker(diag_str)
+            or _contains_private_identifier(diag_str)
+            or _looks_like_unnecessary_absolute_path(diag_str)
+        ):
+            diagnostics.append("[redacted]")
+        else:
+            diagnostics.append(diag_str)
 
     accepted: list[ExternalTelemetryEvent] = []
     accepted_fingerprints: list[str] = []
@@ -590,17 +602,17 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     observed_sessions: set[str] = set()
     duplicate_count = 0
 
-    for event in accepted_events:
+    for idx, event in enumerate(accepted_events):
         try:
             normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
         except ValueError as exc:
             message = str(exc)
             if message.startswith("UNSAFE:"):
                 unsafe_seen = True
-                diagnostics.append(f"event {event.event_id or 'unknown'}: {message.removeprefix('UNSAFE:')}")
+                diagnostics.append(f"event index {idx}: {message.removeprefix('UNSAFE:')}")
             else:
                 malformed_seen = True
-                diagnostics.append(f"event {event.event_id or 'unknown'}: {message}")
+                diagnostics.append(f"event index {idx}: {message}")
             rejected_count += 1
             continue
 

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -200,33 +200,38 @@ class TelemetryAdapter(ABC):
 
 class TelemetryAdapterRegistry:
     def __init__(self):
-        self._adapters: dict[str, TelemetryAdapter] = {}
+        self._adapters: dict[tuple[str, str | None], TelemetryAdapter] = {}
 
-    def register(self, fmt: str, adapter: TelemetryAdapter) -> None:
-        if fmt in self._adapters:
-            raise ValueError(f"Adapter for format '{fmt}' is already registered.")
-        self._adapters[fmt] = adapter
+    def register(self, fmt: str, adapter: TelemetryAdapter, source: str | None = None) -> None:
+        key = (fmt, source)
+        if key in self._adapters:
+            raise ValueError(f"Adapter for format '{fmt}' and source '{source}' is already registered.")
+        self._adapters[key] = adapter
 
-    def get_adapter(self, fmt: str) -> TelemetryAdapter | None:
-        return self._adapters.get(fmt)
+    def get_adapter(self, fmt: str, source: str | None = None) -> TelemetryAdapter | None:
+        if source is not None:
+            adapter = self._adapters.get((fmt, source))
+            if adapter is not None:
+                return adapter
+        return self._adapters.get((fmt, None))
 
-    def unregister(self, fmt: str) -> None:
-        self._adapters.pop(fmt, None)
+    def unregister(self, fmt: str, source: str | None = None) -> None:
+        self._adapters.pop((fmt, source), None)
 
 
 _registry = TelemetryAdapterRegistry()
 
 
-def register_adapter(fmt: str, adapter: TelemetryAdapter) -> None:
-    _registry.register(fmt, adapter)
+def register_adapter(fmt: str, adapter: TelemetryAdapter, source: str | None = None) -> None:
+    _registry.register(fmt, adapter, source)
 
 
-def get_adapter(fmt: str) -> TelemetryAdapter | None:
-    return _registry.get_adapter(fmt)
+def get_adapter(fmt: str, source: str | None = None) -> TelemetryAdapter | None:
+    return _registry.get_adapter(fmt, source)
 
 
-def unregister_adapter(fmt: str) -> None:
-    _registry.unregister(fmt)
+def unregister_adapter(fmt: str, source: str | None = None) -> None:
+    _registry.unregister(fmt, source)
 
 
 class GenericAgentJsonlAdapter(TelemetryAdapter):
@@ -480,7 +485,7 @@ class SessionTelemetry:
 
 def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: str, raw: str) -> dict[str, Any]:
     paths = core_paths.SessionPaths(repo, pr_number)
-    adapter = get_adapter(fmt)
+    adapter = get_adapter(fmt, source=source)
     if adapter is None:
         reported_format = _reported_format_label(fmt)
         summary = _import_summary(

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -566,7 +566,7 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
             duplicate_count=0,
             accepted_fingerprints=[],
             duplicate_fingerprints=[],
-            diagnostics=[f"Adapter parsing failed: {type(exc).__name__}: {exc}"],
+            diagnostics=[f"Adapter parsing failed: {type(exc).__name__}"],
         )
         _append_import_summary(paths, summary)
         return summary
@@ -575,7 +575,7 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     rejected_count = parse_result.rejected_count
     unsafe_seen = parse_result.unsafe_seen
     malformed_seen = parse_result.malformed_seen
-    diagnostics = parse_result.diagnostics
+    diagnostics = [str(diag) for diag in parse_result.diagnostics]
 
     accepted: list[ExternalTelemetryEvent] = []
     accepted_fingerprints: list[str] = []
@@ -936,9 +936,9 @@ def _safe_metadata(metadata: object) -> dict[str, Any]:
     _validate_safe_metadata_value(metadata)
     result = {str(key): value for key, value in metadata.items()}
     try:
-        json.dumps(result)
-    except (TypeError, OverflowError) as exc:
-        raise ValueError(f"metadata contains non-JSON serializable values: {exc}") from None
+        json.dumps(result, allow_nan=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"metadata contains non-JSON serializable or non-finite values: {exc}") from None
     return result
 
 

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -189,7 +189,7 @@ class TelemetryParseResult:
     rejected_count: int
     unsafe_seen: bool
     malformed_seen: bool
-    diagnostics: list[str]
+    diagnostics: list[Any]
 
 
 class TelemetryAdapter(ABC):
@@ -559,6 +559,8 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
 
     try:
         parse_result = adapter.parse(raw, source)
+        if not isinstance(parse_result, TelemetryParseResult):
+            raise TypeError(f"Adapter parse must return a TelemetryParseResult instance, got {type(parse_result).__name__}")
     except Exception as exc:
         summary = _import_summary(
             paths,

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -583,18 +583,30 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     unsafe_seen = parse_result.unsafe_seen
     malformed_seen = parse_result.malformed_seen
 
-    diagnostics: list[str] = []
-    for diag in parse_result.diagnostics:
-        diag_str = str(diag)
-        if (
-            _contains_control_character(diag_str)
-            or _contains_token_marker(diag_str)
-            or _contains_private_identifier(diag_str)
-            or _looks_like_unnecessary_absolute_path(diag_str)
-        ):
-            diagnostics.append("[redacted]")
-        else:
-            diagnostics.append(diag_str)
+    try:
+        if not isinstance(parse_result.diagnostics, list):
+            raise TypeError(
+                f"Adapter diagnostics must be a list, got {type(parse_result.diagnostics).__name__}"
+            )
+        diagnostics: list[str] = []
+        for diag in parse_result.diagnostics:
+            diagnostics.append(_safe_diagnostic_text(str(diag)))
+    except Exception as exc:
+        summary = _import_summary(
+            paths,
+            source=source,
+            fmt=fmt,
+            status="FAILED",
+            reason_code="MALFORMED_TELEMETRY",
+            accepted_count=0,
+            rejected_count=0,
+            duplicate_count=0,
+            accepted_fingerprints=[],
+            duplicate_fingerprints=[],
+            diagnostics=[f"Adapter diagnostics processing failed: {type(exc).__name__}"],
+        )
+        _append_import_summary(paths, summary)
+        return summary
 
     accepted: list[ExternalTelemetryEvent] = []
     accepted_fingerprints: list[str] = []
@@ -612,10 +624,10 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
                 message = str(exc)
                 if message.startswith("UNSAFE:"):
                     unsafe_seen = True
-                    diagnostics.append(f"event index {idx}: {message.removeprefix('UNSAFE:')}")
+                    diagnostics.append(f"event index {idx}: {_safe_diagnostic_text(message.removeprefix('UNSAFE:'))}")
                 else:
                     malformed_seen = True
-                    diagnostics.append(f"event index {idx}: {message}")
+                    diagnostics.append(f"event index {idx}: {_safe_diagnostic_text(message)}")
                 rejected_count += 1
                 continue
 
@@ -978,6 +990,17 @@ def _safe_metadata(metadata: object) -> dict[str, Any]:
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"metadata contains non-JSON serializable or non-finite values: {exc}") from None
     return result
+
+
+def _safe_diagnostic_text(value: str) -> str:
+    if (
+        _contains_control_character(value)
+        or _contains_token_marker(value)
+        or _contains_private_identifier(value)
+        or _looks_like_unnecessary_absolute_path(value)
+    ):
+        return "[redacted]"
+    return value
 
 
 def _validate_safe_metadata_value(value: object, *, key_path: str = "metadata") -> None:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -183,20 +183,13 @@ UNSAFE_METADATA_KEY_MARKERS = (
 TOKEN_MARKERS = ("ghp_", "github_pat_", "xoxb-", "token=")
 
 
+@dataclass
 class TelemetryParseResult:
-    def __init__(
-        self,
-        events: list[ExternalTelemetryEvent],
-        rejected_count: int,
-        unsafe_seen: bool,
-        malformed_seen: bool,
-        diagnostics: list[str],
-    ):
-        self.events = events
-        self.rejected_count = rejected_count
-        self.unsafe_seen = unsafe_seen
-        self.malformed_seen = malformed_seen
-        self.diagnostics = diagnostics
+    events: list[ExternalTelemetryEvent]
+    rejected_count: int
+    unsafe_seen: bool
+    malformed_seen: bool
+    diagnostics: list[str]
 
 
 class TelemetryAdapter(ABC):
@@ -210,10 +203,15 @@ class TelemetryAdapterRegistry:
         self._adapters: dict[str, TelemetryAdapter] = {}
 
     def register(self, fmt: str, adapter: TelemetryAdapter) -> None:
+        if fmt in self._adapters:
+            raise ValueError(f"Adapter for format '{fmt}' is already registered.")
         self._adapters[fmt] = adapter
 
     def get_adapter(self, fmt: str) -> TelemetryAdapter | None:
         return self._adapters.get(fmt)
+
+    def unregister(self, fmt: str) -> None:
+        self._adapters.pop(fmt, None)
 
 
 _registry = TelemetryAdapterRegistry()
@@ -225,6 +223,10 @@ def register_adapter(fmt: str, adapter: TelemetryAdapter) -> None:
 
 def get_adapter(fmt: str) -> TelemetryAdapter | None:
     return _registry.get_adapter(fmt)
+
+
+def unregister_adapter(fmt: str) -> None:
+    _registry.unregister(fmt)
 
 
 class GenericAgentJsonlAdapter(TelemetryAdapter):
@@ -564,14 +566,27 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     duplicate_count = 0
 
     for event in accepted_events:
-        observed_sessions.add(event.source_session_id)
-        if event.identity in existing_fingerprints:
-            duplicate_count += 1
-            duplicate_fingerprints.append(event.identity)
+        try:
+            normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
+        except ValueError as exc:
+            message = str(exc)
+            if message.startswith("UNSAFE:"):
+                unsafe_seen = True
+                diagnostics.append(f"event {event.event_id or 'unknown'}: {message.removeprefix('UNSAFE:')}")
+            else:
+                malformed_seen = True
+                diagnostics.append(f"event {event.event_id or 'unknown'}: {message}")
+            rejected_count += 1
             continue
-        existing_fingerprints.add(event.identity)
-        accepted_fingerprints.append(event.identity)
-        accepted.append(event)
+
+        observed_sessions.add(normalized_event.source_session_id)
+        if normalized_event.identity in existing_fingerprints:
+            duplicate_count += 1
+            duplicate_fingerprints.append(normalized_event.identity)
+            continue
+        existing_fingerprints.add(normalized_event.identity)
+        accepted_fingerprints.append(normalized_event.identity)
+        accepted.append(normalized_event)
 
     ambiguous_seen = len(observed_sessions) > 1
     if unsafe_seen:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from gh_address_cr.core import paths as core_paths
@@ -180,6 +181,99 @@ UNSAFE_METADATA_KEY_MARKERS = (
     "prompt",
 )
 TOKEN_MARKERS = ("ghp_", "github_pat_", "xoxb-", "token=")
+
+
+class TelemetryParseResult:
+    def __init__(
+        self,
+        events: list[ExternalTelemetryEvent],
+        rejected_count: int,
+        unsafe_seen: bool,
+        malformed_seen: bool,
+        diagnostics: list[str],
+    ):
+        self.events = events
+        self.rejected_count = rejected_count
+        self.unsafe_seen = unsafe_seen
+        self.malformed_seen = malformed_seen
+        self.diagnostics = diagnostics
+
+
+class TelemetryAdapter(ABC):
+    @abstractmethod
+    def parse(self, raw: str, source: str) -> TelemetryParseResult:
+        pass
+
+
+class TelemetryAdapterRegistry:
+    def __init__(self):
+        self._adapters: dict[str, TelemetryAdapter] = {}
+
+    def register(self, fmt: str, adapter: TelemetryAdapter) -> None:
+        self._adapters[fmt] = adapter
+
+    def get_adapter(self, fmt: str) -> TelemetryAdapter | None:
+        return self._adapters.get(fmt)
+
+
+_registry = TelemetryAdapterRegistry()
+
+
+def register_adapter(fmt: str, adapter: TelemetryAdapter) -> None:
+    _registry.register(fmt, adapter)
+
+
+def get_adapter(fmt: str) -> TelemetryAdapter | None:
+    return _registry.get_adapter(fmt)
+
+
+class GenericAgentJsonlAdapter(TelemetryAdapter):
+    def parse(self, raw: str, source: str) -> TelemetryParseResult:
+        accepted: list[ExternalTelemetryEvent] = []
+        diagnostics: list[str] = []
+        rejected_count = 0
+        unsafe_seen = False
+        malformed_seen = False
+
+        for line_number, line in enumerate(raw.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                payload = _json_loads_strict(line)
+            except json.JSONDecodeError as exc:
+                malformed_seen = True
+                rejected_count += 1
+                diagnostics.append(f"line {line_number}: invalid JSON: {exc.msg}")
+                continue
+            except ValueError as exc:
+                malformed_seen = True
+                rejected_count += 1
+                diagnostics.append(f"line {line_number}: invalid JSON: {exc}")
+                continue
+            try:
+                event = _normalize_external_event(payload, declared_source=source)
+            except ValueError as exc:
+                message = str(exc)
+                if message.startswith("UNSAFE:"):
+                    unsafe_seen = True
+                    diagnostics.append(f"line {line_number}: {message.removeprefix('UNSAFE:')}")
+                else:
+                    malformed_seen = True
+                    diagnostics.append(f"line {line_number}: {message}")
+                rejected_count += 1
+                continue
+            accepted.append(event)
+
+        return TelemetryParseResult(
+            events=accepted,
+            rejected_count=rejected_count,
+            unsafe_seen=unsafe_seen,
+            malformed_seen=malformed_seen,
+            diagnostics=diagnostics,
+        )
+
+
+register_adapter("agent-jsonl", GenericAgentJsonlAdapter())
 
 
 class SessionTelemetry:
@@ -384,7 +478,8 @@ class SessionTelemetry:
 
 def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: str, raw: str) -> dict[str, Any]:
     paths = core_paths.SessionPaths(repo, pr_number)
-    if fmt != "agent-jsonl":
+    adapter = get_adapter(fmt)
+    if adapter is None:
         reported_format = _reported_format_label(fmt)
         summary = _import_summary(
             paths,
@@ -454,43 +549,21 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
         _append_import_summary_if_available(paths, summary)
         return summary
     existing_fingerprints.update(event.identity for event in existing)
+
+    parse_result = adapter.parse(raw, source)
+    accepted_events = parse_result.events
+    rejected_count = parse_result.rejected_count
+    unsafe_seen = parse_result.unsafe_seen
+    malformed_seen = parse_result.malformed_seen
+    diagnostics = parse_result.diagnostics
+
     accepted: list[ExternalTelemetryEvent] = []
     accepted_fingerprints: list[str] = []
     duplicate_fingerprints: list[str] = []
-    diagnostics: list[str] = []
     observed_sessions: set[str] = set()
-    rejected_count = 0
     duplicate_count = 0
-    unsafe_seen = False
-    malformed_seen = False
 
-    for line_number, line in enumerate(raw.splitlines(), start=1):
-        if not line.strip():
-            continue
-        try:
-            payload = _json_loads_strict(line)
-        except json.JSONDecodeError as exc:
-            malformed_seen = True
-            rejected_count += 1
-            diagnostics.append(f"line {line_number}: invalid JSON: {exc.msg}")
-            continue
-        except ValueError as exc:
-            malformed_seen = True
-            rejected_count += 1
-            diagnostics.append(f"line {line_number}: invalid JSON: {exc}")
-            continue
-        try:
-            event = _normalize_external_event(payload, declared_source=source)
-        except ValueError as exc:
-            message = str(exc)
-            if message.startswith("UNSAFE:"):
-                unsafe_seen = True
-                diagnostics.append(f"line {line_number}: {message.removeprefix('UNSAFE:')}")
-            else:
-                malformed_seen = True
-                diagnostics.append(f"line {line_number}: {message}")
-            rejected_count += 1
-            continue
+    for event in accepted_events:
         observed_sessions.add(event.source_session_id)
         if event.identity in existing_fingerprints:
             duplicate_count += 1

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -552,7 +552,25 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
         return summary
     existing_fingerprints.update(event.identity for event in existing)
 
-    parse_result = adapter.parse(raw, source)
+    try:
+        parse_result = adapter.parse(raw, source)
+    except Exception as exc:
+        summary = _import_summary(
+            paths,
+            source=source,
+            fmt=fmt,
+            status="FAILED",
+            reason_code="MALFORMED_TELEMETRY",
+            accepted_count=0,
+            rejected_count=0,
+            duplicate_count=0,
+            accepted_fingerprints=[],
+            duplicate_fingerprints=[],
+            diagnostics=[f"Adapter parsing failed: {type(exc).__name__}: {exc}"],
+        )
+        _append_import_summary(paths, summary)
+        return summary
+
     accepted_events = parse_result.events
     rejected_count = parse_result.rejected_count
     unsafe_seen = parse_result.unsafe_seen
@@ -916,7 +934,12 @@ def _safe_metadata(metadata: object) -> dict[str, Any]:
     if not isinstance(metadata, dict):
         raise ValueError("metadata must be an object")
     _validate_safe_metadata_value(metadata)
-    return {str(key): value for key, value in metadata.items()}
+    result = {str(key): value for key, value in metadata.items()}
+    try:
+        json.dumps(result)
+    except (TypeError, OverflowError) as exc:
+        raise ValueError(f"metadata contains non-JSON serializable values: {exc}") from None
+    return result
 
 
 def _validate_safe_metadata_value(value: object, *, key_path: str = "metadata") -> None:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -602,28 +602,47 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     observed_sessions: set[str] = set()
     duplicate_count = 0
 
-    for idx, event in enumerate(accepted_events):
-        try:
-            normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
-        except ValueError as exc:
-            message = str(exc)
-            if message.startswith("UNSAFE:"):
-                unsafe_seen = True
-                diagnostics.append(f"event index {idx}: {message.removeprefix('UNSAFE:')}")
-            else:
-                malformed_seen = True
-                diagnostics.append(f"event index {idx}: {message}")
-            rejected_count += 1
-            continue
+    try:
+        for idx, event in enumerate(accepted_events):
+            if not isinstance(event, ExternalTelemetryEvent):
+                raise TypeError(f"Event must be an ExternalTelemetryEvent instance, got {type(event).__name__}")
+            try:
+                normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
+            except ValueError as exc:
+                message = str(exc)
+                if message.startswith("UNSAFE:"):
+                    unsafe_seen = True
+                    diagnostics.append(f"event index {idx}: {message.removeprefix('UNSAFE:')}")
+                else:
+                    malformed_seen = True
+                    diagnostics.append(f"event index {idx}: {message}")
+                rejected_count += 1
+                continue
 
-        observed_sessions.add(normalized_event.source_session_id)
-        if normalized_event.identity in existing_fingerprints:
-            duplicate_count += 1
-            duplicate_fingerprints.append(normalized_event.identity)
-            continue
-        existing_fingerprints.add(normalized_event.identity)
-        accepted_fingerprints.append(normalized_event.identity)
-        accepted.append(normalized_event)
+            observed_sessions.add(normalized_event.source_session_id)
+            if normalized_event.identity in existing_fingerprints:
+                duplicate_count += 1
+                duplicate_fingerprints.append(normalized_event.identity)
+                continue
+            existing_fingerprints.add(normalized_event.identity)
+            accepted_fingerprints.append(normalized_event.identity)
+            accepted.append(normalized_event)
+    except Exception as exc:
+        summary = _import_summary(
+            paths,
+            source=source,
+            fmt=fmt,
+            status="FAILED",
+            reason_code="MALFORMED_TELEMETRY",
+            accepted_count=0,
+            rejected_count=0,
+            duplicate_count=0,
+            accepted_fingerprints=[],
+            duplicate_fingerprints=[],
+            diagnostics=[f"Adapter event processing failed: {type(exc).__name__}"],
+        )
+        _append_import_summary(paths, summary)
+        return summary
 
     ambiguous_seen = len(observed_sessions) > 1
     if unsafe_seen:
@@ -967,6 +986,14 @@ def _validate_safe_metadata_value(value: object, *, key_path: str = "metadata") 
             key_text = str(key)
             if _is_unsafe_metadata_key(key_text):
                 raise ValueError(f"UNSAFE:unsafe metadata field: {key_text}")
+            if _contains_token_marker(key_text):
+                raise ValueError(f"UNSAFE:unsafe token in metadata field key: {key_text}")
+            if _contains_private_identifier(key_text):
+                raise ValueError(f"UNSAFE:unsafe private identifier in metadata field key: {key_text}")
+            if _looks_like_unnecessary_absolute_path(key_text):
+                raise ValueError(f"UNSAFE:unsafe absolute path in metadata field key: {key_text}")
+            if _contains_control_character(key_text):
+                raise ValueError(f"UNSAFE:unsafe control character in metadata field key: {key_text}")
             _validate_safe_metadata_value(nested, key_path=f"{key_path}.{key_text}")
         return
     if isinstance(value, list):

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2216,5 +2216,67 @@ class TestTelemetry(unittest.TestCase):
             self.assertEqual(tracker.metrics[0].exit_code, 0)
             self.assertNotIn("ghp_secret", tracker.metrics[0].command)
 
+    def test_custom_telemetry_adapter_registration(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            _registry,
+        )
+        
+        class MockCustomAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                parts = raw.strip().split(":")
+                if len(parts) != 4:
+                    return TelemetryParseResult(
+                        events=[],
+                        rejected_count=1,
+                        unsafe_seen=False,
+                        malformed_seen=True,
+                        diagnostics=["malformed mock payload"],
+                    )
+                session_id, event_id, operation, duration_str = parts
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id=session_id,
+                    event_id=event_id,
+                    kind="tool_call",
+                    operation=operation,
+                    status="success",
+                    duration_ms=int(duration_str),
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[],
+                )
+
+        register_adapter("mock-custom", MockCustomAdapter())
+        
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                raw_payload = "session-abc:event-123:custom_op:4500"
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-custom",
+                    raw=raw_payload,
+                )
+                self.assertEqual(result["status"], "SUCCESS")
+                self.assertEqual(result["accepted_count"], 1)
+                
+                report = build_efficiency_report("octo/example", "77")
+                self.assertEqual(report["total_events"], 1)
+                self.assertEqual(report["total_observed_duration_ms"], 4500)
+                self.assertEqual(report["slowest_operations"][0]["operation"], "custom_op")
+        
+        if "mock-custom" in _registry._adapters:
+            del _registry._adapters["mock-custom"]
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2601,5 +2601,34 @@ class TestTelemetry(unittest.TestCase):
                 # Ensure the ValueError diagnostic element was converted to a string and did not crash json.dumps
                 self.assertIn("Non-JSON error object", result["diagnostics"])
 
+    def test_custom_telemetry_adapter_invalid_return_type_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+        )
+
+        class MockInvalidReturnAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                # Invalid: returns None instead of a TelemetryParseResult instance
+                return None
+
+        register_adapter("mock-invalid-ret", MockInvalidReturnAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-invalid-ret"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-invalid-ret",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertTrue(any("TypeError: Adapter parse must return a TelemetryParseResult instance, got NoneType" in diag for diag in result["diagnostics"]))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2222,7 +2222,7 @@ class TestTelemetry(unittest.TestCase):
             TelemetryParseResult,
             ExternalTelemetryEvent,
             register_adapter,
-            _registry,
+            unregister_adapter,
         )
         
         class MockCustomAdapter(TelemetryAdapter):
@@ -2256,6 +2256,7 @@ class TestTelemetry(unittest.TestCase):
                 )
 
         register_adapter("mock-custom", MockCustomAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-custom"))
         
         with tempfile.TemporaryDirectory() as tmp:
             with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
@@ -2274,9 +2275,74 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(report["total_events"], 1)
                 self.assertEqual(report["total_observed_duration_ms"], 4500)
                 self.assertEqual(report["slowest_operations"][0]["operation"], "custom_op")
+
+    def test_custom_telemetry_adapter_registration_duplicate_fails(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            register_adapter,
+            unregister_adapter,
+        )
         
-        if "mock-custom" in _registry._adapters:
-            del _registry._adapters["mock-custom"]
+        class MockCustomAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                return TelemetryParseResult([], 0, False, False, [])
+
+        register_adapter("mock-dup", MockCustomAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-dup"))
+
+        with self.assertRaises(ValueError) as context:
+            register_adapter("mock-dup", MockCustomAdapter())
+        self.assertIn("already registered", str(context.exception))
+
+    def test_custom_telemetry_adapter_unsafe_normalization_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+        
+        class MockUnsafeAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                # Return an event containing unsafe metadata keys (e.g. password)
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-unsafe",
+                    kind="tool_call",
+                    operation="op",
+                    status="success",
+                    duration_ms=100,
+                    metadata={"password": "should_be_rejected"}
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[],
+                )
+
+        register_adapter("mock-unsafe", MockUnsafeAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-unsafe"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-unsafe",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertEqual(result["rejected_count"], 1)
+                self.assertTrue(any("unsafe key" in diag or "password" in diag for diag in result["diagnostics"]))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2628,7 +2628,7 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["status"], "FAILED")
                 self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
                 self.assertEqual(result["accepted_count"], 0)
-                self.assertTrue(any("TypeError: Adapter parse must return a TelemetryParseResult instance, got NoneType" in diag for diag in result["diagnostics"]))
+                self.assertTrue(any("Adapter parsing failed: TypeError" in diag for diag in result["diagnostics"]))
 
     def test_custom_telemetry_adapter_diagnostics_sanitization(self):
         from gh_address_cr.core.telemetry import (
@@ -2717,6 +2717,88 @@ class TestTelemetry(unittest.TestCase):
                 
                 self.assertFalse(any("unsafe-secret-token-sk-12345" in diag for diag in result["diagnostics"]))
                 self.assertTrue(any("event index 0" in diag for diag in result["diagnostics"]))
+
+    def test_custom_telemetry_adapter_invalid_event_type_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+            TelemetryParseResult,
+        )
+
+        class MockInvalidEventAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                return TelemetryParseResult(
+                    events=[{"kind": "tool_call", "operation": "safe", "status": "success"}],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[]
+                )
+
+        register_adapter("mock-invalid-event", MockInvalidEventAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-invalid-event"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-invalid-event",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertTrue(any("Adapter event processing failed: TypeError" in diag for diag in result["diagnostics"]))
+
+    def test_import_external_telemetry_rejects_unsafe_metadata_keys(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+        )
+
+        class MockUnsafeMetadataKeyAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                return TelemetryParseResult(
+                    events=[
+                        ExternalTelemetryEvent(
+                            schema_version="1.0",
+                            source="custom-source",
+                            source_session_id="run-1",
+                            event_id="evt-1",
+                            kind="tool_call",
+                            operation="safe operation",
+                            duration_ms=10,
+                            status="success",
+                            metadata={"ghp_unsafe_token_as_key": "some_value"},
+                        )
+                    ],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[]
+                )
+
+        register_adapter("mock-unsafe-meta-key", MockUnsafeMetadataKeyAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-unsafe-meta-key"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-unsafe-meta-key",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
+                self.assertEqual(result["rejected_count"], 1)
+                self.assertTrue(any("unsafe token in metadata field key" in diag for diag in result["diagnostics"]))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2669,6 +2669,54 @@ class TestTelemetry(unittest.TestCase):
                 redacted_count = sum(1 for diag in result["diagnostics"] if diag == "[redacted]")
                 self.assertEqual(redacted_count, 3)
 
+    def test_custom_telemetry_adapter_invalid_diagnostics_container_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+        )
+
+        class MockInvalidDiagnosticsAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-invalid-diagnostics",
+                    kind="tool_call",
+                    operation="op",
+                    status="success",
+                    duration_ms=100,
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=None,
+                )
+
+        register_adapter("mock-invalid-diag-container", MockInvalidDiagnosticsAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-invalid-diag-container"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-invalid-diag-container",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertTrue(
+                    any("Adapter diagnostics processing failed: TypeError" in diag for diag in result["diagnostics"])
+                )
+
     def test_import_external_telemetry_event_id_redaction_in_normalization_diagnostics(self):
         from gh_address_cr.core.telemetry import (
             TelemetryAdapter,
@@ -2686,11 +2734,11 @@ class TestTelemetry(unittest.TestCase):
                             schema_version="1.0",
                             source="custom-source",
                             source_session_id="run-1",
-                            event_id="unsafe-secret-token-sk-12345",
+                            event_id="ghp_unsafe_event_id",
                             kind="tool_call",
                             operation="safe operation",
                             duration_ms=10,
-                            status="invalid-status",
+                            status="success",
                         )
                     ],
                     rejected_count=0,
@@ -2715,7 +2763,7 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
                 self.assertEqual(result["rejected_count"], 1)
                 
-                self.assertFalse(any("unsafe-secret-token-sk-12345" in diag for diag in result["diagnostics"]))
+                self.assertFalse(any("ghp_unsafe_event_id" in diag for diag in result["diagnostics"]))
                 self.assertTrue(any("event index 0" in diag for diag in result["diagnostics"]))
 
     def test_custom_telemetry_adapter_invalid_event_type_rejection(self):
@@ -2798,7 +2846,8 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["status"], "FAILED")
                 self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
                 self.assertEqual(result["rejected_count"], 1)
-                self.assertTrue(any("unsafe token in metadata field key" in diag for diag in result["diagnostics"]))
+                self.assertFalse(any("ghp_unsafe_token_as_key" in diag for diag in result["diagnostics"]))
+                self.assertTrue(any("[redacted]" in diag for diag in result["diagnostics"]))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2630,5 +2630,93 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["accepted_count"], 0)
                 self.assertTrue(any("TypeError: Adapter parse must return a TelemetryParseResult instance, got NoneType" in diag for diag in result["diagnostics"]))
 
+    def test_custom_telemetry_adapter_diagnostics_sanitization(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+            TelemetryParseResult,
+        )
+
+        class MockSensitiveDiagnosticsAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                return TelemetryParseResult(
+                    events=[],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[
+                        "Safe diagnostic message",
+                        "Rejected secret token: github_token=123",
+                        "Path failure: /Users/alice/private/key.pem",
+                        "User info: username=bob",
+                    ]
+                )
+
+        register_adapter("mock-sensitive-diag", MockSensitiveDiagnosticsAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-sensitive-diag"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-sensitive-diag",
+                    raw="dummy_payload",
+                )
+                self.assertIn("Safe diagnostic message", result["diagnostics"])
+                redacted_count = sum(1 for diag in result["diagnostics"] if diag == "[redacted]")
+                self.assertEqual(redacted_count, 3)
+
+    def test_import_external_telemetry_event_id_redaction_in_normalization_diagnostics(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            register_adapter,
+            unregister_adapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+        )
+
+        class MockUnsafeEventIdAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str):
+                return TelemetryParseResult(
+                    events=[
+                        ExternalTelemetryEvent(
+                            schema_version="1.0",
+                            source="custom-source",
+                            source_session_id="run-1",
+                            event_id="unsafe-secret-token-sk-12345",
+                            kind="tool_call",
+                            operation="safe operation",
+                            duration_ms=10,
+                            status="invalid-status",
+                        )
+                    ],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[]
+                )
+
+        register_adapter("mock-unsafe-event-id", MockUnsafeEventIdAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-unsafe-event-id"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-unsafe-event-id",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
+                self.assertEqual(result["rejected_count"], 1)
+                
+                self.assertFalse(any("unsafe-secret-token-sk-12345" in diag for diag in result["diagnostics"]))
+                self.assertTrue(any("event index 0" in diag for diag in result["diagnostics"]))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2421,7 +2421,104 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["status"], "FAILED")
                 self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
                 self.assertEqual(result["accepted_count"], 0)
-                self.assertTrue(any("Adapter parsing failed: ValueError: Int conversion failed" in diag for diag in result["diagnostics"]))
+                # Confirm we only expose the exception type name and NOT the raw exception message for safety
+                self.assertTrue(any(diag == "Adapter parsing failed: ValueError" for diag in result["diagnostics"]))
+
+    def test_custom_telemetry_adapter_nan_metadata_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+        
+        class MockNaNMetadataAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                # Return metadata with a NaN float constant
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-nan",
+                    kind="tool_call",
+                    operation="op",
+                    status="success",
+                    duration_ms=100,
+                    metadata={"ratio": float("nan")}
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[],
+                )
+
+        register_adapter("mock-nan", MockNaNMetadataAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-nan"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-nan",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertEqual(result["rejected_count"], 1)
+                self.assertTrue(any("non-finite" in diag for diag in result["diagnostics"]))
+
+    def test_custom_telemetry_adapter_non_json_diagnostics_coercion(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+        
+        class MockNonJsonDiagnosticsAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-diag-coerce",
+                    kind="tool_call",
+                    operation="op",
+                    status="success",
+                    duration_ms=100,
+                )
+                # Return a diagnostic item that is an Exception instance rather than a string
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[ValueError("Non-JSON error object")],
+                )
+
+        register_adapter("mock-diag-coerce", MockNonJsonDiagnosticsAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-diag-coerce"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-diag-coerce",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "SUCCESS")
+                self.assertEqual(result["accepted_count"], 1)
+                # Ensure the ValueError diagnostic element was converted to a string and did not crash json.dumps
+                self.assertIn("Non-JSON error object", result["diagnostics"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2295,6 +2295,87 @@ class TestTelemetry(unittest.TestCase):
             register_adapter("mock-dup", MockCustomAdapter())
         self.assertIn("already registered", str(context.exception))
 
+        # Check that registering the same format with a specific source also raises error on duplicate
+        register_adapter("mock-dup", MockCustomAdapter(), source="special-src")
+        self.addCleanup(lambda: unregister_adapter("mock-dup", source="special-src"))
+
+        with self.assertRaises(ValueError) as context_src:
+            register_adapter("mock-dup", MockCustomAdapter(), source="special-src")
+        self.assertIn("already registered", str(context_src.exception))
+
+    def test_custom_telemetry_adapter_source_override(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+
+        class DefaultMockAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-1",
+                    event_id="event-1",
+                    kind="tool_call",
+                    operation="op-default",
+                    status="success",
+                    duration_ms=1000,
+                )
+                return TelemetryParseResult([event], 0, False, False, [])
+
+        class SpecialMockAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-1",
+                    event_id="event-1",
+                    kind="tool_call",
+                    operation="op-override",
+                    status="success",
+                    duration_ms=2000,
+                )
+                return TelemetryParseResult([event], 0, False, False, [])
+
+        # Register format default adapter
+        register_adapter("multi-source", DefaultMockAdapter())
+        self.addCleanup(lambda: unregister_adapter("multi-source"))
+
+        # Register source-specific override adapter
+        register_adapter("multi-source", SpecialMockAdapter(), source="special-host")
+        self.addCleanup(lambda: unregister_adapter("multi-source", source="special-host"))
+
+        # 1. Verification with default fallback
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result_default = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="ordinary-host",
+                    fmt="multi-source",
+                    raw="dummy",
+                )
+                self.assertEqual(result_default["status"], "SUCCESS")
+                report_default = build_efficiency_report("octo/example", "77")
+                self.assertEqual(report_default["slowest_operations"][0]["operation"], "op-default")
+
+        # 2. Verification with source override priority
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result_override = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="special-host",
+                    fmt="multi-source",
+                    raw="dummy",
+                )
+                self.assertEqual(result_override["status"], "SUCCESS")
+                report_override = build_efficiency_report("octo/example", "77")
+                self.assertEqual(report_override["slowest_operations"][0]["operation"], "op-override")
+
     def test_custom_telemetry_adapter_unsafe_normalization_rejection(self):
         from gh_address_cr.core.telemetry import (
             TelemetryAdapter,

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2344,5 +2344,84 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["rejected_count"], 1)
                 self.assertTrue(any("unsafe key" in diag or "password" in diag for diag in result["diagnostics"]))
 
+    def test_custom_telemetry_adapter_non_json_metadata_rejection(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+        
+        class MockNonJsonMetadataAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                # Return metadata with a non-serializable datetime object
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-non-json",
+                    kind="tool_call",
+                    operation="op",
+                    status="success",
+                    duration_ms=100,
+                    metadata={"created_at": datetime.now()}
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[],
+                )
+
+        register_adapter("mock-non-json", MockNonJsonMetadataAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-non-json"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-non-json",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertEqual(result["rejected_count"], 1)
+                self.assertTrue(any("non-JSON serializable" in diag for diag in result["diagnostics"]))
+
+    def test_custom_telemetry_adapter_parsing_exception_handling(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            register_adapter,
+            unregister_adapter,
+        )
+        
+        class MockCrashedAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                # Raise ValueError simulating a parsing crash
+                raise ValueError("Int conversion failed on dummy payload")
+
+        register_adapter("mock-crash", MockCrashedAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-crash"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-crash",
+                    raw="dummy_payload",
+                )
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "MALFORMED_TELEMETRY")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertTrue(any("Adapter parsing failed: ValueError: Int conversion failed" in diag for diag in result["diagnostics"]))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses #82.

Refactors the external telemetry ingestion system by introducing a formal `TelemetryAdapter` abstract base class and `TelemetryAdapterRegistry` pattern.

### Changes
- Defined `TelemetryAdapter` and `TelemetryParseResult` under `src/gh_address_cr/core/telemetry.py`.
- Introduced `TelemetryAdapterRegistry` and adapter helper registration methods.
- Refactored current `agent-jsonl` parsing logic into `GenericAgentJsonlAdapter` and registered it.
- Updated `import_external_telemetry` to resolve adapters using the registry.
- Added comprehensive unit tests in `tests/core/test_telemetry.py` to verify registry behavior, parsing, and custom adapter support.

All verification steps passed successfully.
