### PR TITLE
docs: update AGENTS workflow commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,11 @@ Public behavior changes MUST update code, docs, and executable tests together. T
 
 ### Verification Commands
 Before claiming work is complete, run these local checks:
-- **Linting**: `ruff check src tests` (configured in `pyproject.toml`).
+- **Linting**: `ruff check src tests scripts/build_plugin_payload.py` (configured in `pyproject.toml`).
 - **Unit Tests**: `python3 -m unittest discover -s tests`.
 - **CLI Smoke Test**: `python3 -m gh_address_cr --help`.
+- **Agent Contract Smoke Test**: `python3 -m gh_address_cr agent manifest`.
+- **Plugin Payload Checks**: `python3 scripts/build_plugin_payload.py --output dist/plugin/gh-address-cr` and `python3 scripts/build_plugin_payload.py --check`.
 
 ### Git Workflow
 - **Status Check**: Always run `git status` before starting work.
@@ -69,6 +71,7 @@ Before claiming work is complete, run these local checks:
 - **Fail fast**: Do not add silent fallbacks or hidden behavior changes.
 - **Smallest change**: Default to the smallest safe change. Avoid opportunistic refactors.
 - **Contract discipline**: If a public or agent-facing contract changes, update docs and tests together.
+- **Skill/runtime feedback**: When the `gh-address-cr` workflow itself blocks progress because of a repeatable skill/runtime gap, use `gh-address-cr submit-feedback ...` against this repository instead of burying the problem in PR findings or local notes.
 
 ### Architecture Preflight Gate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Before claiming work is complete, run these local checks:
 - **Fail fast**: Do not add silent fallbacks or hidden behavior changes.
 - **Smallest change**: Default to the smallest safe change. Avoid opportunistic refactors.
 - **Contract discipline**: If a public or agent-facing contract changes, update docs and tests together.
-- **Skill/runtime feedback**: When the `gh-address-cr` workflow itself blocks progress because of a repeatable skill/runtime gap, use `gh-address-cr submit-feedback ...` against this repository instead of burying the problem in PR findings or local notes.
+- **Skill/runtime feedback**: When the `gh-address-cr` workflow itself blocks progress because of a repeatable skill/runtime gap, use `python3 -m gh_address_cr submit-feedback ...` against this repository instead of burying the problem in PR findings or local notes.
 
 ### Architecture Preflight Gate
 


### PR DESCRIPTION
## Summary
- align `AGENTS.md` verification commands with the repo's current documented checks
- add the `agent manifest` and plugin payload build/check commands used by current workflows
- document that repeatable skill/runtime gaps should use `gh-address-cr submit-feedback` instead of being buried in PR findings

## Verification
- `git diff --check -- AGENTS.md`
