### PR TITLE
perf: stream telemetry file reads

### DIFF
--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -460,6 +460,7 @@ class SessionTelemetry:
         try:
             if not path.is_file():
                 return
+            loaded_metrics: list[ExecutionMetric] = []
             with path.open("r", encoding="utf-8") as handle:
                 for line in handle:
                     if not line.strip():
@@ -470,7 +471,8 @@ class SessionTelemetry:
                         continue
                     metric = self._metric_from_payload(payload)
                     if metric is not None:
-                        self.metrics.append(metric)
+                        loaded_metrics.append(metric)
+            self.metrics.extend(loaded_metrics)
         except OSError:
             return
 

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -460,19 +460,19 @@ class SessionTelemetry:
         try:
             if not path.is_file():
                 return
-            lines = path.read_text(encoding="utf-8").splitlines()
+            with path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    if not line.strip():
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    metric = self._metric_from_payload(payload)
+                    if metric is not None:
+                        self.metrics.append(metric)
         except OSError:
             return
-        for line in lines:
-            if not line.strip():
-                continue
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            metric = self._metric_from_payload(payload)
-            if metric is not None:
-                self.metrics.append(metric)
 
     @staticmethod
     def _metric_from_payload(payload: object) -> ExecutionMetric | None:
@@ -1378,21 +1378,21 @@ def _load_external_events_with_diagnostics(paths: core_paths.SessionPaths) -> tu
     events: list[ExternalTelemetryEvent] = []
     diagnostics: list[str] = []
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    payload = _json_loads_strict(line)
+                    if not isinstance(payload, dict):
+                        raise ValueError("record must be a JSON object")
+                    events.append(_normalize_external_event(payload, declared_source=str(payload.get("source") or "")))
+                except json.JSONDecodeError as exc:
+                    diagnostics.append(f"external telemetry line {line_number}: invalid JSON: {exc.msg}")
+                except ValueError as exc:
+                    diagnostics.append(f"external telemetry line {line_number}: {exc}")
     except OSError as exc:
         return [], [f"external telemetry unreadable: {exc}"]
-    for line_number, line in enumerate(lines, start=1):
-        if not line.strip():
-            continue
-        try:
-            payload = _json_loads_strict(line)
-            if not isinstance(payload, dict):
-                raise ValueError("record must be a JSON object")
-            events.append(_normalize_external_event(payload, declared_source=str(payload.get("source") or "")))
-        except json.JSONDecodeError as exc:
-            diagnostics.append(f"external telemetry line {line_number}: invalid JSON: {exc.msg}")
-        except ValueError as exc:
-            diagnostics.append(f"external telemetry line {line_number}: {exc}")
     return events, diagnostics
 
 

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1997,6 +1997,38 @@ class TestTelemetry(unittest.TestCase):
 
             self.assertEqual(tracker.metrics, [])
 
+    def test_configure_file_does_not_append_partial_metrics_when_stream_read_fails_midway(self):
+        class _BrokenTelemetryStream:
+            def __init__(self, first_line: str):
+                self._first_line = first_line
+                self._yielded = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return self._first_line
+                raise OSError("denied")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            telemetry_file = Path(tmp) / "telemetry.jsonl"
+            telemetry_file.write_text("{}", encoding="utf-8")
+            tracker = SessionTelemetry.get_instance()
+            valid_line = '{"command":"pytest","start_time":0.0,"end_time":1.0,"exit_code":0}\n'
+
+            with patch.object(Path, "open", return_value=_BrokenTelemetryStream(valid_line)):
+                tracker.configure_file(telemetry_file)
+
+            self.assertEqual(tracker.metrics, [])
+
     def test_record_is_fail_open_when_metric_persistence_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             telemetry_file = Path(tmp) / "telemetry.jsonl"

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1992,7 +1992,7 @@ class TestTelemetry(unittest.TestCase):
             telemetry_file.write_text("{}", encoding="utf-8")
             tracker = SessionTelemetry.get_instance()
 
-            with patch.object(Path, "read_text", side_effect=OSError("denied")):
+            with patch.object(Path, "open", side_effect=OSError("denied")):
                 tracker.configure_file(telemetry_file)
 
             self.assertEqual(tracker.metrics, [])


### PR DESCRIPTION
## Summary
- switch telemetry metric loading to stream lines with `Path.open()` instead of `read_text().splitlines()`
- switch external telemetry loading to stream lines in-place while preserving per-line diagnostics
- update fail-open unit test to patch `Path.open` (matching the new loader path)

## Why this change
`telemetry.jsonl` and `external-telemetry.jsonl` can grow large in long-running sessions. Streaming removes full-file materialization, reducing peak memory and avoiding an extra large-string split pass.

## Validation
- `ruff check src tests`
- `python3 -m unittest discover -s tests`
- `python3 -m gh_address_cr --help`
