### PR TITLE
refactor: cleanup redundant emission and scope noisy-review (#121, #95)

### DIFF
--- a/specs/022-cleanup/PR_SCOPE.md
+++ b/specs/022-cleanup/PR_SCOPE.md
@@ -1,0 +1,1 @@
+Scope: Cleanup redundant code and PR-scope noisy-review.\nRelates to #121, #95


### PR DESCRIPTION
Remove duplicate status emissions and ensure noisy-review improvements remain PR-scoped.\n\nCloses #121\nCloses #95