### PR TITLE
[codex] fix final-gate guidance telemetry formatting

### DIFF
--- a/src/gh_address_cr/commands/final_gate.py
+++ b/src/gh_address_cr/commands/final_gate.py
@@ -343,8 +343,10 @@ def _string_list(value: object) -> list[str]:
         return []
     if isinstance(value, (list, tuple)):
         return [text for item in value if (text := str(item).strip())]
-    text = str(value).strip()
-    return [text] if text else []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    return []
 
 
 def build_completion_summary_guidance(

--- a/src/gh_address_cr/commands/final_gate.py
+++ b/src/gh_address_cr/commands/final_gate.py
@@ -323,8 +323,13 @@ def build_completion_summary_line(result: core_gate.GateResult, telemetry_report
 
 def _safe_int(value: object, *, default: int) -> int:
     try:
-        return int(value) if value is not None else default
-    except (TypeError, ValueError):
+        if value is None:
+            return default
+        if isinstance(value, float):
+            return int(value) if math.isfinite(value) else default
+        parsed = int(value)
+        return parsed
+    except (OverflowError, TypeError, ValueError):
         return default
 
 

--- a/src/gh_address_cr/commands/final_gate.py
+++ b/src/gh_address_cr/commands/final_gate.py
@@ -363,16 +363,14 @@ def build_completion_summary_guidance(
     checks_not_green = result.counts.get("pr_checks_not_green_count", 0)
 
     coverage = telemetry_report.get("coverage_label") or "unavailable"
-    total_events = telemetry_report.get("total_events") or 0
-    success_rate = telemetry_report.get("success_rate")
-    if success_rate is None:
-        success_rate = 0.0
-    inefficiency_flags = telemetry_report.get("inefficiency_flags") or []
+    total_events = _safe_int(telemetry_report.get("total_events"), default=0)
+    success_rate = _safe_float(telemetry_report.get("success_rate"), default=0.0)
+    inefficiency_flags = _string_list(telemetry_report.get("inefficiency_flags"))
     flags_str = "; ".join(inefficiency_flags) if inefficiency_flags else "none"
     telemetry_diagnostics = [
-        str(diagnostic)
-        for diagnostic in (telemetry_report.get("diagnostics") or [])
-        if str(diagnostic).strip()
+        diagnostic
+        for diagnostic in _string_list(telemetry_report.get("diagnostics"))
+        if diagnostic.strip()
     ]
     telemetry_diagnostics_str = "; ".join(telemetry_diagnostics)
     report_artifact = telemetry_report.get("report_artifact") or "N/A"

--- a/src/gh_address_cr/commands/final_gate.py
+++ b/src/gh_address_cr/commands/final_gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import shutil
 import sys
@@ -329,7 +330,10 @@ def _safe_int(value: object, *, default: int) -> int:
 
 def _safe_float(value: object, *, default: float) -> float:
     try:
-        return float(value) if value is not None else default
+        if value is None:
+            return default
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else default
     except (TypeError, ValueError):
         return default
 
@@ -338,8 +342,9 @@ def _string_list(value: object) -> list[str]:
     if value is None:
         return []
     if isinstance(value, (list, tuple)):
-        return [str(item) for item in value if str(item)]
-    return [str(value)]
+        return [text for item in value if (text := str(item).strip())]
+    text = str(value).strip()
+    return [text] if text else []
 
 
 def build_completion_summary_guidance(

--- a/tests/test_final_gate.py
+++ b/tests/test_final_gate.py
@@ -418,6 +418,28 @@ class FinalGateTestCase(unittest.TestCase):
             "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (2 events, 0.0%) | inefficiency: none]",
         )
 
+    def test_build_completion_summary_line_normalizes_non_finite_total_events(self):
+        from gh_address_cr.commands.final_gate import build_completion_summary_line
+
+        result = self.evaluate(
+            self.passing_session(),
+            remote_threads=[{"id": "THREAD_DONE", "isResolved": True}],
+        )
+        telemetry_report = {
+            "coverage_label": "partial",
+            "total_events": float("inf"),
+            "success_rate": 100.0,
+            "inefficiency_flags": [],
+            "report_artifact": "path/to/report.json",
+        }
+
+        summary_line = build_completion_summary_line(result, telemetry_report)
+
+        self.assertEqual(
+            summary_line,
+            "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (0 events, 100.0%) | inefficiency: none]",
+        )
+
     def test_build_completion_summary_line_reports_required_check_counts(self):
         from gh_address_cr.commands.final_gate import build_completion_summary_line
         result = self.evaluate(

--- a/tests/test_final_gate.py
+++ b/tests/test_final_gate.py
@@ -540,3 +540,27 @@ class FinalGateTestCase(unittest.TestCase):
         }
         guidance = build_completion_summary_guidance(result, telemetry_report, summary_path=None)
         self.assertIn("[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: unavailable (0 events, 0.0%) | inefficiency: none]", guidance)
+
+    def test_build_completion_summary_guidance_tolerates_malformed_telemetry_fields(self):
+        from gh_address_cr.commands.final_gate import build_completion_summary_guidance
+
+        result = self.evaluate(
+            self.passing_session(),
+            remote_threads=[{"id": "THREAD_DONE", "isResolved": True}],
+        )
+        telemetry_report = {
+            "coverage_label": "partial",
+            "total_events": "NaN",
+            "success_rate": "oops",
+            "inefficiency_flags": "retry-loop",
+            "diagnostics": "host telemetry degraded",
+            "report_artifact": "report.json",
+        }
+
+        guidance = build_completion_summary_guidance(result, telemetry_report, summary_path=None)
+
+        self.assertIn(
+            "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (0 events, 0.0%) | inefficiency: retry-loop]",
+            guidance,
+        )
+        self.assertIn("Telemetry diagnostics: host telemetry degraded", guidance)

--- a/tests/test_final_gate.py
+++ b/tests/test_final_gate.py
@@ -610,3 +610,28 @@ class FinalGateTestCase(unittest.TestCase):
             guidance,
         )
         self.assertNotIn("inefficiency flags present", guidance)
+
+    def test_build_completion_summary_guidance_treats_falsey_scalar_list_fields_as_absent(self):
+        from gh_address_cr.commands.final_gate import build_completion_summary_guidance
+
+        result = self.evaluate(
+            self.passing_session(),
+            remote_threads=[{"id": "THREAD_DONE", "isResolved": True}],
+        )
+        telemetry_report = {
+            "coverage_label": "partial",
+            "total_events": 1,
+            "success_rate": 100.0,
+            "inefficiency_flags": False,
+            "diagnostics": 0,
+            "report_artifact": "report.json",
+        }
+
+        guidance = build_completion_summary_guidance(result, telemetry_report, summary_path=None)
+
+        self.assertIn(
+            "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (1 events, 100.0%) | inefficiency: none]",
+            guidance,
+        )
+        self.assertNotIn("inefficiency flags present", guidance)
+        self.assertNotIn("Telemetry diagnostics:", guidance)

--- a/tests/test_final_gate.py
+++ b/tests/test_final_gate.py
@@ -396,6 +396,28 @@ class FinalGateTestCase(unittest.TestCase):
             "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (0 events, 0.0%) | inefficiency: retry-loop]",
         )
 
+    def test_build_completion_summary_line_normalizes_non_finite_success_rate(self):
+        from gh_address_cr.commands.final_gate import build_completion_summary_line
+
+        result = self.evaluate(
+            self.passing_session(),
+            remote_threads=[{"id": "THREAD_DONE", "isResolved": True}],
+        )
+        telemetry_report = {
+            "coverage_label": "partial",
+            "total_events": 2,
+            "success_rate": "NaN",
+            "inefficiency_flags": [],
+            "report_artifact": "path/to/report.json",
+        }
+
+        summary_line = build_completion_summary_line(result, telemetry_report)
+
+        self.assertEqual(
+            summary_line,
+            "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (2 events, 0.0%) | inefficiency: none]",
+        )
+
     def test_build_completion_summary_line_reports_required_check_counts(self):
         from gh_address_cr.commands.final_gate import build_completion_summary_line
         result = self.evaluate(
@@ -564,3 +586,27 @@ class FinalGateTestCase(unittest.TestCase):
             guidance,
         )
         self.assertIn("Telemetry diagnostics: host telemetry degraded", guidance)
+
+    def test_build_completion_summary_guidance_filters_blank_inefficiency_flags(self):
+        from gh_address_cr.commands.final_gate import build_completion_summary_guidance
+
+        result = self.evaluate(
+            self.passing_session(),
+            remote_threads=[{"id": "THREAD_DONE", "isResolved": True}],
+        )
+        telemetry_report = {
+            "coverage_label": "partial",
+            "total_events": 1,
+            "success_rate": 100.0,
+            "inefficiency_flags": "",
+            "diagnostics": "",
+            "report_artifact": "report.json",
+        }
+
+        guidance = build_completion_summary_guidance(result, telemetry_report, summary_path=None)
+
+        self.assertIn(
+            "[gh-address-cr: PASSED | threads: 0 | reviews: 0 | checks: N/A | telemetry: partial (1 events, 100.0%) | inefficiency: none]",
+            guidance,
+        )
+        self.assertNotIn("inefficiency flags present", guidance)


### PR DESCRIPTION
## What changed
- normalize `build_completion_summary_guidance()` telemetry fields with the same safe helpers already used by `build_completion_summary_line()`
- tolerate malformed `total_events`, `success_rate`, `inefficiency_flags`, and `diagnostics` values instead of raising at summary generation time
- add a regression test covering malformed telemetry payloads

## Why
`fix: expose final-gate completion summary line (#104)` added guidance rendering for completion summaries, but the guidance path still assumed telemetry fields had correct types. A malformed telemetry payload could crash summary generation with `TypeError`, even though the summary-line path was already fail-open.

## Impact
- final-gate guidance stays fail-open for malformed telemetry inputs
- machine/human completion-summary helpers now share consistent formatting behavior
- regression coverage protects the contract going forward

## Validation
- `python3 -m unittest discover -s tests`
- `ruff check src tests`
- `python3 -m gh_address_cr --help`
