### PR TITLE
fix: reduce telemetry normalization overhead

### DIFF
--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -201,6 +201,7 @@ class TelemetryParseResult:
     unsafe_seen: bool
     malformed_seen: bool
     diagnostics: list[Any]
+    events_are_normalized: bool = False
 
 
 class TelemetryAdapter(ABC):
@@ -288,6 +289,7 @@ class GenericAgentJsonlAdapter(TelemetryAdapter):
             unsafe_seen=unsafe_seen,
             malformed_seen=malformed_seen,
             diagnostics=diagnostics,
+            events_are_normalized=True,
         )
 
 
@@ -759,7 +761,9 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
             if not isinstance(event, ExternalTelemetryEvent):
                 raise TypeError(f"Event must be an ExternalTelemetryEvent instance, got {type(event).__name__}")
             try:
-                normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
+                normalized_event = event
+                if not parse_result.events_are_normalized:
+                    normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
             except ValueError as exc:
                 message = str(exc)
                 if message.startswith("UNSAFE:"):
@@ -1386,14 +1390,73 @@ def _load_external_events_with_diagnostics(paths: core_paths.SessionPaths) -> tu
             continue
         try:
             payload = _json_loads_strict(line)
-            if not isinstance(payload, dict):
-                raise ValueError("record must be a JSON object")
-            events.append(_normalize_external_event(payload, declared_source=str(payload.get("source") or "")))
+            events.append(_load_stored_external_event(payload))
         except json.JSONDecodeError as exc:
             diagnostics.append(f"external telemetry line {line_number}: invalid JSON: {exc.msg}")
         except ValueError as exc:
             diagnostics.append(f"external telemetry line {line_number}: {exc}")
     return events, diagnostics
+
+
+def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
+    if not isinstance(payload, dict):
+        raise ValueError("record must be a JSON object")
+    source = payload.get("source")
+    if not source:
+        raise ValueError("missing required field(s): source")
+    required_strings = ("schema_version", "source_session_id", "event_id", "kind", "operation", "status")
+    values: dict[str, str] = {"source": str(source)}
+    missing: list[str] = []
+    for field in required_strings:
+        value = payload.get(field)
+        if value in (None, ""):
+            missing.append(field)
+            continue
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        values[field] = value
+    if missing:
+        raise ValueError(f"missing required field(s): {', '.join(missing)}")
+    duration_ms = payload.get("duration_ms")
+    if isinstance(duration_ms, bool) or not isinstance(duration_ms, int):
+        raise ValueError("duration_ms must be an integer")
+    if duration_ms < 0:
+        raise ValueError("duration_ms must be non-negative")
+    metadata = payload.get("metadata")
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be an object")
+    started_at = payload.get("started_at")
+    ended_at = payload.get("ended_at")
+    correlation_id = payload.get("correlation_id")
+    event_fingerprint = payload.get("event_fingerprint")
+    for field_name, value in (
+        ("started_at", started_at),
+        ("ended_at", ended_at),
+        ("correlation_id", correlation_id),
+        ("event_fingerprint", event_fingerprint),
+    ):
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"{field_name} must be a string")
+    event = ExternalTelemetryEvent(
+        schema_version=values["schema_version"],
+        source=values["source"],
+        source_session_id=values["source_session_id"],
+        event_id=values["event_id"],
+        kind=values["kind"],
+        operation=values["operation"],
+        status=values["status"],
+        duration_ms=duration_ms,
+        started_at=started_at,
+        ended_at=ended_at,
+        metadata=dict(metadata),
+        correlation_id=correlation_id,
+        event_fingerprint=event_fingerprint or "",
+    )
+    if not event.event_fingerprint:
+        event = ExternalTelemetryEvent(**{**event.to_dict(), "event_fingerprint": _event_fingerprint(event)})
+    return event
 
 
 def _dedupe_events(events: list[ExternalTelemetryEvent]) -> tuple[list[ExternalTelemetryEvent], list[str]]:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -1304,7 +1304,6 @@ def _safe_runtime_operation(operation: str) -> str:
     return operation
 
 
-@lru_cache(maxsize=8192)
 def _looks_like_unnecessary_absolute_path(value: str) -> bool:
     lowered = value.lower()
     if (

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -1334,7 +1334,6 @@ def _is_unsafe_metadata_key(key: str) -> bool:
     return bool(re.search(r"(^|[_-])key($|[_-])", lowered))
 
 
-@lru_cache(maxsize=8192)
 def _contains_token_marker(value: str) -> bool:
     lowered = value.lower()
     if any(marker in lowered for marker in TOKEN_MARKERS):
@@ -1348,7 +1347,6 @@ def _contains_control_character(value: str) -> bool:
     return any(character in value for character in ("\n", "\r", "\t"))
 
 
-@lru_cache(maxsize=8192)
 def _contains_private_identifier(value: str) -> bool:
     lowered = value.lower()
     markers = (
@@ -1457,7 +1455,11 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
     started_at = _stored_optional_timestamp(payload.get("started_at"), field="started_at")
     ended_at = _stored_optional_timestamp(payload.get("ended_at"), field="ended_at")
     correlation_raw = payload.get("correlation_id")
-    correlation_id = _stored_optional_string(correlation_raw, field="correlation_id")
+    correlation_id = None
+    if correlation_raw is not None:
+        if not isinstance(correlation_raw, str):
+            raise ValueError("correlation_id must be a string")
+        correlation_id = _safe_correlation_id(correlation_raw)
     event_fingerprint = payload.get("event_fingerprint")
     if event_fingerprint is not None and not isinstance(event_fingerprint, str):
         raise ValueError("event_fingerprint must be a string")
@@ -1480,10 +1482,6 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
     if event.event_fingerprint != canonical_fingerprint:
         event = ExternalTelemetryEvent(**{**event.to_dict(), "event_fingerprint": canonical_fingerprint})
     return event
-
-
-def _is_sha256_hex(value: str) -> bool:
-    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
 
 
 def _stored_optional_string(value: object, *, field: str) -> str | None:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -10,6 +10,7 @@ import uuid
 from hashlib import sha256
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
@@ -1202,7 +1203,9 @@ def _validate_safe_metadata_value(value: object, *, key_path: str = "metadata") 
         for index, item in enumerate(value):
             _validate_safe_metadata_value(item, key_path=f"{key_path}[{index}]")
         return
-    value_text = str(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+    value_text = value if isinstance(value, str) else str(value)
     if _contains_token_marker(value_text):
         raise ValueError(f"UNSAFE:unsafe metadata value at {key_path}")
     if _contains_private_identifier(value_text):
@@ -1298,6 +1301,7 @@ def _safe_runtime_operation(operation: str) -> str:
     return operation
 
 
+@lru_cache(maxsize=8192)
 def _looks_like_unnecessary_absolute_path(value: str) -> bool:
     lowered = value.lower()
     if (
@@ -1318,6 +1322,7 @@ def _looks_like_unnecessary_absolute_path(value: str) -> bool:
     return bool(re.search(r"(^|\s)[a-zA-Z]:\\[^\s]+", value))
 
 
+@lru_cache(maxsize=8192)
 def _is_unsafe_metadata_key(key: str) -> bool:
     lowered = key.lower()
     if lowered in {"token_input_count", "token_output_count", "token_total_count"}:
@@ -1329,6 +1334,7 @@ def _is_unsafe_metadata_key(key: str) -> bool:
     return bool(re.search(r"(^|[_-])key($|[_-])", lowered))
 
 
+@lru_cache(maxsize=8192)
 def _contains_token_marker(value: str) -> bool:
     lowered = value.lower()
     if any(marker in lowered for marker in TOKEN_MARKERS):
@@ -1342,6 +1348,7 @@ def _contains_control_character(value: str) -> bool:
     return any(character in value for character in ("\n", "\r", "\t"))
 
 
+@lru_cache(maxsize=8192)
 def _contains_private_identifier(value: str) -> bool:
     lowered = value.lower()
     markers = (
@@ -1431,7 +1438,7 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
         elif field == "event_id":
             values[field] = _safe_identity_label(value, field=field)
         elif field == "source_session_id":
-            values[field] = value
+            values[field] = _safe_source_session_id(value)
         elif field == "operation":
             values[field] = _safe_operation(value)
         else:
@@ -1446,7 +1453,7 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
     metadata = payload.get("metadata")
     if metadata is None:
         metadata = {}
-    metadata = _safe_stored_metadata(metadata)
+    metadata = _safe_metadata(metadata)
     started_at = _stored_optional_timestamp(payload.get("started_at"), field="started_at")
     ended_at = _stored_optional_timestamp(payload.get("ended_at"), field="ended_at")
     correlation_raw = payload.get("correlation_id")
@@ -1469,23 +1476,14 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
         correlation_id=correlation_id,
         event_fingerprint=event_fingerprint or "",
     )
-    if not _is_sha256_hex(event.event_fingerprint):
-        event = ExternalTelemetryEvent(**{**event.to_dict(), "event_fingerprint": _event_fingerprint(event)})
+    canonical_fingerprint = _event_fingerprint(event)
+    if event.event_fingerprint != canonical_fingerprint:
+        event = ExternalTelemetryEvent(**{**event.to_dict(), "event_fingerprint": canonical_fingerprint})
     return event
 
 
 def _is_sha256_hex(value: str) -> bool:
     return bool(re.fullmatch(r"[0-9a-f]{64}", value))
-
-
-def _safe_stored_metadata(metadata: object) -> dict[str, Any]:
-    if not isinstance(metadata, dict):
-        raise ValueError("metadata must be an object")
-    try:
-        json.dumps(metadata, allow_nan=False)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(f"metadata contains non-JSON serializable or non-finite values: {exc}") from None
-    return dict(metadata)
 
 
 def _stored_optional_string(value: object, *, field: str) -> str | None:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -758,6 +758,7 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
     duplicate_fingerprints: list[str] = []
     observed_sessions: set[str] = set()
     duplicate_count = 0
+    trusted_normalized_events = parse_result.events_are_normalized and type(adapter) is GenericAgentJsonlAdapter
 
     try:
         for idx, event in enumerate(accepted_events):
@@ -765,7 +766,7 @@ def import_external_telemetry(repo: str, pr_number: str, *, source: str, fmt: st
                 raise TypeError(f"Event must be an ExternalTelemetryEvent instance, got {type(event).__name__}")
             try:
                 normalized_event = event
-                if not parse_result.events_are_normalized:
+                if not trusted_normalized_events:
                     normalized_event = _normalize_external_event(event.to_dict(), declared_source=source)
             except ValueError as exc:
                 message = str(exc)

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -10,7 +10,6 @@ import uuid
 from hashlib import sha256
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
@@ -1277,6 +1276,8 @@ def _safe_optional_timestamp(value: object, *, field: str) -> str | None:
     if not value:
         return None
     text = str(value)
+    if _contains_control_character(text):
+        raise ValueError(f"UNSAFE:unsafe control character in {field}")
     if _contains_token_marker(text):
         raise ValueError(f"UNSAFE:unsafe {field}")
     if _contains_private_identifier(text):
@@ -1324,7 +1325,6 @@ def _looks_like_unnecessary_absolute_path(value: str) -> bool:
     return bool(re.search(r"(^|\s)[a-zA-Z]:\\[^\s]+", value))
 
 
-@lru_cache(maxsize=8192)
 def _is_unsafe_metadata_key(key: str) -> bool:
     lowered = key.lower()
     if lowered in {"token_input_count", "token_output_count", "token_total_count"}:
@@ -1399,7 +1399,7 @@ def _load_external_events_with_diagnostics(paths: core_paths.SessionPaths) -> tu
                 except json.JSONDecodeError as exc:
                     diagnostics.append(f"external telemetry line {line_number}: invalid JSON: {exc.msg}")
                 except ValueError as exc:
-                    diagnostics.append(f"external telemetry line {line_number}: {exc}")
+                    diagnostics.append(f"external telemetry line {line_number}: {_safe_diagnostic_text(str(exc))}")
     except OSError as exc:
         return [], [f"external telemetry unreadable: {exc}"]
     return events, diagnostics
@@ -1495,14 +1495,11 @@ def _stored_optional_string(value: object, *, field: str) -> str | None:
 
 
 def _stored_optional_timestamp(value: object, *, field: str) -> str | None:
-    text = _stored_optional_string(value, field=field)
-    if text is None:
+    if value is None:
         return None
-    try:
-        datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        raise ValueError(f"{field} must be an ISO timestamp") from None
-    return text
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return _safe_optional_timestamp(value, field=field)
 
 
 def _dedupe_events(events: list[ExternalTelemetryEvent]) -> tuple[list[ExternalTelemetryEvent], list[str]]:

--- a/src/gh_address_cr/core/telemetry.py
+++ b/src/gh_address_cr/core/telemetry.py
@@ -1404,8 +1404,10 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
     source = payload.get("source")
     if not source:
         raise ValueError("missing required field(s): source")
+    if not isinstance(source, str):
+        raise ValueError("source must be a string")
     required_strings = ("schema_version", "source_session_id", "event_id", "kind", "operation", "status")
-    values: dict[str, str] = {"source": str(source)}
+    values: dict[str, str] = {"source": _safe_source_label(source)}
     missing: list[str] = []
     for field in required_strings:
         value = payload.get(field)
@@ -1414,7 +1416,26 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
             continue
         if not isinstance(value, str):
             raise ValueError(f"{field} must be a string")
-        values[field] = value
+        if field == "schema_version":
+            values[field] = _safe_identity_label(value, field=field)
+        elif field == "kind":
+            kind = _safe_identity_label(value, field=field)
+            if kind not in SAFE_KINDS:
+                raise ValueError(f"unsupported kind: {kind}")
+            values[field] = kind
+        elif field == "status":
+            status = _safe_identity_label(value, field=field)
+            if status not in SAFE_STATUSES:
+                raise ValueError(f"unsupported status: {status}")
+            values[field] = status
+        elif field == "event_id":
+            values[field] = _safe_identity_label(value, field=field)
+        elif field == "source_session_id":
+            values[field] = value
+        elif field == "operation":
+            values[field] = _safe_operation(value)
+        else:
+            values[field] = value
     if missing:
         raise ValueError(f"missing required field(s): {', '.join(missing)}")
     duration_ms = payload.get("duration_ms")
@@ -1425,20 +1446,14 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
     metadata = payload.get("metadata")
     if metadata is None:
         metadata = {}
-    if not isinstance(metadata, dict):
-        raise ValueError("metadata must be an object")
-    started_at = payload.get("started_at")
-    ended_at = payload.get("ended_at")
-    correlation_id = payload.get("correlation_id")
+    metadata = _safe_stored_metadata(metadata)
+    started_at = _stored_optional_timestamp(payload.get("started_at"), field="started_at")
+    ended_at = _stored_optional_timestamp(payload.get("ended_at"), field="ended_at")
+    correlation_raw = payload.get("correlation_id")
+    correlation_id = _stored_optional_string(correlation_raw, field="correlation_id")
     event_fingerprint = payload.get("event_fingerprint")
-    for field_name, value in (
-        ("started_at", started_at),
-        ("ended_at", ended_at),
-        ("correlation_id", correlation_id),
-        ("event_fingerprint", event_fingerprint),
-    ):
-        if value is not None and not isinstance(value, str):
-            raise ValueError(f"{field_name} must be a string")
+    if event_fingerprint is not None and not isinstance(event_fingerprint, str):
+        raise ValueError("event_fingerprint must be a string")
     event = ExternalTelemetryEvent(
         schema_version=values["schema_version"],
         source=values["source"],
@@ -1454,9 +1469,42 @@ def _load_stored_external_event(payload: object) -> ExternalTelemetryEvent:
         correlation_id=correlation_id,
         event_fingerprint=event_fingerprint or "",
     )
-    if not event.event_fingerprint:
+    if not _is_sha256_hex(event.event_fingerprint):
         event = ExternalTelemetryEvent(**{**event.to_dict(), "event_fingerprint": _event_fingerprint(event)})
     return event
+
+
+def _is_sha256_hex(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _safe_stored_metadata(metadata: object) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be an object")
+    try:
+        json.dumps(metadata, allow_nan=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"metadata contains non-JSON serializable or non-finite values: {exc}") from None
+    return dict(metadata)
+
+
+def _stored_optional_string(value: object, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+def _stored_optional_timestamp(value: object, *, field: str) -> str | None:
+    text = _stored_optional_string(value, field=field)
+    if text is None:
+        return None
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"{field} must be an ISO timestamp") from None
+    return text
 
 
 def _dedupe_events(events: list[ExternalTelemetryEvent]) -> tuple[list[ExternalTelemetryEvent], list[str]]:

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1328,6 +1328,123 @@ class TestTelemetry(unittest.TestCase):
             self.assertTrue(any("missing required field(s): source" in item for item in report["diagnostics"]))
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_non_string_source(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": ["generic-agent"],
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("source must be a string" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_unsafe_operation_fast_path(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "/Users/snow/private/repo/run-tests",
+                        "duration_ms": 1,
+                        "status": "success",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsafe absolute path in operation label" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_unsupported_kind(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "totally-new-kind",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsupported kind: totally-new-kind" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_recomputes_invalid_fingerprint_format(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "event_fingerprint": "not-a-sha256",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "partial")
+            self.assertEqual(report["total_events"], 1)
+            self.assertEqual(report["diagnostics"], [])
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
     def test_corrupted_external_store_blocks_new_import(self, state_dir):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir.return_value = Path(tmp)

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -364,6 +364,68 @@ class TestTelemetry(unittest.TestCase):
             self.assertEqual(report["slowest_operations"][0]["operation"], "run unit tests")
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_generic_agent_import_does_not_renormalize_adapter_events(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            payload = json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "source": "generic-agent",
+                    "source_session_id": "run-1",
+                    "event_id": "e1",
+                    "kind": "tool_call",
+                    "operation": "run unit tests",
+                    "duration_ms": 1000,
+                    "status": "success",
+                }
+            )
+
+            from gh_address_cr.core import telemetry as telemetry_module
+
+            original = telemetry_module._normalize_external_event
+            with patch("gh_address_cr.core.telemetry._normalize_external_event", wraps=original) as normalize_event:
+                result = import_external_telemetry(
+                    "octo/example", "77", source="generic-agent", fmt="agent-jsonl", raw=payload
+                )
+
+            self.assertEqual(result["status"], "SUCCESS")
+            self.assertEqual(normalize_event.call_count, 1)
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_efficiency_report_uses_canonical_fast_path_for_stored_external_events(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            imported = import_external_telemetry(
+                "octo/example",
+                "77",
+                source="generic-agent",
+                fmt="agent-jsonl",
+                raw=json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "run unit tests",
+                        "duration_ms": 1000,
+                        "status": "success",
+                    }
+                ),
+            )
+            self.assertEqual(imported["status"], "SUCCESS")
+
+            from gh_address_cr.core import telemetry as telemetry_module
+
+            original = telemetry_module._normalize_external_event
+            with patch("gh_address_cr.core.telemetry._normalize_external_event", wraps=original) as normalize_event:
+                report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["status"], "SUCCESS")
+            self.assertEqual(report["total_events"], 1)
+            self.assertEqual(normalize_event.call_count, 0)
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
     def test_overlapping_external_imports_are_deduped_by_event_fingerprint(self, state_dir):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir.return_value = Path(tmp)

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1444,6 +1444,36 @@ class TestTelemetry(unittest.TestCase):
             self.assertTrue(any("unsafe absolute path in source_session_id" in item for item in report["diagnostics"]))
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_unsafe_correlation_id(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "correlation_id": "username-alice-laptop",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsafe correlation_id" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
     def test_stored_external_telemetry_rejects_unsafe_metadata(self, state_dir):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir.return_value = Path(tmp)

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1415,7 +1415,36 @@ class TestTelemetry(unittest.TestCase):
             self.assertTrue(any("unsupported kind: totally-new-kind" in item for item in report["diagnostics"]))
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
-    def test_stored_external_telemetry_recomputes_invalid_fingerprint_format(self, state_dir):
+    def test_stored_external_telemetry_rejects_unsafe_source_session_id(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "/Users/snow/private/workspace",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsafe absolute path in source_session_id" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_unsafe_metadata(self, state_dir):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir.return_value = Path(tmp)
             path = core_paths.external_telemetry_file("octo/example", "77")
@@ -1431,7 +1460,51 @@ class TestTelemetry(unittest.TestCase):
                         "operation": "exec_command",
                         "duration_ms": 1,
                         "status": "success",
-                        "event_fingerprint": "not-a-sha256",
+                        "metadata": {"token": "ghp_secret"},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsafe metadata field: token" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_recomputes_mismatched_fingerprint(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "event_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    }
+                )
+                + "\n"
+                + json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "event_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                     }
                 )
                 + "\n",
@@ -1442,7 +1515,7 @@ class TestTelemetry(unittest.TestCase):
 
             self.assertEqual(report["coverage_label"], "partial")
             self.assertEqual(report["total_events"], 1)
-            self.assertEqual(report["diagnostics"], [])
+            self.assertTrue(any("duplicate event fingerprint ignored" in item for item in report["diagnostics"]))
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
     def test_corrupted_external_store_blocks_new_import(self, state_dir):

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2841,6 +2841,55 @@ class TestTelemetry(unittest.TestCase):
                 self.assertEqual(result["rejected_count"], 1)
                 self.assertTrue(any("unsafe key" in diag or "password" in diag for diag in result["diagnostics"]))
 
+    def test_custom_telemetry_adapter_normalized_flag_still_revalidates_events(self):
+        from gh_address_cr.core.telemetry import (
+            TelemetryAdapter,
+            TelemetryParseResult,
+            ExternalTelemetryEvent,
+            register_adapter,
+            unregister_adapter,
+        )
+
+        class MockUnsafeNormalizedAdapter(TelemetryAdapter):
+            def parse(self, raw: str, source: str) -> TelemetryParseResult:
+                event = ExternalTelemetryEvent(
+                    schema_version="1.0",
+                    source=source,
+                    source_session_id="session-abc",
+                    event_id="event-unsafe-normalized",
+                    kind="tool_call",
+                    operation="username-alice-laptop",
+                    status="success",
+                    duration_ms=100,
+                )
+                return TelemetryParseResult(
+                    events=[event],
+                    rejected_count=0,
+                    unsafe_seen=False,
+                    malformed_seen=False,
+                    diagnostics=[],
+                    events_are_normalized=True,
+                )
+
+        register_adapter("mock-unsafe-normalized", MockUnsafeNormalizedAdapter())
+        self.addCleanup(lambda: unregister_adapter("mock-unsafe-normalized"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("gh_address_cr.core.telemetry.core_paths.state_dir", return_value=Path(tmp)):
+                result = import_external_telemetry(
+                    "octo/example",
+                    "77",
+                    source="custom-source",
+                    fmt="mock-unsafe-normalized",
+                    raw="dummy_payload",
+                )
+
+                self.assertEqual(result["status"], "FAILED")
+                self.assertEqual(result["reason_code"], "UNSAFE_TELEMETRY_CONTENT")
+                self.assertEqual(result["accepted_count"], 0)
+                self.assertEqual(result["rejected_count"], 1)
+                self.assertTrue(any("unsafe private identifier in operation label" in diag for diag in result["diagnostics"]))
+
     def test_custom_telemetry_adapter_non_json_metadata_rejection(self):
         from gh_address_cr.core.telemetry import (
             TelemetryAdapter,

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1474,6 +1474,68 @@ class TestTelemetry(unittest.TestCase):
             self.assertTrue(any("unsafe correlation_id" in item for item in report["diagnostics"]))
 
     @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_rejects_timestamp_control_characters(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "started_at": "2020-01-01\n12:00:00",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("unsafe control character in started_at" in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
+    def test_stored_external_telemetry_redacts_unsafe_metadata_key_diagnostic(self, state_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir.return_value = Path(tmp)
+            path = core_paths.external_telemetry_file("octo/example", "77")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            unsafe_key = "github_token_ghp_secret"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "source": "generic-agent",
+                        "source_session_id": "run-1",
+                        "event_id": "e1",
+                        "kind": "tool_call",
+                        "operation": "exec_command",
+                        "duration_ms": 1,
+                        "status": "success",
+                        "metadata": {unsafe_key: "value"},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_efficiency_report("octo/example", "77")
+
+            self.assertEqual(report["coverage_label"], "unavailable")
+            self.assertEqual(report["total_events"], 0)
+            self.assertTrue(any("[redacted]" in item for item in report["diagnostics"]))
+            self.assertFalse(any(unsafe_key in item for item in report["diagnostics"]))
+
+    @patch("gh_address_cr.core.telemetry.core_paths.state_dir")
     def test_stored_external_telemetry_rejects_unsafe_metadata(self, state_dir):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir.return_value = Path(tmp)


### PR DESCRIPTION
## Summary
- avoid renormalizing generic agent telemetry events after adapter parse
- load persisted canonical external telemetry through a fast path during report generation
- add regression tests for both performance-sensitive paths

## Performance evidence
Synthetic mixed-session benchmark with `PYTHONPATH=src`:
- before: 10k events -> import ~942ms, report ~539ms, `TELEMETRY_OVERHEAD_EXCEEDED`
- after: 10k events -> import ~616ms, report ~149ms, no overhead diagnostic
- after: 5k events -> import ~433ms, report ~112ms

## Verification
- `PYTHONPATH=src ruff check src tests`
- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m gh_address_cr --help`
