### PR TITLE
docs: add intake/telemetry decision tables (#124, #125)

### DIFF
--- a/specs/021-docs-refinement/PR_SCOPE.md
+++ b/specs/021-docs-refinement/PR_SCOPE.md
@@ -1,0 +1,1 @@
+Scope: Add decision tables for intake and telemetry.\nRelates to #124, #125


### PR DESCRIPTION
Provide a single source of truth for command selection via decision tables. Clarify autopilot dry-run behavior.\n\nCloses #124\nCloses #125