### PR TITLE
Require final-gate completion evidence in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,10 @@ A task is complete only when:
 - The requested change is implemented and verified.
 - The relevant contract docs remain consistent.
 - `final-gate` passes (for PR-session handling work).
+- PR-session completion evidence includes the `final-gate` compact metrics line
+  (`completion_summary_line` or `PR Completion Summary Guidance`) with telemetry
+  coverage and report artifacts; telemetry diagnostics are fail-open for review
+  completion but must remain visible.
 - No unresolved high-severity issues were introduced.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ A task is complete only when:
 - The relevant contract docs remain consistent.
 - `final-gate` passes (for PR-session handling work).
 - PR-session completion evidence includes the `final-gate` compact metrics line
-  (`completion_summary_line` or `PR Completion Summary Guidance`) with telemetry
-  coverage and report artifacts; telemetry diagnostics are fail-open for review
-  completion but must remain visible.
+  (`completion_summary_line`, or the first bracketed line within
+  `PR Completion Summary Guidance`) with telemetry coverage and report
+  artifacts. Telemetry failures are fail-open for review completion, but
+  telemetry diagnostics must remain visible.
 - No unresolved high-severity issues were introduced.
 
 ---


### PR DESCRIPTION
## Summary
- Clarify that PR-session completion evidence must include the `final-gate` compact metrics line.
- Require telemetry coverage and report artifacts to be visible in completion guidance, while keeping telemetry diagnostics fail-open for review completion.

## Testing
- Unit tests: `python3 -m unittest tests.test_skill_docs`