### PR TITLE
feat(agent): support batch skeleton generation via agent next --batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Advanced integration commands:
 - `agent manifest`
 - `agent classify`
 - `agent next`
+- `agent next --batch`
 - `agent submit`
 - `agent submit-batch`
 - `agent fix`
@@ -155,7 +156,9 @@ hydrated by the runtime during publish, so independent worker evidence does not
 need to wait for a final commit hash. Use
 `agent fix-all --input <batch-response.json>` to route explicit per-thread batch
 evidence, or `agent fix-all --homogeneous-reason <why>` only for a homogeneous
-repeated concern.
+repeated concern. When `fix-all` reports `PER_THREAD_EVIDENCE_REQUIRED`, run
+`agent next --batch --agent-id <id>` to claim eligible GitHub review threads and
+write a fillable `batch-response-skeleton.json` before `agent submit-batch`.
 
 When exactly one PR session is cached, PR-scoped commands such as `address`,
 `review`, `threads`, `final-gate`, and `telemetry summary` may omit

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -60,6 +60,218 @@ Minimal invocation model:
 
 Advanced/internal integrations are documented later in this reference.
 
+## Command Topology (ASCII)
+
+This map is the CLI coverage checklist. Every public command is either a
+session producer, a session mutator, a side-effect publisher, a gate, a telemetry
+observer, or an operator utility. Arrows show the intended upstream/downstream
+handoff. Commands that emit a `next_action` or `commands` object must point to a
+downstream command in this map.
+
+```text
++-------------------+
+| gh-address-cr CLI |
++---------+---------+
+          |
+          +-- active-pr
+          |      |
+          |      +--> address --lean
+          |      +--> review
+          |
+          +-- review [--auto-simple]
+          |      |
+          |      +--> WAITING_FOR_EXTERNAL_REVIEW
+          |      |      |
+          |      |      +--> review-to-findings
+          |      |      +--> findings --input <json|-|fixed-blocks> --source <producer>
+          |      |      +--> adapter <adapter_cmd...>
+          |      |      +--> review (same command, after producer handoff)
+          |      |
+          |      +--> WAITING_FOR_SIMPLE_ADDRESS
+          |      |      |
+          |      |      +--> address --lean
+          |      |      +--> threads --lean
+          |      |      +--> agent classify
+          |      |      +--> agent next --role fixer
+          |      |      +--> agent next --batch
+          |      |
+          |      +--> session work items
+          |
+          +-- address [--lean|--summary]
+          |      |
+          |      +--> threads [--lean|--summary]
+          |      +--> agent fix
+          |      +--> agent next --batch
+          |      +--> agent submit-batch
+          |      +--> agent publish
+          |
+          +-- threads [--lean|--summary]
+          |      |
+          |      +--> agent classify
+          |      +--> agent next
+          |      +--> agent fix
+          |      +--> agent resolve-stale
+          |
+          +-- findings --input <json|->
+          |      |
+          |      +--> agent classify
+          |      +--> agent next
+          |      +--> agent submit
+          |
+          +-- adapter <adapter_cmd...>
+          |      |
+          |      +--> findings contract
+          |      +--> review/address session sync
+          |
+          +-- agent <subcommand>
+          |      |
+          |      +--> manifest
+          |      |
+          |      +--> classify
+          |      |      |
+          |      |      +--> next --role fixer
+          |      |
+          |      +--> next --role <role>
+          |      |      |
+          |      |      +--> ActionRequest
+          |      |      +--> ActionResponse skeleton
+          |      |      +--> submit
+          |      |
+          |      +--> next --batch
+          |      |      |
+          |      |      +--> BatchActionResponse skeleton
+          |      |      +--> submit-batch
+          |      |      +--> fix-all --input <batch-response.json>
+          |      |
+          |      +--> submit
+          |      |      |
+          |      |      +--> accepted evidence
+          |      |      +--> publish (GitHub thread fixes)
+          |      |      +--> final-gate
+          |      |
+          |      +--> submit-batch
+          |      |      |
+          |      |      +--> per-item accepted evidence
+          |      |      +--> publish
+          |      |      +--> final-gate
+          |      |
+          |      +--> fix
+          |      |      |
+          |      |      +--> classify + next + submit shortcut
+          |      |      +--> publish (--publish or explicit publish)
+          |      |
+          |      +--> trivial-fix
+          |      |      |
+          |      |      +--> narrow documentation/typo fix shortcut
+          |      |      +--> publish (--publish or explicit publish)
+          |      |
+          |      +--> fix-all
+          |      |      |
+          |      |      +--> --input <batch-response.json> -> submit-batch path
+          |      |      +--> --homogeneous-reason <why> -> homogeneous batch shortcut
+          |      |      +--> PER_THREAD_EVIDENCE_REQUIRED -> next --batch
+          |      |
+          |      +--> resolve-stale
+          |      |      |
+          |      |      +--> stale/outdated thread evidence
+          |      |      +--> publish
+          |      |      +--> final-gate
+          |      |
+          |      +--> evidence add
+          |      |      |
+          |      |      +--> evidence_ref in ActionResponse or BatchActionResponse
+          |      |
+          |      +--> evidence list
+          |      |
+          |      +--> publish
+          |      |      |
+          |      |      +--> GitHub reply + resolve side effects
+          |      |      +--> final-gate
+          |      |
+          |      +--> leases
+          |      +--> reclaim
+          |      |
+          |      +--> orchestrate start
+          |      +--> orchestrate step
+          |      +--> orchestrate status
+          |      +--> orchestrate resume
+          |      +--> orchestrate stop
+          |      +--> orchestrate submit
+          |      +--> orchestrate autopilot
+          |
+          +-- final-gate [--require-checks|--require-required-checks]
+          |      |
+          |      +--> PASS -> completion_summary_line + audit summary
+          |      +--> FAIL -> address/threads/agent publish/agent next --batch
+          |
+          +-- telemetry ingest
+          |      |
+          |      +--> telemetry summary
+          |      +--> final-gate telemetry coverage
+          |
+          +-- telemetry summary
+          |      |
+          |      +--> efficiency report artifact
+          |
+          +-- command-session --input <operations.json|->
+          |      |
+          |      +--> repeated gh-address-cr operations
+          |
+          +-- review-to-findings --input <finding-blocks.md|->
+          |      |
+          |      +--> findings --input <json|->
+          |
+          +-- submit-action <action-request.json>
+          |      |
+          |      +--> generated ActionResponse
+          |      +--> agent submit
+          |
+          +-- submit-feedback
+          |      |
+          |      +--> maintainer issue intake for repeatable skill/runtime gaps
+          |
+          +-- doctor
+          |      |
+          |      +--> rerun blocked command after environment repair
+          |
+          +-- version / --version
+          |
+          +-- global output flags
+                 |
+                 +--> --machine
+                 +--> --human
+```
+
+Verification boundaries:
+
+```text
+producer output
+  -> review-to-findings/findings/adapter
+  -> session items
+  -> agent classify
+  -> agent next or agent next --batch
+  -> ActionResponse or BatchActionResponse
+  -> agent submit or agent submit-batch
+  -> accepted evidence
+  -> agent publish (GitHub thread side effects only)
+  -> final-gate
+  -> completion_summary_line
+```
+
+Batch-specific verification:
+
+```text
+fix-all PER_THREAD_EVIDENCE_REQUIRED
+  -> commands.batch_next
+  -> agent next --batch
+  -> runtime-owned leases + request_id values
+  -> batch-response-skeleton.json
+  -> agent fills common evidence + per-item summary/why
+  -> agent submit-batch validates lease ownership and request context
+  -> agent publish posts replies and resolves threads
+  -> final-gate verifies no unresolved threads remain
+```
+
 Stable machine summary fields:
 
 - `status`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,31 +4,47 @@
 
 `gh-address-cr` should be understood first as a PR-scoped workflow orchestrator.
 
-Primary commands:
+Primary workflow commands:
 
 - `active-pr`
 - `review`
 - `address`
 - `final-gate`
 
-Advanced/internal integration entrypoints:
+Other public top-level commands:
 
 - `threads`
 - `findings`
 - `adapter`
+- `telemetry ingest`
+- `telemetry summary`
+- `command-session`
 - `review-to-findings`
+- `submit-action`
+- `submit-feedback`
+- `doctor`
+- `version`
+
+Advanced/internal integration entrypoints:
+
+Agent protocol entrypoints:
+
 - `agent manifest`
 - `agent classify`
 - `agent next`
+- `agent next --batch`
 - `agent submit`
 - `agent submit-batch`
 - `agent fix`
+- `agent trivial-fix`
 - `agent fix-all`
 - `agent resolve-stale`
-- `agent evidence`
+- `agent evidence add`
+- `agent evidence list`
 - `agent publish`
 - `agent leases`
 - `agent reclaim`
+- `agent orchestrate`
 
 Fail-fast contract:
 
@@ -140,8 +156,7 @@ downstream command in this map.
           |      +--> next --batch
           |      |      |
           |      |      +--> BatchActionResponse skeleton
-          |      |      +--> submit-batch
-          |      |      +--> fix-all --input <batch-response.json>
+          |      |      +--> submit-batch or fix-all --input <batch-response.json>
           |      |
           |      +--> submit
           |      |      |
@@ -268,6 +283,7 @@ fix-all PER_THREAD_EVIDENCE_REQUIRED
   -> batch-response-skeleton.json
   -> agent fills common evidence + per-item summary/why
   -> agent submit-batch validates lease ownership and request context
+  -> agent fix-all --input routes to the same batch evidence validation path
   -> agent publish posts replies and resolves threads
   -> final-gate verifies no unresolved threads remain
 ```
@@ -314,18 +330,21 @@ The runtime is the coordinator. AI agents consume structured requests and return
 gh-address-cr agent manifest
 gh-address-cr agent classify owner/repo 123 local-finding:abc --classification fix --note "Real defect."
 gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1
+gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1 --batch
 gh-address-cr agent submit owner/repo 123 --input action-response.json
 gh-address-cr agent submit owner/repo 123 --input action-response.json --publish
 gh-address-cr agent submit-batch owner/repo 123 --input batch-response.json
 gh-address-cr agent evidence add owner/repo 123 --name local-verified --commit <sha> --files src/example.py --validation "python3 -m unittest tests.test_example=passed" [--severity P0|P1|P2|P3|P4 --severity-note <why>]
+gh-address-cr agent evidence list owner/repo 123
 gh-address-cr agent fix owner/repo 123 github-thread:THREAD_ID --commit <sha> --files src/example.py --summary "Fixed it." --why "The guarded path covers the review case." --validation "python3 -m unittest tests.test_example=passed" [--severity P0|P1|P2|P3|P4 --severity-note <why>] --publish
+gh-address-cr agent trivial-fix owner/repo 123 github-thread:THREAD_ID --commit <sha> --files docs/example.md --summary "Fixed typo." --validation "docs-only=passed" --publish
 gh-address-cr agent fix-all owner/repo 123 --input batch-response.json
 gh-address-cr agent fix-all owner/repo 123 --commit <sha> --files src/shared.py --validation "python3 -m unittest tests.test_shared=passed" --homogeneous-reason "Repeated same-file thread concern." [--severity P0|P1|P2|P3|P4 --severity-note <why>]
 gh-address-cr agent resolve-stale owner/repo 123 --commit <sha> --files src/stale.py --validation "python3 -m unittest tests.test_stale=passed" --match-files
 gh-address-cr agent publish owner/repo 123
 gh-address-cr agent leases owner/repo 123
 gh-address-cr agent reclaim owner/repo 123
-gh-address-cr agent orchestrate {start,step,status,stop,resume,submit} owner/repo 123
+gh-address-cr agent orchestrate {start,step,status,stop,resume,submit,autopilot} owner/repo 123
 gh-address-cr doctor owner/repo 123
 gh-address-cr final-gate owner/repo 123
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -330,7 +330,7 @@ The runtime is the coordinator. AI agents consume structured requests and return
 gh-address-cr agent manifest
 gh-address-cr agent classify owner/repo 123 local-finding:abc --classification fix --note "Real defect."
 gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1
-gh-address-cr agent next owner/repo 123 --role fixer --agent-id codex-fixer-1 --batch
+gh-address-cr agent next owner/repo 123 --batch --agent-id codex-fixer-1
 gh-address-cr agent submit owner/repo 123 --input action-response.json
 gh-address-cr agent submit owner/repo 123 --input action-response.json --publish
 gh-address-cr agent submit-batch owner/repo 123 --input batch-response.json

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -34,6 +34,7 @@ Agent protocol commands:
 /gh-address-cr agent manifest
 /gh-address-cr agent classify <owner/repo> <pr_number> <item_id> --classification <fix|clarify|defer|reject> --note <why>
 /gh-address-cr agent next <owner/repo> <pr_number> --role <role> --agent-id <id>
+/gh-address-cr agent next <owner/repo> <pr_number> --batch --agent-id <id>
 /gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>
 /gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>
 /gh-address-cr agent fix <owner/repo> <pr_number> <item_id> --commit <sha> --files <paths> --summary <text> --why <text> --validation <cmd=passed>
@@ -115,7 +116,7 @@ When exactly one cached PR session exists, PR-scoped commands may omit `<owner/r
 
 If `review` returns `BLOCKED`, inspect the loop request artifact, apply `fix`, `clarify`, `defer`, or `reject` through runtime evidence, then rerun the same `review` command.
 
-GitHub review comment reply tasks must be submitted to the runtime before they can be published. Draft structured fix evidence inside an `ActionResponse` or `BatchActionResponse`, submit it with `gh-address-cr agent submit` or `gh-address-cr agent submit-batch`, then run `gh-address-cr agent publish <owner/repo> <pr_number>` so the runtime hydrates commit evidence, records reply evidence, and resolves the thread safely. For shared files/validation evidence, keep per-thread summary/why entries in the batch; use `agent fix-all --homogeneous-reason <why>` only for a homogeneous repeated concern. Use `agent trivial-fix` only for documentation or typo-only GitHub threads; if the runtime reports `TRIVIAL_THREAD_NOT_ELIGIBLE`, return to the normal classify/next/submit path.
+GitHub review comment reply tasks must be submitted to the runtime before they can be published. Draft structured fix evidence inside an `ActionResponse` or `BatchActionResponse`, submit it with `gh-address-cr agent submit` or `gh-address-cr agent submit-batch`, then run `gh-address-cr agent publish <owner/repo> <pr_number>` so the runtime hydrates commit evidence, records reply evidence, and resolves the thread safely. For shared files/validation evidence, keep per-thread summary/why entries in the batch; when `fix-all` reports `PER_THREAD_EVIDENCE_REQUIRED`, run `gh-address-cr agent next <owner/repo> <pr_number> --batch --agent-id <id>` to claim eligible GitHub review threads and write a fillable batch skeleton. Use `agent fix-all --homogeneous-reason <why>` only for a homogeneous repeated concern. Use `agent trivial-fix` only for documentation or typo-only GitHub threads; if the runtime reports `TRIVIAL_THREAD_NOT_ELIGIBLE`, return to the normal classify/next/submit path.
 
 Prefer `workflow_decision.v1` JSON for structured triage handoff when available. Required fields are `schema_version`, `request_id`, `item_id`, `decision`, and `reason`; Markdown decision blocks remain compatibility prose, not the preferred machine contract.
 

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -8,7 +8,7 @@ interface:
     2. Start with `gh-address-cr review <owner/repo> <pr_number>` or `gh-address-cr address <owner/repo> <pr_number>`.
     3. For multi-agent work, inspect `gh-address-cr agent manifest`, claim with `agent next`, fill `response_skeleton_path`, submit evidence with `agent submit` or GitHub-thread batch evidence with `agent submit-batch`, reuse evidence with `agent evidence add` when appropriate, inspect with `agent leases`, and recover stale claims with `agent reclaim`.
     4. GitHub review comment reply tasks are not complete when a reply is drafted. Submit the `ActionResponse` with `gh-address-cr agent submit` or the `BatchActionResponse` with `gh-address-cr agent submit-batch`, preserving per-thread summary/why, then run `gh-address-cr agent publish`.
-    4a. Use `agent fix-all --homogeneous-reason <why>` only for a homogeneous repeated concern; mixed reviewer questions need per-thread batch evidence.
+    4a. Use `agent fix-all --homogeneous-reason <why>` only for a homogeneous repeated concern; when mixed reviewer questions return `PER_THREAD_EVIDENCE_REQUIRED`, run `agent next --batch --agent-id <id>` to create the batch leases and skeleton before `agent submit-batch`.
     5. AI agents may classify, fix, clarify, defer, reject, or verify. They must not post GitHub replies or resolve threads directly.
     6. GitHub review threads require both reply and resolve, with durable reply evidence from the current authenticated login.
     7. Local findings require valid terminal notes and validation evidence.

--- a/skill/references/agent-protocol.md
+++ b/skill/references/agent-protocol.md
@@ -31,6 +31,8 @@ High-level commands emit structured JSON by default. Agents must consume these f
   - Records triage-phase evidence before a mutating fixer lease is issued.
 - `gh-address-cr agent next <owner/repo> <pr_number> --role <role> --agent-id <id>`
   - Claims one eligible item and writes an `ActionRequest`.
+- `gh-address-cr agent next <owner/repo> <pr_number> --batch --agent-id <id>`
+  - Claims eligible non-stale GitHub review-thread `fix` items for the agent and writes a fillable `BatchActionResponse` skeleton.
 - `gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>`
   - Validates an `ActionResponse`, lease ownership, and required evidence.
 - `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>`
@@ -108,6 +110,6 @@ For `--validation`, use `<command>=<result>` when you need a result other than t
 
 ## Batch Notes
 
-`BatchActionResponse` is limited to GitHub review-thread `fix` evidence with existing per-item leases; it is not a GitHub publishing shortcut and does not support local findings. Prefer `agent submit-batch` when one files/validation set addresses multiple already-synced GitHub threads, and keep per-thread summary/why entries for reviewer-facing replies. Commit evidence is a publish-time hydration input, not a worker-submit prerequisite. Use `agent fix-all` only with `--input <batch-response.json>` or with `--homogeneous-reason <why>` for a homogeneous repeated concern.
+`BatchActionResponse` is limited to GitHub review-thread `fix` evidence with existing per-item leases; it is not a GitHub publishing shortcut and does not support local findings. Prefer `agent submit-batch` when one files/validation set addresses multiple already-synced GitHub threads, and keep per-thread summary/why entries for reviewer-facing replies. Commit evidence is a publish-time hydration input, not a worker-submit prerequisite. Use `agent fix-all` only with `--input <batch-response.json>` or with `--homogeneous-reason <why>` for a homogeneous repeated concern. When `fix-all` returns `PER_THREAD_EVIDENCE_REQUIRED`, run `agent next --batch --agent-id <id>` to create the batch leases and skeleton instead of hand-writing the JSON shape.
 
 `agent next` emits both `request_path` and `response_skeleton_path`. Prefer filling the skeleton instead of hand-writing `ActionResponse` JSON. Required user-supplied fields are intentionally empty so an unedited skeleton is rejected instead of published.

--- a/skill/references/status-action-map.md
+++ b/skill/references/status-action-map.md
@@ -26,8 +26,11 @@ If `reason_code` is `WAITING_FOR_SIMPLE_ADDRESS`:
 - **GitHub review comment reply tasks**: A reply draft is not a submitted task. Fill the issued `response_skeleton_path` or `batch_response_skeleton`, then run `gh-address-cr agent submit <owner/repo> <pr_number> --input <response.json>` or `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>` before `gh-address-cr agent publish <owner/repo> <pr_number>`.
 - **Lean path**: Re-run `gh-address-cr address <owner/repo> <pr_number> --lean` or `gh-address-cr threads <owner/repo> <pr_number> --lean` when only item IDs, claimability, and evidence presence are needed.
 
+If `reason_code` is `PER_THREAD_EVIDENCE_REQUIRED`:
+- **Action**: Run the returned `commands.batch_next` or `gh-address-cr agent next <owner/repo> <pr_number> --batch --agent-id <id>` to claim eligible GitHub review threads and write `batch-response-skeleton.json`. Fill common files/validation plus per-thread summary/why, then run the returned `submit_batch` command and publish.
+
 If `reason_code` is `FINAL_GATE_UNRESOLVED_REMOTE_THREADS` or `FINAL_GATE_BLOCKING_GITHUB_ITEMS`:
-- **Action**: Run the returned `next_action` exactly. The normal recovery is `gh-address-cr address <owner/repo> <pr_number> --lean`, then `gh-address-cr agent submit-batch <owner/repo> <pr_number> --input <batch-response.json>` or per-thread `agent fix`. Use `gh-address-cr agent fix-all ... --homogeneous-reason <why>` only for a homogeneous repeated concern. Follow with `gh-address-cr agent publish <owner/repo> <pr_number>` and `gh-address-cr final-gate <owner/repo> <pr_number>`.
+- **Action**: Run the returned `next_action` exactly. The normal recovery is `gh-address-cr address <owner/repo> <pr_number> --lean`, then `gh-address-cr agent next <owner/repo> <pr_number> --batch --agent-id <id>` for shared batch evidence or per-thread `agent fix`. Use `gh-address-cr agent fix-all ... --homogeneous-reason <why>` only for a homogeneous repeated concern. Follow with `gh-address-cr agent publish <owner/repo> <pr_number>` and `gh-address-cr final-gate <owner/repo> <pr_number>`.
 
 If `reason_code` is `FINAL_GATE_MISSING_REPLY_EVIDENCE`:
 - **Action**: Run `gh-address-cr agent publish <owner/repo> <pr_number>` when accepted evidence is present, then rerun `gh-address-cr final-gate <owner/repo> <pr_number>`.

--- a/src/gh_address_cr/commands/agent.py
+++ b/src/gh_address_cr/commands/agent.py
@@ -177,14 +177,15 @@ def handle_agent_next(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--agent-id", default="agent")
     parser.add_argument("--item-id")
     parser.add_argument("--now")
-    parser.add_argument(
-        "--batch",
-        action="store_true",
-        help="Claim eligible GitHub review-thread fixes and write a BatchActionResponse skeleton.",
-    )
+    parser.add_argument("--batch", action="store_true", help="Generate a skeleton batch-response.json for all unresolved threads.")
+    parser.add_argument("--files", help="Only batch lease threads that affect these files (comma-separated).")
     parsed = parser.parse_args(_prepend_optional(repo, passthrough))
     if not parsed.batch and not parsed.role:
         parser.error("one of the following arguments is required: --role or --batch")
+    if parsed.batch and parsed.role:
+        parser.error("arguments --role and --batch are mutually exclusive")
+    if not parsed.batch and parsed.files:
+        parser.error("argument --files can only be used with --batch")
     try:
         now_dt = None
         if parsed.now:
@@ -194,6 +195,7 @@ def handle_agent_next(repo: str | None, passthrough: list[str]) -> int:
                 parsed.repo,
                 parsed.pr_number,
                 agent_id=parsed.agent_id,
+                files=_parse_agent_files(parsed.files),
                 now=now_dt,
             )
         else:

--- a/src/gh_address_cr/commands/agent.py
+++ b/src/gh_address_cr/commands/agent.py
@@ -88,6 +88,7 @@ def build_agent_manifest() -> dict:
         "output_formats": [
             "action_response.v1",
             "batch_action_response.v1",
+            "batch_action_response_skeleton.v1",
             "evidence_record.v1",
             "evidence_profile.v1",
             "gate_report.v1",
@@ -172,23 +173,38 @@ def handle_agent_next(repo: str | None, passthrough: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="gh-address-cr agent next")
     parser.add_argument("repo")
     parser.add_argument("pr_number")
-    parser.add_argument("--role", required=True)
+    parser.add_argument("--role")
     parser.add_argument("--agent-id", default="agent")
     parser.add_argument("--item-id")
     parser.add_argument("--now")
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Claim eligible GitHub review-thread fixes and write a BatchActionResponse skeleton.",
+    )
     parsed = parser.parse_args(_prepend_optional(repo, passthrough))
+    if not parsed.batch and not parsed.role:
+        parser.error("one of the following arguments is required: --role or --batch")
     try:
         now_dt = None
         if parsed.now:
             now_dt = datetime.fromisoformat(parsed.now.replace("Z", "+00:00"))
-        payload = agent_protocol.issue_action_request(
-            parsed.repo,
-            parsed.pr_number,
-            role=parsed.role,
-            agent_id=parsed.agent_id,
-            item_id=parsed.item_id,
-            now=now_dt,
-        )
+        if parsed.batch:
+            payload = agent_protocol.issue_batch_action_request(
+                parsed.repo,
+                parsed.pr_number,
+                agent_id=parsed.agent_id,
+                now=now_dt,
+            )
+        else:
+            payload = agent_protocol.issue_action_request(
+                parsed.repo,
+                parsed.pr_number,
+                role=parsed.role,
+                agent_id=parsed.agent_id,
+                item_id=parsed.item_id,
+                now=now_dt,
+            )
     except WorkflowError as exc:
         return output_workflow_error(exc, repo=parsed.repo, pr_number=parsed.pr_number)
     sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/src/gh_address_cr/commands/agent.py
+++ b/src/gh_address_cr/commands/agent.py
@@ -177,7 +177,7 @@ def handle_agent_next(repo: str | None, passthrough: list[str]) -> int:
     parser.add_argument("--agent-id", default="agent")
     parser.add_argument("--item-id")
     parser.add_argument("--now")
-    parser.add_argument("--batch", action="store_true", help="Generate a skeleton batch-response.json for all unresolved threads.")
+    parser.add_argument("--batch", action="store_true", help="Generate a skeleton batch-response-skeleton.json for all unresolved threads.")
     parser.add_argument("--files", help="Only batch lease threads that affect these files (comma-separated).")
     parsed = parser.parse_args(_prepend_optional(repo, passthrough))
     if not parsed.batch and not parsed.role:

--- a/src/gh_address_cr/commands/high_level.py
+++ b/src/gh_address_cr/commands/high_level.py
@@ -340,6 +340,7 @@ def summary_commands(repo: str, pr_number: str) -> dict[str, str]:
         "threads": f"gh-address-cr threads {repo} {pr_number} --lean",
         "classify": f"gh-address-cr agent classify {repo} {pr_number} <item_id> --classification fix --note <note>",
         "next": f"gh-address-cr agent next {repo} {pr_number} --role fixer --agent-id <agent_id>",
+        "batch_next": f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>",
         "submit": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
         "submit_batch": f"gh-address-cr agent submit-batch {repo} {pr_number} --input batch-response.json",
         "fix_all": f"gh-address-cr agent fix-all {repo} {pr_number} --input batch-response.json",

--- a/src/gh_address_cr/core/agent_protocol.py
+++ b/src/gh_address_cr/core/agent_protocol.py
@@ -277,6 +277,256 @@ def issue_action_request(
     }
 
 
+def issue_batch_action_request(
+    repo: str,
+    pr_number: str,
+    *,
+    agent_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current_time = _coerce_now(now)
+    session = session_store.load_session(repo, pr_number)
+    ledger = _ledger(session)
+    expired = expire_leases(session, now=current_time)
+    _return_expired_items_to_open(session, expired)
+
+    target_items = []
+    for item_id, item in _items(session).items():
+        if not is_github_thread_item(item):
+            continue
+        existing_lease = _active_fixer_lease_for_item(session, item_id, agent_id=agent_id)
+        if existing_lease is not None or _is_batch_claimable_github_thread(item):
+            target_items.append((item_id, item))
+
+    if not target_items:
+        session_store.save_session(repo, pr_number, session)
+        raise WorkflowError(
+            status="NO_ELIGIBLE_ITEM",
+            reason_code="NO_ELIGIBLE_ITEM",
+            waiting_on="work_item",
+            exit_code=4,
+            message="No eligible unresolved github review thread exists.",
+        )
+
+    leased_items = []
+    for item_id, item in target_items:
+        existing_lease = _active_fixer_lease_for_item(session, item_id, agent_id=agent_id)
+
+        if existing_lease:
+            lease_id = existing_lease["lease_id"]
+            request_id = existing_lease.get("request_id") or ""
+            if not request_id:
+                request_id = _stable_id(
+                    "req",
+                    {
+                        "session_id": session["session_id"],
+                        "item_id": item_id,
+                        "role": "fixer",
+                        "agent_id": agent_id,
+                        "lease_id": lease_id,
+                    },
+                )
+                existing_lease["request_id"] = request_id
+            leased_items.append(
+                {
+                    "item_id": item_id,
+                    "lease_id": lease_id,
+                    "request_id": request_id,
+                }
+            )
+        else:
+            if not _has_classification_evidence(item):
+                item["classification_evidence"] = {
+                    "event_type": "classification_recorded",
+                    "classification": "fix",
+                    "note": "Batch fix skeleton requested by agent next --batch.",
+                    "record_id": _stable_id(
+                        "classification",
+                        {
+                            "session_id": session["session_id"],
+                            "item_id": item_id,
+                            "agent_id": agent_id,
+                            "role": "fixer",
+                        },
+                    ),
+                }
+                item["decision"] = "fix"
+                ledger.append_event(
+                    session_id=str(session["session_id"]),
+                    item_id=item_id,
+                    lease_id=None,
+                    agent_id=agent_id,
+                    role="fixer",
+                    event_type="classification_recorded",
+                    payload={
+                        "classification": "fix",
+                        "note": "Batch fix skeleton requested by agent next --batch.",
+                    },
+                )
+            lease_id = f"lease_{uuid4().hex}"
+            request_id = _stable_id(
+                "req",
+                {
+                    "session_id": session["session_id"],
+                    "item_id": item_id,
+                    "role": "fixer",
+                    "agent_id": agent_id,
+                    "lease_id": lease_id,
+                },
+            )
+            request_item = dict(item)
+            request_item["state"] = "claimed"
+            request = {
+                "schema_version": PROTOCOL_VERSION,
+                "request_id": request_id,
+                "session_id": session["session_id"],
+                "lease_id": lease_id,
+                "agent_role": "fixer",
+                "item": request_item,
+                "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
+                "required_evidence": _required_evidence_for(item, "fixer"),
+                "repository_context": {"repo": repo, "pr_number": str(pr_number)},
+                "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
+                "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+            }
+            handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
+            if handling_boundary is not None:
+                request["handling_boundary"] = handling_boundary
+            request_hash = ActionRequest.from_dict(request).stable_hash()
+            request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
+            response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
+            request["response_skeleton_path"] = str(response_skeleton_path)
+
+            try:
+                claim_lease(
+                    session,
+                    item,
+                    agent_id=agent_id,
+                    role="fixer",
+                    request_hash=request_hash,
+                    lease_id=lease_id,
+                    now=current_time,
+                    request_id=request_id,
+                    request_path=str(request_path),
+                    resume_token=f"resume:{request_id}",
+                    allow_same_agent_github_thread_file_overlap=True,
+                )
+            except LeaseConflictError as exc:
+                session_store.save_session(repo, pr_number, session)
+                raise WorkflowError(
+                    status="LEASE_REJECTED",
+                    reason_code=exc.reason_code,
+                    waiting_on="lease",
+                    exit_code=5,
+                    message=str(exc),
+                    payload={"item_id": item_id},
+                ) from exc
+
+            item["state"] = "claimed"
+            item["active_lease_id"] = lease_id
+            request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
+            response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            ledger.append_event(
+                session_id=str(session["session_id"]),
+                item_id=item_id,
+                lease_id=lease_id,
+                agent_id=agent_id,
+                role="fixer",
+                event_type="request_issued",
+                payload={
+                    "request_id": request_id,
+                    "request_path": str(request_path),
+                    "response_skeleton_path": str(response_skeleton_path),
+                },
+            )
+
+            leased_items.append(
+                {
+                    "item_id": item_id,
+                    "lease_id": lease_id,
+                    "request_id": request_id,
+                }
+            )
+
+    batch_skeleton = {
+        "schema_version": PROTOCOL_VERSION,
+        "agent_id": agent_id,
+        "resolution": "fix",
+        "common": {
+            "files": [],
+            "commit_hash": "",
+            "validation_commands": [
+                {
+                    "command": "",
+                    "result": "passed",
+                }
+            ],
+            "fix_reply": {
+                "summary": "",
+                "why": "",
+            },
+        },
+        "items": [
+            {
+                "item_id": item_info["item_id"],
+                "request_id": item_info["request_id"],
+                "lease_id": item_info["lease_id"],
+                "fix_reply": {
+                    "summary": "",
+                    "why": "",
+                },
+            }
+            for item_info in leased_items
+        ],
+    }
+
+    batch_skeleton_path = session_store.workspace_dir(repo, pr_number) / "batch-response-skeleton.json"
+    batch_skeleton_path.write_text(json.dumps(batch_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    session_store.save_session(repo, pr_number, session)
+
+    submit_command = f"gh-address-cr agent submit-batch {repo} {pr_number} --input {batch_skeleton_path}"
+    return {
+        "status": "BATCH_ACTION_REQUESTED",
+        "repo": repo,
+        "pr_number": str(pr_number),
+        "response_skeleton_path": str(batch_skeleton_path),
+        "lease_count": len(leased_items),
+        "leased_items": leased_items,
+        "commands": {
+            "submit_batch": submit_command,
+            "fix_all": f"gh-address-cr agent fix-all {repo} {pr_number} --input {batch_skeleton_path}",
+            "publish": f"gh-address-cr agent publish {repo} {pr_number}",
+        },
+        "next_action": f"Edit {batch_skeleton_path} and submit it with `{submit_command}`.",
+    }
+
+
+def _active_fixer_lease_for_item(
+    session: dict[str, Any], item_id: str, *, agent_id: str | None = None
+) -> dict[str, Any] | None:
+    for lease in session.get("leases", {}).values():
+        if not isinstance(lease, dict):
+            continue
+        if lease.get("item_id") != item_id:
+            continue
+        if lease.get("status") != "active":
+            continue
+        if lease.get("role") != "fixer":
+            continue
+        if agent_id is not None and lease.get("agent_id") != agent_id:
+            continue
+        return lease
+    return None
+
+
+def _is_batch_claimable_github_thread(item: dict[str, Any]) -> bool:
+    return is_claimable_github_thread(item) and not is_stale_github_thread_item(item)
+
+
 def _handling_boundary_summary_or_none(item: dict[str, Any], *, role: str) -> dict[str, Any] | None:
     if role != "fixer" or item.get("item_kind") != "github_thread":
         return None

--- a/src/gh_address_cr/core/agent_protocol.py
+++ b/src/gh_address_cr/core/agent_protocol.py
@@ -422,6 +422,14 @@ def issue_batch_action_request(
                 if max_to_lease <= 0:
                     continue
 
+                if _has_classification_evidence(item):
+                    evidence = item.get("classification_evidence")
+                    decision = evidence.get("classification") if isinstance(evidence, dict) else None
+                    if not decision:
+                        decision = item.get("decision")
+                    if decision != "fix":
+                        continue
+
                 if not _has_classification_evidence(item):
                     item["classification_evidence"] = {
                         "event_type": "classification_recorded",
@@ -451,84 +459,84 @@ def issue_batch_action_request(
                         },
                     )
 
-                    lease_id = f"lease_{uuid4().hex}"
-                    request_id = _stable_id(
-                        "req",
-                        {
-                            "session_id": session["session_id"],
-                            "item_id": item_id,
-                            "role": "fixer",
-                            "agent_id": agent_id,
-                            "lease_id": lease_id,
-                        },
-                    )
-                    request_item = dict(item)
-                    request_item["state"] = "claimed"
-                    request = {
-                        "schema_version": PROTOCOL_VERSION,
-                        "request_id": request_id,
+                lease_id = f"lease_{uuid4().hex}"
+                request_id = _stable_id(
+                    "req",
+                    {
                         "session_id": session["session_id"],
+                        "item_id": item_id,
+                        "role": "fixer",
+                        "agent_id": agent_id,
                         "lease_id": lease_id,
-                        "agent_role": "fixer",
-                        "item": request_item,
-                        "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
-                        "required_evidence": _required_evidence_for(item, "fixer"),
-                        "repository_context": {"repo": repo, "pr_number": str(pr_number)},
-                        "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
-                        "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+                    },
+                )
+                request_item = dict(item)
+                request_item["state"] = "claimed"
+                request = {
+                    "schema_version": PROTOCOL_VERSION,
+                    "request_id": request_id,
+                    "session_id": session["session_id"],
+                    "lease_id": lease_id,
+                    "agent_role": "fixer",
+                    "item": request_item,
+                    "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
+                    "required_evidence": _required_evidence_for(item, "fixer"),
+                    "repository_context": {"repo": repo, "pr_number": str(pr_number)},
+                    "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
+                    "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+                }
+                handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
+                if handling_boundary is not None:
+                    request["handling_boundary"] = handling_boundary
+                request_hash = ActionRequest.from_dict(request).stable_hash()
+                request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
+                response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
+                request["response_skeleton_path"] = str(response_skeleton_path)
+
+                claim_lease(
+                    session,
+                    item,
+                    agent_id=agent_id,
+                    role="fixer",
+                    request_hash=request_hash,
+                    lease_id=lease_id,
+                    now=current_time,
+                    request_id=request_id,
+                    request_path=str(request_path),
+                    resume_token=f"resume:{request_id}",
+                    allow_same_agent_github_thread_file_overlap=True,
+                )
+
+                item["state"] = "claimed"
+                item["active_lease_id"] = lease_id
+                request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
+                response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                ledger.append_event(
+                    session_id=str(session["session_id"]),
+                    item_id=item_id,
+                    lease_id=lease_id,
+                    agent_id=agent_id,
+                    role="fixer",
+                    event_type="request_issued",
+                    payload={
+                        "request_id": request_id,
+                        "request_path": str(request_path),
+                        "response_skeleton_path": str(response_skeleton_path),
+                    },
+                )
+
+                leased_items.append(
+                    {
+                        "item_id": item_id,
+                        "lease_id": lease_id,
+                        "request_id": request_id,
                     }
-                    handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
-                    if handling_boundary is not None:
-                        request["handling_boundary"] = handling_boundary
-                    request_hash = ActionRequest.from_dict(request).stable_hash()
-                    request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
-                    response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
-                    request["response_skeleton_path"] = str(response_skeleton_path)
-
-                    claim_lease(
-                        session,
-                        item,
-                        agent_id=agent_id,
-                        role="fixer",
-                        request_hash=request_hash,
-                        lease_id=lease_id,
-                        now=current_time,
-                        request_id=request_id,
-                        request_path=str(request_path),
-                        resume_token=f"resume:{request_id}",
-                        allow_same_agent_github_thread_file_overlap=True,
-                    )
-
-                    item["state"] = "claimed"
-                    item["active_lease_id"] = lease_id
-                    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-                    response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
-                    response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-                    ledger.append_event(
-                        session_id=str(session["session_id"]),
-                        item_id=item_id,
-                        lease_id=lease_id,
-                        agent_id=agent_id,
-                        role="fixer",
-                        event_type="request_issued",
-                        payload={
-                            "request_id": request_id,
-                            "request_path": str(request_path),
-                            "response_skeleton_path": str(response_skeleton_path),
-                        },
-                    )
-
-                    leased_items.append(
-                        {
-                            "item_id": item_id,
-                            "lease_id": lease_id,
-                            "request_id": request_id,
-                        }
-                    )
-                    newly_leased_items.append((lease_id, item))
-                    max_to_lease -= 1
+                )
+                newly_leased_items.append((lease_id, item))
+                max_to_lease -= 1
 
     except Exception as exc:
         # Thread 7: Roll back newly leased items in this batch on failure
@@ -577,8 +585,14 @@ def issue_batch_action_request(
                         existing_items_replies[itm["item_id"]] = itm.get("fix_reply")
                 if isinstance(existing_data.get("common"), dict):
                     existing_common = existing_data["common"]
-        except Exception:
-            pass
+        except Exception as exc:
+            raise WorkflowError(
+                status="INVALID_BATCH_SKELETON",
+                reason_code="INVALID_JSON",
+                waiting_on="batch_action_response",
+                exit_code=5,
+                message=f"Failed to parse existing batch skeleton JSON: {exc}",
+            ) from exc
 
     items_list = []
     for item_info in leased_items:

--- a/src/gh_address_cr/core/agent_protocol.py
+++ b/src/gh_address_cr/core/agent_protocol.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from gh_address_cr import PROTOCOL_VERSION
+from gh_address_cr import PROTOCOL_VERSION, MAX_PARALLEL_CLAIMS
 from gh_address_cr.core import session as session_store
 from gh_address_cr.core.errors import WorkflowError
 from gh_address_cr.core.github_thread_state import (
@@ -282,6 +282,7 @@ def issue_batch_action_request(
     pr_number: str,
     *,
     agent_id: str,
+    files: list[str] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     current_time = _coerce_now(now)
@@ -290,10 +291,24 @@ def issue_batch_action_request(
     expired = expire_leases(session, now=current_time)
     _return_expired_items_to_open(session, expired)
 
+    active_leases_count = sum(
+        1
+        for lease in session.get("leases", {}).values()
+        if isinstance(lease, dict)
+        and lease.get("status") == "active"
+        and lease.get("role") == "fixer"
+        and lease.get("agent_id") == agent_id
+    )
+    max_to_lease = max(0, MAX_PARALLEL_CLAIMS - active_leases_count)
+
     target_items = []
     for item_id, item in _items(session).items():
         if not is_github_thread_item(item):
             continue
+        if files:
+            item_path = item.get("path")
+            if not item_path or item_path not in files:
+                continue
         existing_lease = _active_fixer_lease_for_item(session, item_id, agent_id=agent_id)
         if existing_lease is not None or _is_batch_claimable_github_thread(item):
             target_items.append((item_id, item))
@@ -309,183 +324,303 @@ def issue_batch_action_request(
         )
 
     leased_items = []
-    for item_id, item in target_items:
-        existing_lease = _active_fixer_lease_for_item(session, item_id, agent_id=agent_id)
+    newly_leased_items = []
+    try:
+        for item_id, item in target_items:
+            existing_lease = _active_fixer_lease_for_item(session, item_id, agent_id=agent_id)
 
-        if existing_lease:
-            lease_id = existing_lease["lease_id"]
-            request_id = existing_lease.get("request_id") or ""
-            if not request_id:
-                request_id = _stable_id(
-                    "req",
-                    {
-                        "session_id": session["session_id"],
-                        "item_id": item_id,
-                        "role": "fixer",
-                        "agent_id": agent_id,
-                        "lease_id": lease_id,
-                    },
-                )
-                existing_lease["request_id"] = request_id
-            leased_items.append(
-                {
-                    "item_id": item_id,
-                    "lease_id": lease_id,
-                    "request_id": request_id,
-                }
-            )
-        else:
-            if not _has_classification_evidence(item):
-                item["classification_evidence"] = {
-                    "event_type": "classification_recorded",
-                    "classification": "fix",
-                    "note": "Batch fix skeleton requested by agent next --batch.",
-                    "record_id": _stable_id(
-                        "classification",
+            if existing_lease:
+                lease_id = existing_lease["lease_id"]
+                request_id = existing_lease.get("request_id") or ""
+                request_path = existing_lease.get("request_path")
+                request_hash = existing_lease.get("request_hash")
+                path_ok = request_path and Path(request_path).is_file()
+
+                if not _has_classification_evidence(item):
+                    item["classification_evidence"] = {
+                        "event_type": "classification_recorded",
+                        "classification": "fix",
+                        "note": "Batch fix skeleton requested by agent next --batch.",
+                        "record_id": _stable_id(
+                            "classification",
+                            {
+                                "session_id": session["session_id"],
+                                "item_id": item_id,
+                                "agent_id": agent_id,
+                                "role": "fixer",
+                            },
+                        ),
+                    }
+                    item["decision"] = "fix"
+                    ledger.append_event(
+                        session_id=str(session["session_id"]),
+                        item_id=item_id,
+                        lease_id=None,
+                        agent_id=agent_id,
+                        role="fixer",
+                        event_type="classification_recorded",
+                        payload={
+                            "classification": "fix",
+                            "note": "Batch fix skeleton requested by agent next --batch.",
+                        },
+                    )
+
+                # Thread 1: Ensure active leases have valid request contexts, otherwise reconstruct
+                if not request_id or not request_hash or not path_ok:
+                    request_id = request_id or _stable_id(
+                        "req",
                         {
                             "session_id": session["session_id"],
                             "item_id": item_id,
-                            "agent_id": agent_id,
                             "role": "fixer",
+                            "agent_id": agent_id,
+                            "lease_id": lease_id,
                         },
-                    ),
-                }
-                item["decision"] = "fix"
-                ledger.append_event(
-                    session_id=str(session["session_id"]),
-                    item_id=item_id,
-                    lease_id=None,
-                    agent_id=agent_id,
-                    role="fixer",
-                    event_type="classification_recorded",
-                    payload={
+                    )
+                    request_item = dict(item)
+                    request_item["state"] = "claimed"
+                    request = {
+                        "schema_version": PROTOCOL_VERSION,
+                        "request_id": request_id,
+                        "session_id": session["session_id"],
+                        "lease_id": lease_id,
+                        "agent_role": "fixer",
+                        "item": request_item,
+                        "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
+                        "required_evidence": _required_evidence_for(item, "fixer"),
+                        "repository_context": {"repo": repo, "pr_number": str(pr_number)},
+                        "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
+                        "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+                    }
+                    handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
+                    if handling_boundary is not None:
+                        request["handling_boundary"] = handling_boundary
+
+                    new_request_hash = ActionRequest.from_dict(request).stable_hash()
+                    new_request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
+                    response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
+                    request["response_skeleton_path"] = str(response_skeleton_path)
+
+                    new_request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                    existing_lease["request_id"] = request_id
+                    existing_lease["request_hash"] = new_request_hash
+                    existing_lease["request_path"] = str(new_request_path)
+
+                    if not response_skeleton_path.is_file():
+                        response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
+                        response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                leased_items.append(
+                    {
+                        "item_id": item_id,
+                        "lease_id": lease_id,
+                        "request_id": request_id,
+                    }
+                )
+            else:
+                if max_to_lease <= 0:
+                    continue
+
+                if not _has_classification_evidence(item):
+                    item["classification_evidence"] = {
+                        "event_type": "classification_recorded",
                         "classification": "fix",
                         "note": "Batch fix skeleton requested by agent next --batch.",
-                    },
-                )
-            lease_id = f"lease_{uuid4().hex}"
-            request_id = _stable_id(
-                "req",
-                {
-                    "session_id": session["session_id"],
-                    "item_id": item_id,
-                    "role": "fixer",
-                    "agent_id": agent_id,
-                    "lease_id": lease_id,
-                },
-            )
-            request_item = dict(item)
-            request_item["state"] = "claimed"
-            request = {
-                "schema_version": PROTOCOL_VERSION,
-                "request_id": request_id,
-                "session_id": session["session_id"],
-                "lease_id": lease_id,
-                "agent_role": "fixer",
-                "item": request_item,
-                "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
-                "required_evidence": _required_evidence_for(item, "fixer"),
-                "repository_context": {"repo": repo, "pr_number": str(pr_number)},
-                "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
-                "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+                        "record_id": _stable_id(
+                            "classification",
+                            {
+                                "session_id": session["session_id"],
+                                "item_id": item_id,
+                                "agent_id": agent_id,
+                                "role": "fixer",
+                            },
+                        ),
+                    }
+                    item["decision"] = "fix"
+                    ledger.append_event(
+                        session_id=str(session["session_id"]),
+                        item_id=item_id,
+                        lease_id=None,
+                        agent_id=agent_id,
+                        role="fixer",
+                        event_type="classification_recorded",
+                        payload={
+                            "classification": "fix",
+                            "note": "Batch fix skeleton requested by agent next --batch.",
+                        },
+                    )
+
+                    lease_id = f"lease_{uuid4().hex}"
+                    request_id = _stable_id(
+                        "req",
+                        {
+                            "session_id": session["session_id"],
+                            "item_id": item_id,
+                            "role": "fixer",
+                            "agent_id": agent_id,
+                            "lease_id": lease_id,
+                        },
+                    )
+                    request_item = dict(item)
+                    request_item["state"] = "claimed"
+                    request = {
+                        "schema_version": PROTOCOL_VERSION,
+                        "request_id": request_id,
+                        "session_id": session["session_id"],
+                        "lease_id": lease_id,
+                        "agent_role": "fixer",
+                        "item": request_item,
+                        "allowed_actions": sorted(item.get("allowed_actions") or TERMINAL_RESOLUTIONS),
+                        "required_evidence": _required_evidence_for(item, "fixer"),
+                        "repository_context": {"repo": repo, "pr_number": str(pr_number)},
+                        "forbidden_actions": ["post_github_reply", "resolve_github_thread"],
+                        "resume_command": f"gh-address-cr agent submit {repo} {pr_number} --input response.json",
+                    }
+                    handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
+                    if handling_boundary is not None:
+                        request["handling_boundary"] = handling_boundary
+                    request_hash = ActionRequest.from_dict(request).stable_hash()
+                    request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
+                    response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
+                    request["response_skeleton_path"] = str(response_skeleton_path)
+
+                    claim_lease(
+                        session,
+                        item,
+                        agent_id=agent_id,
+                        role="fixer",
+                        request_hash=request_hash,
+                        lease_id=lease_id,
+                        now=current_time,
+                        request_id=request_id,
+                        request_path=str(request_path),
+                        resume_token=f"resume:{request_id}",
+                        allow_same_agent_github_thread_file_overlap=True,
+                    )
+
+                    item["state"] = "claimed"
+                    item["active_lease_id"] = lease_id
+                    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                    response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
+                    response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                    ledger.append_event(
+                        session_id=str(session["session_id"]),
+                        item_id=item_id,
+                        lease_id=lease_id,
+                        agent_id=agent_id,
+                        role="fixer",
+                        event_type="request_issued",
+                        payload={
+                            "request_id": request_id,
+                            "request_path": str(request_path),
+                            "response_skeleton_path": str(response_skeleton_path),
+                        },
+                    )
+
+                    leased_items.append(
+                        {
+                            "item_id": item_id,
+                            "lease_id": lease_id,
+                            "request_id": request_id,
+                        }
+                    )
+                    newly_leased_items.append((lease_id, item))
+                    max_to_lease -= 1
+
+    except Exception as exc:
+        # Thread 7: Roll back newly leased items in this batch on failure
+        leases = session.setdefault("leases", {})
+        for lid, itm in newly_leased_items:
+            leases.pop(lid, None)
+            _return_item_to_claimable_state(itm)
+            if not is_stale_github_thread_item(itm):
+                itm["blocking"] = True
+            itm["claimed_by"] = None
+            itm["claimed_at"] = None
+            itm["lease_expires_at"] = None
+            itm.pop("active_lease_id", None)
+        session_store.save_session(repo, pr_number, session)
+        if isinstance(exc, LeaseConflictError):
+            raise WorkflowError(
+                status="LEASE_REJECTED",
+                reason_code=exc.reason_code,
+                waiting_on="lease",
+                exit_code=5,
+                message=str(exc),
+                payload={"item_id": item_id} if "item_id" in locals() else {},
+            ) from exc
+        raise
+
+    if not leased_items:
+        session_store.save_session(repo, pr_number, session)
+        raise WorkflowError(
+            status="NO_ELIGIBLE_ITEM",
+            reason_code="NO_ELIGIBLE_ITEM",
+            waiting_on="work_item",
+            exit_code=4,
+            message="No eligible unresolved github review thread exists.",
+        )
+
+    # Thread 6: Avoid overwriting existing batch skeletons by merging
+    batch_skeleton_path = session_store.workspace_dir(repo, pr_number) / "batch-response-skeleton.json"
+    existing_items_replies = {}
+    existing_common = {}
+    if batch_skeleton_path.is_file():
+        try:
+            existing_data = json.loads(batch_skeleton_path.read_text(encoding="utf-8"))
+            if isinstance(existing_data, dict):
+                for itm in existing_data.get("items") or []:
+                    if isinstance(itm, dict) and itm.get("item_id"):
+                        existing_items_replies[itm["item_id"]] = itm.get("fix_reply")
+                if isinstance(existing_data.get("common"), dict):
+                    existing_common = existing_data["common"]
+        except Exception:
+            pass
+
+    items_list = []
+    for item_info in leased_items:
+        item_id = item_info["item_id"]
+        fix_reply = {
+            "summary": "",
+            "why": "",
+        }
+        if item_id in existing_items_replies and isinstance(existing_items_replies[item_id], dict):
+            fix_reply.update(existing_items_replies[item_id])
+
+        items_list.append(
+            {
+                "item_id": item_id,
+                "request_id": item_info["request_id"],
+                "lease_id": item_info["lease_id"],
+                "fix_reply": fix_reply,
             }
-            handling_boundary = _handling_boundary_summary_or_none(item, role="fixer")
-            if handling_boundary is not None:
-                request["handling_boundary"] = handling_boundary
-            request_hash = ActionRequest.from_dict(request).stable_hash()
-            request_path = session_store.workspace_dir(repo, pr_number) / f"action-request-{request_id}.json"
-            response_skeleton_path = session_store.workspace_dir(repo, pr_number) / f"action-response-skeleton-{request_id}.json"
-            request["response_skeleton_path"] = str(response_skeleton_path)
-
-            try:
-                claim_lease(
-                    session,
-                    item,
-                    agent_id=agent_id,
-                    role="fixer",
-                    request_hash=request_hash,
-                    lease_id=lease_id,
-                    now=current_time,
-                    request_id=request_id,
-                    request_path=str(request_path),
-                    resume_token=f"resume:{request_id}",
-                    allow_same_agent_github_thread_file_overlap=True,
-                )
-            except LeaseConflictError as exc:
-                session_store.save_session(repo, pr_number, session)
-                raise WorkflowError(
-                    status="LEASE_REJECTED",
-                    reason_code=exc.reason_code,
-                    waiting_on="lease",
-                    exit_code=5,
-                    message=str(exc),
-                    payload={"item_id": item_id},
-                ) from exc
-
-            item["state"] = "claimed"
-            item["active_lease_id"] = lease_id
-            request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-            response_skeleton = _response_skeleton_for_request(request, agent_id=agent_id, item=item)
-            response_skeleton_path.write_text(json.dumps(response_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-            ledger.append_event(
-                session_id=str(session["session_id"]),
-                item_id=item_id,
-                lease_id=lease_id,
-                agent_id=agent_id,
-                role="fixer",
-                event_type="request_issued",
-                payload={
-                    "request_id": request_id,
-                    "request_path": str(request_path),
-                    "response_skeleton_path": str(response_skeleton_path),
-                },
-            )
-
-            leased_items.append(
-                {
-                    "item_id": item_id,
-                    "lease_id": lease_id,
-                    "request_id": request_id,
-                }
-            )
+        )
 
     batch_skeleton = {
         "schema_version": PROTOCOL_VERSION,
         "agent_id": agent_id,
         "resolution": "fix",
         "common": {
-            "files": [],
-            "commit_hash": "",
-            "validation_commands": [
+            "files": existing_common.get("files") or [],
+            "commit_hash": existing_common.get("commit_hash") or "",
+            "validation_commands": existing_common.get("validation_commands") or [
                 {
                     "command": "",
                     "result": "passed",
                 }
             ],
-            "fix_reply": {
+            "fix_reply": existing_common.get("fix_reply") or {
                 "summary": "",
                 "why": "",
             },
         },
-        "items": [
-            {
-                "item_id": item_info["item_id"],
-                "request_id": item_info["request_id"],
-                "lease_id": item_info["lease_id"],
-                "fix_reply": {
-                    "summary": "",
-                    "why": "",
-                },
-            }
-            for item_info in leased_items
-        ],
+        "items": items_list,
     }
 
-    batch_skeleton_path = session_store.workspace_dir(repo, pr_number) / "batch-response-skeleton.json"
     batch_skeleton_path.write_text(json.dumps(batch_skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
     session_store.save_session(repo, pr_number, session)
 
     submit_command = f"gh-address-cr agent submit-batch {repo} {pr_number} --input {batch_skeleton_path}"

--- a/src/gh_address_cr/core/gate.py
+++ b/src/gh_address_cr/core/gate.py
@@ -337,6 +337,7 @@ def _final_gate_commands(repo: str, pr_number: str) -> dict[str, str]:
         "address": f"gh-address-cr address {repo} {pr_number} --lean",
         "publish": f"gh-address-cr agent publish {repo} {pr_number}",
         "final_gate": f"gh-address-cr final-gate {repo} {pr_number}",
+        "batch_next": f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>",
         "submit_batch": f"gh-address-cr agent submit-batch {repo} {pr_number} --input batch-response.json",
         "fix_all": f"gh-address-cr agent fix-all {repo} {pr_number} --input batch-response.json",
         "fix_all_homogeneous": (

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -668,7 +668,8 @@ def fast_fix_matching_threads(
             payload={"matched_count": len(matches), "files": sorted(normalized_file_set)},
         )
     if not stale_only and not normalized_homogeneous_reason:
-        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>"
+        files_str = ",".join(sorted(normalized_file_set))
+        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id> --files {files_str}"
         next_action = (
             f"Run `{batch_command}` to claim the matching GitHub review threads and write a "
             "BatchActionResponse skeleton, then fill per-thread summary/why entries and submit it. "
@@ -691,7 +692,8 @@ def fast_fix_matching_threads(
             },
         )
     if not stale_only and normalized_homogeneous_reason and not _has_homogeneous_thread_bodies(matches):
-        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>"
+        files_str = ",".join(sorted(normalized_file_set))
+        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id> --files {files_str}"
         next_action = (
             f"Run `{batch_command}` to claim the matching GitHub review threads and write a "
             "BatchActionResponse skeleton with per-thread summary/why entries. The matched threads have missing "

--- a/src/gh_address_cr/core/workflow.py
+++ b/src/gh_address_cr/core/workflow.py
@@ -668,10 +668,11 @@ def fast_fix_matching_threads(
             payload={"matched_count": len(matches), "files": sorted(normalized_file_set)},
         )
     if not stale_only and not normalized_homogeneous_reason:
+        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>"
         next_action = (
-            f"Use `gh-address-cr agent submit-batch {repo} {pr_number} --input batch-response.json` "
-            "with per-thread summary/why entries, or rerun fix-all with `--homogeneous-reason <why>` "
-            "only for a homogeneous repeated concern."
+            f"Run `{batch_command}` to claim the matching GitHub review threads and write a "
+            "BatchActionResponse skeleton, then fill per-thread summary/why entries and submit it. "
+            "Rerun fix-all with `--homogeneous-reason <why>` only for a homogeneous repeated concern."
         )
         raise WorkflowError(
             status=rejected_status,
@@ -679,13 +680,22 @@ def fast_fix_matching_threads(
             waiting_on="batch_action_response",
             exit_code=4,
             message=next_action,
-            payload={"matched_count": len(matches), "files": sorted(normalized_file_set)},
+            payload={
+                "matched_count": len(matches),
+                "files": sorted(normalized_file_set),
+                "commands": {
+                    "batch_next": batch_command,
+                    "submit_batch": f"gh-address-cr agent submit-batch {repo} {pr_number} --input <batch-response.json>",
+                    "fix_all_input": f"gh-address-cr agent fix-all {repo} {pr_number} --input <batch-response.json>",
+                },
+            },
         )
     if not stale_only and normalized_homogeneous_reason and not _has_homogeneous_thread_bodies(matches):
+        batch_command = f"gh-address-cr agent next {repo} {pr_number} --batch --agent-id <agent_id>"
         next_action = (
-            f"Use `gh-address-cr agent submit-batch {repo} {pr_number} --input batch-response.json` "
-            "with per-thread summary/why entries. The matched threads have missing or distinct thread bodies, "
-            "so fix-all cannot prove a homogeneous repeated concern."
+            f"Run `{batch_command}` to claim the matching GitHub review threads and write a "
+            "BatchActionResponse skeleton with per-thread summary/why entries. The matched threads have missing "
+            "or distinct thread bodies, so fix-all cannot prove a homogeneous repeated concern."
         )
         raise WorkflowError(
             status=rejected_status,
@@ -693,7 +703,15 @@ def fast_fix_matching_threads(
             waiting_on="batch_action_response",
             exit_code=4,
             message=next_action,
-            payload={"matched_count": len(matches), "files": sorted(normalized_file_set)},
+            payload={
+                "matched_count": len(matches),
+                "files": sorted(normalized_file_set),
+                "commands": {
+                    "batch_next": batch_command,
+                    "submit_batch": f"gh-address-cr agent submit-batch {repo} {pr_number} --input <batch-response.json>",
+                    "fix_all_input": f"gh-address-cr agent fix-all {repo} {pr_number} --input <batch-response.json>",
+                },
+            },
         )
 
     accepted_count = 0

--- a/tests/fixtures/thin_skill_orchestration/documentation_contracts.json
+++ b/tests/fixtures/thin_skill_orchestration/documentation_contracts.json
@@ -4,6 +4,7 @@
     "final-gate",
     "agent manifest",
     "agent next",
+    "agent next --batch",
     "agent submit",
     "agent submit-batch",
     "adapter check-runtime"

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -1225,7 +1225,12 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(payload["status"], "FAST_FIX_ALL_REJECTED")
         self.assertEqual(payload["reason_code"], "PER_THREAD_EVIDENCE_REQUIRED")
         self.assertEqual(payload["waiting_on"], "batch_action_response")
-        self.assertIn("agent submit-batch", payload["next_action"])
+        self.assertIn("agent next", payload["next_action"])
+        self.assertIn("--batch", payload["next_action"])
+        self.assertEqual(
+            payload["commands"]["batch_next"],
+            f"gh-address-cr agent next {self.repo} {self.pr} --batch --agent-id <agent_id>",
+        )
         session = self.load_session()
         self.assertEqual(session["items"]["github-thread:abc"]["state"], "open")
         self.assertEqual(session["items"]["github-thread:def"]["state"], "open")
@@ -1260,6 +1265,7 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertEqual(payload["status"], "FAST_FIX_ALL_REJECTED")
         self.assertEqual(payload["reason_code"], "PER_THREAD_EVIDENCE_REQUIRED")
         self.assertIn("distinct thread bodies", payload["next_action"])
+        self.assertIn("--batch", payload["next_action"])
         session = self.load_session()
         self.assertEqual(session["items"]["github-thread:abc"]["state"], "open")
         self.assertEqual(session["items"]["github-thread:def"]["state"], "open")

--- a/tests/test_control_plane_workflow.py
+++ b/tests/test_control_plane_workflow.py
@@ -1229,7 +1229,7 @@ class ControlPlaneWorkflowCLITest(PythonScriptTestCase):
         self.assertIn("--batch", payload["next_action"])
         self.assertEqual(
             payload["commands"]["batch_next"],
-            f"gh-address-cr agent next {self.repo} {self.pr} --batch --agent-id <agent_id>",
+            f"gh-address-cr agent next {self.repo} {self.pr} --batch --agent-id <agent_id> --files src/shared.py",
         )
         session = self.load_session()
         self.assertEqual(session["items"]["github-thread:abc"]["state"], "open")

--- a/tests/test_issue112_batch_next.py
+++ b/tests/test_issue112_batch_next.py
@@ -95,14 +95,85 @@ class BatchNextTestCase(PythonScriptTestCase):
         self.assertEqual(submitted_payload["status"], "BATCH_ACTION_ACCEPTED")
         self.assertEqual(submitted_payload["accepted_count"], 2)
 
-    def test_batch_next_reuses_existing_active_leases(self):
+    def test_batch_next_with_files_filter(self):
+        items = [
+            {
+                "item_id": "thread-a",
+                "item_kind": "github_thread",
+                "source": "github",
+                "path": "src/a.py",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-b",
+                "item_kind": "github_thread",
+                "source": "github",
+                "path": "src/b.py",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+        ]
+        self.init_session(items)
+
+        # 仅选择过滤 "src/a.py"
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--files", "src/a.py", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        self.assertEqual(response["lease_count"], 1)
+        self.assertEqual(response["leased_items"][0]["item_id"], "thread-a")
+
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-a"]["state"], "claimed")
+        self.assertEqual(session["items"]["thread-b"]["state"], "open")
+
+    def test_batch_next_excludes_non_fix_classifications(self):
+        items = [
+            {
+                "item_id": "thread-fix",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-reject",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+                "classification_evidence": {
+                    "event_type": "classification_recorded",
+                    "classification": "reject",
+                    "record_id": "ev-reject",
+                },
+            },
+        ]
+        self.init_session(items)
+
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        
+        # 应当仅租赁了 "thread-fix"
+        self.assertEqual(response["lease_count"], 1)
+        self.assertEqual(response["leased_items"][0]["item_id"], "thread-fix")
+
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-fix"]["state"], "claimed")
+        self.assertEqual(session["items"]["thread-reject"]["state"], "open")
+
+    def test_batch_next_respects_max_parallel_claims(self):
         items = [
             {
                 "item_id": "thread-1",
                 "item_kind": "github_thread",
                 "source": "github",
-                "state": "claimed",
-                "active_lease_id": "lease-existing",
+                "state": "open",
                 "allowed_actions": ["fix", "clarify", "defer", "reject"],
             },
             {
@@ -112,7 +183,42 @@ class BatchNextTestCase(PythonScriptTestCase):
                 "state": "open",
                 "allowed_actions": ["fix", "clarify", "defer", "reject"],
             },
+            {
+                "item_id": "thread-3",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
         ]
+        self.init_session(items)
+
+        # 由于 MAX_PARALLEL_CLAIMS 被配置为 2 (可以从 CapabilityManifest.constraints 查看)
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        
+        # 仅应有最多 2 个新租赁
+        self.assertEqual(response["lease_count"], 2)
+        
+        session = self.load_session()
+        claimed_count = sum(1 for itm in session["items"].values() if itm["state"] == "claimed")
+        self.assertEqual(claimed_count, 2)
+
+    def test_batch_next_reconstructs_lease_context(self):
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "claimed",
+                "active_lease_id": "lease-existing",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            }
+        ]
+        # lease-existing 缺失 request_hash/request_path
         leases = {
             "lease-existing": {
                 "lease_id": "lease-existing",
@@ -120,7 +226,7 @@ class BatchNextTestCase(PythonScriptTestCase):
                 "agent_id": "test-agent",
                 "role": "fixer",
                 "status": "active",
-                "request_id": "req-existing",
+                "request_id": "",
                 "expires_at": "2026-06-12T23:59:59Z",
                 "created_at": "2026-06-12T21:59:59Z",
             }
@@ -131,89 +237,131 @@ class BatchNextTestCase(PythonScriptTestCase):
             "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-
-        session = self.load_session()
-        self.assertEqual(session["items"]["thread-1"]["active_lease_id"], "lease-existing")
-        self.assertEqual(session["items"]["thread-2"]["state"], "claimed")
-
         response = json.loads(result.stdout)
+        
+        # 验证 lease-existing 已经在 session 中补充了 request_id/request_hash/request_path
+        session = self.load_session()
+        updated_lease = session["leases"]["lease-existing"]
+        self.assertTrue(updated_lease.get("request_id"))
+        self.assertTrue(updated_lease.get("request_hash"))
+        self.assertTrue(updated_lease.get("request_path"))
+        self.assertTrue(Path(updated_lease["request_path"]).is_file())
+
+        # 验证生成的 skeleton 能正常被 submit-batch
         skeleton_path = Path(response["response_skeleton_path"])
         skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
+        skeleton["common"]["files"] = ["src/a.py"]
+        skeleton["common"]["validation_commands"][0]["command"] = "echo pass"
+        skeleton["common"]["fix_reply"]["test_command"] = "echo pass"
+        skeleton["common"]["fix_reply"]["test_result"] = "passed"
+        skeleton["items"][0]["fix_reply"]["summary"] = "fixed missing request context"
+        skeleton["items"][0]["fix_reply"]["why"] = "reconstructed successfully"
+        skeleton_path.write_text(json.dumps(skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-        items_in_skeleton = {itm["item_id"]: itm for itm in skeleton["items"]}
-        self.assertIn("thread-1", items_in_skeleton)
-        self.assertIn("thread-2", items_in_skeleton)
-        self.assertEqual(items_in_skeleton["thread-1"]["lease_id"], "lease-existing")
-        self.assertEqual(items_in_skeleton["thread-1"]["request_id"], "req-existing")
+        submitted = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(skeleton_path))
+        self.assertEqual(submitted.returncode, 0, submitted.stderr)
 
-    def test_batch_next_skips_stale_and_other_agent_leases(self):
-        items = [
-            {
-                "item_id": "thread-open",
-                "item_kind": "github_thread",
-                "source": "github",
-                "state": "open",
-                "allowed_actions": ["fix", "clarify", "defer", "reject"],
-            },
-            {
-                "item_id": "thread-stale",
-                "item_kind": "github_thread",
-                "source": "github",
-                "state": "stale",
-                "status": "STALE",
-                "allowed_actions": ["fix", "clarify", "defer", "reject"],
-            },
-            {
-                "item_id": "thread-other-agent",
-                "item_kind": "github_thread",
-                "source": "github",
-                "state": "claimed",
-                "active_lease_id": "lease-other",
-                "allowed_actions": ["fix", "clarify", "defer", "reject"],
-            },
-        ]
-        leases = {
-            "lease-other": {
-                "lease_id": "lease-other",
-                "item_id": "thread-other-agent",
-                "agent_id": "other-agent",
-                "role": "fixer",
-                "status": "active",
-                "request_id": "req-other",
-                "request_hash": "req-other",
-                "expires_at": "2026-06-12T23:59:59Z",
-                "created_at": "2026-06-12T21:59:59Z",
-            }
-        }
-        self.init_session(items, leases)
-
-        result = self.run_runtime_module(
-            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        response = json.loads(result.stdout)
-        skeleton = json.loads(Path(response["response_skeleton_path"]).read_text(encoding="utf-8"))
-        self.assertEqual([item["item_id"] for item in skeleton["items"]], ["thread-open"])
-
-    def test_batch_next_fails_when_no_unresolved_threads(self):
+    def test_batch_next_rolls_back_on_conflict(self):
         items = [
             {
                 "item_id": "thread-1",
                 "item_kind": "github_thread",
                 "source": "github",
-                "state": "closed",
+                "path": "src/b.py",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-2",
+                "item_kind": "github_thread",
+                "source": "github",
+                "path": "src/a.py",
+                "line": 2,
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+        ]
+        # 外部已经有人占用了 "src/a.py" 上的锁，这会导致 thread-2 的 claim_lease 爆发 LeaseConflictError
+        leases = {
+            "lease-other": {
+                "lease_id": "lease-other",
+                "item_id": "thread-other",
+                "agent_id": "other-agent",
+                "role": "fixer",
+                "status": "active",
+                "conflict_keys": ["file:src/a.py"],
+                "expires_at": "2026-06-12T23:59:59Z",
+                "created_at": "2026-06-12T21:59:59Z",
+            }
+        }
+        self.init_session(items, leases)
+
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        # 应该发生 LEASE_REJECTED
+        self.assertEqual(result.returncode, 5, result.stderr)
+
+        # 验证 session 一致性：此前成功获取的 thread-1 应当被回滚释放，不留痕迹
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-1"]["state"], "open")
+        self.assertNotIn("thread-1", [l.get("item_id") for l in session["leases"].values() if l.get("agent_id") == "test-agent"])
+
+    def test_batch_next_merges_existing_skeleton_replies(self):
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
             }
         ]
         self.init_session(items)
 
-        result = self.run_runtime_module("agent", "next", self.repo, self.pr, "--batch")
-        self.assertEqual(result.returncode, 4, result.stderr)
-        err = json.loads(result.stdout)
-        self.assertEqual(err["status"], "NO_ELIGIBLE_ITEM")
+        # 1. 运行第一次，写入 skeleton
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        
+        # 模拟用户手工编辑 skeleton 文件
+        skeleton_path = Path(response["response_skeleton_path"])
+        skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
+        skeleton["items"][0]["fix_reply"]["summary"] = "User edited summary"
+        skeleton["items"][0]["fix_reply"]["why"] = "User edited why"
+        skeleton["common"]["commit_hash"] = "edited-commit"
+        skeleton_path.write_text(json.dumps(skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        # 2. 运行第二次，应当做增量合并
+        result2 = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+
+        # 验证编辑好的字段在二次获取后没有丢失
+        updated_skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated_skeleton["items"][0]["fix_reply"]["summary"], "User edited summary")
+        self.assertEqual(updated_skeleton["items"][0]["fix_reply"]["why"], "User edited why")
+        self.assertEqual(updated_skeleton["common"]["commit_hash"], "edited-commit")
 
     def test_cli_requires_role_or_batch(self):
         self.init_session([])
         result = self.run_runtime_module("agent", "next", self.repo, self.pr)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("one of the following arguments is required: --role or --batch", result.stderr)
+
+    def test_cli_role_and_batch_are_mutually_exclusive(self):
+        self.init_session([])
+        # 同时传入 --role 与 --batch
+        result = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--batch")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("arguments --role and --batch are mutually exclusive", result.stderr)
+
+    def test_cli_files_only_allowed_with_batch(self):
+        self.init_session([])
+        # 仅传入 --role 与 --files，但没有 --batch
+        result = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--files", "src/a.py")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("argument --files can only be used with --batch", result.stderr)

--- a/tests/test_issue112_batch_next.py
+++ b/tests/test_issue112_batch_next.py
@@ -305,7 +305,7 @@ class BatchNextTestCase(PythonScriptTestCase):
         # 验证 session 一致性：此前成功获取的 thread-1 应当被回滚释放，不留痕迹
         session = self.load_session()
         self.assertEqual(session["items"]["thread-1"]["state"], "open")
-        self.assertNotIn("thread-1", [l.get("item_id") for l in session["leases"].values() if l.get("agent_id") == "test-agent"])
+        self.assertNotIn("thread-1", [lease.get("item_id") for lease in session["leases"].values() if lease.get("agent_id") == "test-agent"])
 
     def test_batch_next_merges_existing_skeleton_replies(self):
         items = [

--- a/tests/test_issue112_batch_next.py
+++ b/tests/test_issue112_batch_next.py
@@ -365,3 +365,49 @@ class BatchNextTestCase(PythonScriptTestCase):
         result = self.run_runtime_module("agent", "next", self.repo, self.pr, "--role", "fixer", "--files", "src/a.py")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("argument --files can only be used with --batch", result.stderr)
+
+    def test_batch_next_fails_fast_on_invalid_skeleton_json(self):
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            }
+        ]
+        self.init_session(items)
+        skeleton_path = self.workspace_dir() / "batch-response-skeleton.json"
+        skeleton_path.write_text("invalid json content", encoding="utf-8")
+
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 5, result.stderr)
+        self.assertIn("Failed to parse existing batch skeleton JSON", result.stderr)
+
+    def test_batch_next_leases_already_classified_threads(self):
+        items = [
+            {
+                "item_id": "thread-classified",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+                "classification_evidence": {
+                    "event_type": "classification_recorded",
+                    "classification": "fix",
+                    "note": "already classified",
+                    "record_id": "rec-exist",
+                },
+                "decision": "fix",
+            }
+        ]
+        self.init_session(items)
+
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-classified"]["state"], "claimed")

--- a/tests/test_issue112_batch_next.py
+++ b/tests/test_issue112_batch_next.py
@@ -1,0 +1,167 @@
+import json
+from pathlib import Path
+from tests.helpers import PythonScriptTestCase
+
+
+class BatchNextTestCase(PythonScriptTestCase):
+    def init_session(self, items, leases=None):
+        self.workspace_dir().mkdir(parents=True, exist_ok=True)
+        payload = {
+            "session_id": f"{self.repo}#{self.pr}",
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "status": "ACTIVE",
+            "items": {item["item_id"]: item for item in items},
+            "leases": leases or {},
+            "ledger_path": str(self.workspace_dir() / "evidence.jsonl"),
+        }
+        self.session_file().write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    def test_batch_next_generates_leases_and_skeleton(self):
+        # 1. 构造 2 个 unresolved github_thread items
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "title": "Concern 1",
+                "body": "First issue",
+                "path": "src/a.py",
+                "line": 10,
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-2",
+                "item_kind": "github_thread",
+                "source": "github",
+                "title": "Concern 2",
+                "body": "Second issue",
+                "path": "src/b.py",
+                "line": 20,
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+        ]
+        self.init_session(items)
+
+        # 2. 运行 agent next --batch
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        # 3. 检查 CLI stdout 响应
+        response = json.loads(result.stdout)
+        self.assertEqual(response["status"], "BATCH_ACTION_REQUESTED")
+        self.assertEqual(response["lease_count"], 2)
+        self.assertEqual(len(response["leased_items"]), 2)
+
+        # 4. 验证 session 状态（两个 item 应该都变成了 claimed 状态并获得了 lease）
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-1"]["state"], "claimed")
+        self.assertEqual(session["items"]["thread-2"]["state"], "claimed")
+        
+        lease_ids = [item_info["lease_id"] for item_info in response["leased_items"]]
+        for lid in lease_ids:
+            self.assertIn(lid, session["leases"])
+            self.assertEqual(session["leases"][lid]["status"], "active")
+            self.assertEqual(session["leases"][lid]["role"], "fixer")
+
+        # 5. 验证生成的 batch-response-skeleton.json 结构
+        skeleton_path = Path(response["response_skeleton_path"])
+        self.assertTrue(skeleton_path.exists())
+        skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
+        
+        self.assertEqual(skeleton["agent_id"], "test-agent")
+        self.assertEqual(skeleton["resolution"], "fix")
+        self.assertIn("common", skeleton)
+        self.assertIn("items", skeleton)
+        self.assertEqual(len(skeleton["items"]), 2)
+        
+        item1_ids = {itm["item_id"] for itm in skeleton["items"]}
+        self.assertEqual(item1_ids, {"thread-1", "thread-2"})
+
+    def test_batch_next_reuses_existing_active_leases(self):
+        # 1. 构造一个已租赁的和一个未租赁的 unresolved github_thread items
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "claimed",
+                "active_lease_id": "lease-existing",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-2",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+        ]
+        leases = {
+            "lease-existing": {
+                "lease_id": "lease-existing",
+                "item_id": "thread-1",
+                "agent_id": "test-agent",
+                "role": "fixer",
+                "status": "active",
+                "request_id": "req-existing",
+                "expires_at": "2026-06-12T23:59:59Z",
+                "created_at": "2026-06-12T21:59:59Z",
+            }
+        }
+        self.init_session(items, leases)
+
+        # 2. 运行 agent next --batch
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        # 3. 验证 session 状态：thread-1 保持原来的 lease，thread-2 获得新 lease
+        session = self.load_session()
+        self.assertEqual(session["items"]["thread-1"]["active_lease_id"], "lease-existing")
+        self.assertEqual(session["items"]["thread-2"]["state"], "claimed")
+        
+        # 4. 验证 skeleton 是否包含这两个
+        response = json.loads(result.stdout)
+        skeleton_path = Path(response["response_skeleton_path"])
+        skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
+        
+        items_in_skeleton = {itm["item_id"]: itm for itm in skeleton["items"]}
+        self.assertIn("thread-1", items_in_skeleton)
+        self.assertIn("thread-2", items_in_skeleton)
+        self.assertEqual(items_in_skeleton["thread-1"]["lease_id"], "lease-existing")
+        self.assertEqual(items_in_skeleton["thread-1"]["request_id"], "req-existing")
+
+    def test_batch_next_fails_when_no_unresolved_threads(self):
+        # 1. 构造一个 terminal (closed) 的 thread 或者是没有 items 的 session
+        items = [
+            {
+                "item_id": "thread-1",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "closed",
+            }
+        ]
+        self.init_session(items)
+
+        # 2. 运行 agent next --batch，预期返回 4 (NO_ELIGIBLE_ITEM)
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch"
+        )
+        self.assertEqual(result.returncode, 4, result.stderr)
+        err = json.loads(result.stdout)
+        self.assertEqual(err["status"], "NO_ELIGIBLE_ITEM")
+
+    def test_cli_requires_role_or_batch(self):
+        self.init_session([])
+        # 1. 运行不带 --role 也不带 --batch 的命令，预期报错
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("one of the following arguments is required: --role or --batch", result.stderr)

--- a/tests/test_issue112_batch_next.py
+++ b/tests/test_issue112_batch_next.py
@@ -18,7 +18,6 @@ class BatchNextTestCase(PythonScriptTestCase):
         self.session_file().write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
     def test_batch_next_generates_leases_and_skeleton(self):
-        # 1. 构造 2 个 unresolved github_thread items
         items = [
             {
                 "item_id": "thread-1",
@@ -45,45 +44,58 @@ class BatchNextTestCase(PythonScriptTestCase):
         ]
         self.init_session(items)
 
-        # 2. 运行 agent next --batch
         result = self.run_runtime_module(
             "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
-        # 3. 检查 CLI stdout 响应
         response = json.loads(result.stdout)
         self.assertEqual(response["status"], "BATCH_ACTION_REQUESTED")
         self.assertEqual(response["lease_count"], 2)
         self.assertEqual(len(response["leased_items"]), 2)
+        self.assertIn("agent submit-batch octo/example 77 --input", response["next_action"])
+        self.assertIn("submit_batch", response["commands"])
 
-        # 4. 验证 session 状态（两个 item 应该都变成了 claimed 状态并获得了 lease）
         session = self.load_session()
         self.assertEqual(session["items"]["thread-1"]["state"], "claimed")
         self.assertEqual(session["items"]["thread-2"]["state"], "claimed")
-        
+
         lease_ids = [item_info["lease_id"] for item_info in response["leased_items"]]
         for lid in lease_ids:
             self.assertIn(lid, session["leases"])
             self.assertEqual(session["leases"][lid]["status"], "active")
             self.assertEqual(session["leases"][lid]["role"], "fixer")
+            self.assertEqual(session["leases"][lid]["agent_id"], "test-agent")
 
-        # 5. 验证生成的 batch-response-skeleton.json 结构
         skeleton_path = Path(response["response_skeleton_path"])
         self.assertTrue(skeleton_path.exists())
         skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
-        
+
         self.assertEqual(skeleton["agent_id"], "test-agent")
         self.assertEqual(skeleton["resolution"], "fix")
         self.assertIn("common", skeleton)
         self.assertIn("items", skeleton)
         self.assertEqual(len(skeleton["items"]), 2)
-        
+
         item1_ids = {itm["item_id"] for itm in skeleton["items"]}
         self.assertEqual(item1_ids, {"thread-1", "thread-2"})
 
+        skeleton["common"]["files"] = ["src/a.py", "src/b.py"]
+        skeleton["common"]["validation_commands"][0]["command"] = "python3 -m unittest tests.test_issue112_batch_next"
+        skeleton["common"]["fix_reply"]["test_command"] = "python3 -m unittest tests.test_issue112_batch_next"
+        skeleton["common"]["fix_reply"]["test_result"] = "passed"
+        for item in skeleton["items"]:
+            item["fix_reply"]["summary"] = f"Fixed {item['item_id']}"
+            item["fix_reply"]["why"] = f"The validation covers {item['item_id']}."
+        skeleton_path.write_text(json.dumps(skeleton, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        submitted = self.run_runtime_module("agent", "submit-batch", self.repo, self.pr, "--input", str(skeleton_path))
+        self.assertEqual(submitted.returncode, 0, submitted.stderr)
+        submitted_payload = json.loads(submitted.stdout)
+        self.assertEqual(submitted_payload["status"], "BATCH_ACTION_ACCEPTED")
+        self.assertEqual(submitted_payload["accepted_count"], 2)
+
     def test_batch_next_reuses_existing_active_leases(self):
-        # 1. 构造一个已租赁的和一个未租赁的 unresolved github_thread items
         items = [
             {
                 "item_id": "thread-1",
@@ -115,30 +127,76 @@ class BatchNextTestCase(PythonScriptTestCase):
         }
         self.init_session(items, leases)
 
-        # 2. 运行 agent next --batch
         result = self.run_runtime_module(
             "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
-        # 3. 验证 session 状态：thread-1 保持原来的 lease，thread-2 获得新 lease
         session = self.load_session()
         self.assertEqual(session["items"]["thread-1"]["active_lease_id"], "lease-existing")
         self.assertEqual(session["items"]["thread-2"]["state"], "claimed")
-        
-        # 4. 验证 skeleton 是否包含这两个
+
         response = json.loads(result.stdout)
         skeleton_path = Path(response["response_skeleton_path"])
         skeleton = json.loads(skeleton_path.read_text(encoding="utf-8"))
-        
+
         items_in_skeleton = {itm["item_id"]: itm for itm in skeleton["items"]}
         self.assertIn("thread-1", items_in_skeleton)
         self.assertIn("thread-2", items_in_skeleton)
         self.assertEqual(items_in_skeleton["thread-1"]["lease_id"], "lease-existing")
         self.assertEqual(items_in_skeleton["thread-1"]["request_id"], "req-existing")
 
+    def test_batch_next_skips_stale_and_other_agent_leases(self):
+        items = [
+            {
+                "item_id": "thread-open",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "open",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-stale",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "stale",
+                "status": "STALE",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+            {
+                "item_id": "thread-other-agent",
+                "item_kind": "github_thread",
+                "source": "github",
+                "state": "claimed",
+                "active_lease_id": "lease-other",
+                "allowed_actions": ["fix", "clarify", "defer", "reject"],
+            },
+        ]
+        leases = {
+            "lease-other": {
+                "lease_id": "lease-other",
+                "item_id": "thread-other-agent",
+                "agent_id": "other-agent",
+                "role": "fixer",
+                "status": "active",
+                "request_id": "req-other",
+                "request_hash": "req-other",
+                "expires_at": "2026-06-12T23:59:59Z",
+                "created_at": "2026-06-12T21:59:59Z",
+            }
+        }
+        self.init_session(items, leases)
+
+        result = self.run_runtime_module(
+            "agent", "next", self.repo, self.pr, "--batch", "--agent-id", "test-agent"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        skeleton = json.loads(Path(response["response_skeleton_path"]).read_text(encoding="utf-8"))
+        self.assertEqual([item["item_id"] for item in skeleton["items"]], ["thread-open"])
+
     def test_batch_next_fails_when_no_unresolved_threads(self):
-        # 1. 构造一个 terminal (closed) 的 thread 或者是没有 items 的 session
         items = [
             {
                 "item_id": "thread-1",
@@ -149,19 +207,13 @@ class BatchNextTestCase(PythonScriptTestCase):
         ]
         self.init_session(items)
 
-        # 2. 运行 agent next --batch，预期返回 4 (NO_ELIGIBLE_ITEM)
-        result = self.run_runtime_module(
-            "agent", "next", self.repo, self.pr, "--batch"
-        )
+        result = self.run_runtime_module("agent", "next", self.repo, self.pr, "--batch")
         self.assertEqual(result.returncode, 4, result.stderr)
         err = json.loads(result.stdout)
         self.assertEqual(err["status"], "NO_ELIGIBLE_ITEM")
 
     def test_cli_requires_role_or_batch(self):
         self.init_session([])
-        # 1. 运行不带 --role 也不带 --batch 的命令，预期报错
-        result = self.run_runtime_module(
-            "agent", "next", self.repo, self.pr
-        )
+        result = self.run_runtime_module("agent", "next", self.repo, self.pr)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("one of the following arguments is required: --role or --batch", result.stderr)

--- a/tests/test_python_wrappers.py
+++ b/tests/test_python_wrappers.py
@@ -596,6 +596,7 @@ else:
                 "threads": f"gh-address-cr threads {self.repo} {self.pr} --lean",
                 "classify": f"gh-address-cr agent classify {self.repo} {self.pr} <item_id> --classification fix --note <note>",
                 "next": f"gh-address-cr agent next {self.repo} {self.pr} --role fixer --agent-id <agent_id>",
+                "batch_next": f"gh-address-cr agent next {self.repo} {self.pr} --batch --agent-id <agent_id>",
                 "submit": f"gh-address-cr agent submit {self.repo} {self.pr} --input response.json",
                 "submit_batch": f"gh-address-cr agent submit-batch {self.repo} {self.pr} --input batch-response.json",
                 "fix_all": (

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -41,6 +41,13 @@ def read_repo_docs(*paths):
     return "\n".join(path.read_text(encoding="utf-8") for path in paths)
 
 
+def cli_topology_section():
+    text = CLI_REFERENCE_MD.read_text(encoding="utf-8")
+    start = text.index("## Command Topology (ASCII)")
+    end = text.index("Stable machine summary fields:", start)
+    return text[start:end]
+
+
 class SkillDocumentationContractTest(unittest.TestCase):
     def test_skill_declares_packaged_skill_root_scope(self):
         text = SKILL_MD.read_text(encoding="utf-8")
@@ -149,6 +156,82 @@ class SkillDocumentationContractTest(unittest.TestCase):
         self.assertIn("`--input <batch-response.json>`", protocol_text)
         self.assertIn("`--homogeneous-reason <why>`", protocol_text)
         self.assertIn("agent resolve-stale", protocol_text)
+
+    def test_cli_reference_ascii_topology_covers_public_command_surface(self):
+        section = cli_topology_section()
+        self.assertTrue(section.isascii())
+        for command in (
+            "active-pr",
+            "review",
+            "review [--auto-simple]",
+            "address [--lean|--summary]",
+            "threads [--lean|--summary]",
+            "findings --input <json|->",
+            "adapter <adapter_cmd...>",
+            "doctor",
+            "telemetry ingest",
+            "telemetry summary",
+            "command-session --input <operations.json|->",
+            "final-gate",
+            "review-to-findings --input <finding-blocks.md|->",
+            "submit-feedback",
+            "submit-action <action-request.json>",
+            "version / --version",
+            "--machine",
+            "--human",
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, section)
+
+    def test_cli_reference_ascii_topology_covers_agent_command_surface(self):
+        section = cli_topology_section()
+        for command in (
+            "manifest",
+            "classify",
+            "next --role <role>",
+            "next --batch",
+            "submit",
+            "submit-batch",
+            "fix",
+            "trivial-fix",
+            "fix-all",
+            "resolve-stale",
+            "evidence add",
+            "evidence list",
+            "publish",
+            "leases",
+            "reclaim",
+            "orchestrate start",
+            "orchestrate step",
+            "orchestrate status",
+            "orchestrate resume",
+            "orchestrate stop",
+            "orchestrate submit",
+            "orchestrate autopilot",
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, section)
+
+    def test_cli_reference_ascii_topology_covers_upstream_downstream_verification(self):
+        section = cli_topology_section()
+        for edge in (
+            "WAITING_FOR_EXTERNAL_REVIEW",
+            "WAITING_FOR_SIMPLE_ADDRESS",
+            "PER_THREAD_EVIDENCE_REQUIRED -> next --batch",
+            "producer output",
+            "session items",
+            "agent classify",
+            "ActionResponse or BatchActionResponse",
+            "agent submit or agent submit-batch",
+            "accepted evidence",
+            "agent publish (GitHub thread side effects only)",
+            "final-gate",
+            "completion_summary_line",
+            "runtime-owned leases + request_id values",
+            "agent submit-batch validates lease ownership and request context",
+        ):
+            with self.subTest(edge=edge):
+                self.assertIn(edge, section)
 
     def test_skill_documents_runtime_complexity_additive_fields(self):
         skill_text = SKILL_MD.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #112

This PR introduces the `--batch` flag to the `agent next` command in `gh-address-cr`.

When `fix-all` is rejected due to non-homogeneous threads or manual resolution is required for multiple threads, running `gh-address-cr agent next --batch` will:
- Automatically claim/lease all unresolved GitHub review threads.
- Generate a `batch-response-skeleton.json` in the workspace.
- Allow the agent/developer to fill in per-thread fix details and submit with `submit-batch`.

Also includes new unit tests, documentation, and ASCII topology updates.
