### PR TITLE
fix: fail loud on orphan ledger events and promote response projector (#137)

### DIFF
--- a/src/gh_address_cr/core/agent_protocol.py
+++ b/src/gh_address_cr/core/agent_protocol.py
@@ -993,7 +993,7 @@ def _accept_action_response_submission(
             payload={"item_id": item_id, "lease_id": lease_id, "evidence_record_id": record.record_id},
         )
 
-    _apply_response_to_item(item, response)
+    apply_response_to_item(item, response)
 
     _record_validation_command_telemetry(session, response.get("validation_commands") or [], seen=telemetry_seen)
 
@@ -1015,7 +1015,7 @@ def _accept_action_response_submission(
 
 
 def replayable_action_response(response: dict[str, Any]) -> dict[str, Any]:
-    """Subset of an ActionResponse needed to replay `_apply_response_to_item`."""
+    """Subset of an ActionResponse needed to replay `apply_response_to_item`."""
     snapshot: dict[str, Any] = {
         "resolution": response.get("resolution"),
         "note": response.get("note"),
@@ -1601,7 +1601,13 @@ def _expected_request_hash_for_response(
     return None, "REQUEST_CONTEXT_NOT_FOUND"
 
 
-def _apply_response_to_item(item: dict[str, Any], response: dict[str, Any]) -> None:
+def apply_response_to_item(item: dict[str, Any], response: dict[str, Any]) -> None:
+    """Fold an accepted ActionResponse onto a session item in place.
+
+    Public projection helper: the event-sourcing fold in
+    `runtime_kernel.session_projection` replays this to rebuild agent deltas, so it
+    must stay a public symbol rather than a private cross-module import (#137).
+    """
     resolution = str(response["resolution"])
     if item.get("item_kind") == "github_thread":
         item["state"] = "publish_ready"

--- a/src/gh_address_cr/core/runtime_kernel/session_projection.py
+++ b/src/gh_address_cr/core/runtime_kernel/session_projection.py
@@ -41,18 +41,28 @@ def apply_ledger_events(
 
     for record in records:
         event_type = _attr(record, "event_type")
+        if event_type not in AGENT_EVENT_TYPES:
+            # Events this fold does not project (e.g. request_issued, response_rejected)
+            # never mutate item state and may legitimately reference an item_id absent
+            # from the base map; skip them before the orphan guard so non-agent events
+            # cannot trip a spurious crash-recovery failure.
+            continue
         item_id = str(_attr(record, "item_id") or "")
         payload = _attr(record, "payload") or {}
         item = items.get(item_id)
         if item is None:
-            # Fail loud: a ledger event whose item is absent from the base map means
-            # the cache and the durable ledger have diverged. Silently skipping it
-            # (the old `continue`) would reconstruct a partial projection and quietly
-            # weaken the crash-recovery guarantee this module promises (#137).
+            # Fail loud: a *projected* ledger event whose item is absent from the base
+            # map means the cache and the durable ledger have diverged. Silently
+            # skipping it (the old `continue`) would reconstruct a partial projection
+            # and quietly weaken the crash-recovery guarantee this module promises
+            # (#137). Carry record_id/timestamp so the offending ledger event is
+            # immediately locatable when debugging divergence.
             raise ValueError(
                 f"orphan ledger event references unknown item_id {item_id!r} "
-                f"(event_type={event_type!r}); session base has {len(items)} item(s) — "
-                "ledger/cache divergence breaks deterministic crash-recovery replay"
+                f"(event_type={event_type!r}, record_id={_attr(record, 'record_id')!r}, "
+                f"timestamp={_attr(record, 'timestamp')!r}); session base has "
+                f"{len(items)} item(s) — ledger/cache divergence breaks deterministic "
+                "crash-recovery replay"
             )
 
         if event_type == "classification_recorded":

--- a/src/gh_address_cr/core/runtime_kernel/session_projection.py
+++ b/src/gh_address_cr/core/runtime_kernel/session_projection.py
@@ -33,7 +33,7 @@ def apply_ledger_events(
     `payload`. Records are applied in iteration order, which the ledger preserves
     as append order.
     """
-    from gh_address_cr.core.agent_protocol import _apply_response_to_item
+    from gh_address_cr.core.agent_protocol import apply_response_to_item
 
     items: dict[str, dict[str, Any]] = {
         str(item_id): copy.deepcopy(dict(item)) for item_id, item in base_items.items()
@@ -45,7 +45,15 @@ def apply_ledger_events(
         payload = _attr(record, "payload") or {}
         item = items.get(item_id)
         if item is None:
-            continue
+            # Fail loud: a ledger event whose item is absent from the base map means
+            # the cache and the durable ledger have diverged. Silently skipping it
+            # (the old `continue`) would reconstruct a partial projection and quietly
+            # weaken the crash-recovery guarantee this module promises (#137).
+            raise ValueError(
+                f"orphan ledger event references unknown item_id {item_id!r} "
+                f"(event_type={event_type!r}); session base has {len(items)} item(s) — "
+                "ledger/cache divergence breaks deterministic crash-recovery replay"
+            )
 
         if event_type == "classification_recorded":
             classification = str(payload.get("classification") or "")
@@ -60,8 +68,8 @@ def apply_ledger_events(
         elif event_type == "response_accepted":
             response = payload.get("response")
             if isinstance(response, Mapping):
-                _apply_response_to_item(item, dict(response))
-                # `_apply_response_to_item` stamps local-finding `handled_at` with
+                apply_response_to_item(item, dict(response))
+                # `apply_response_to_item` stamps local-finding `handled_at` with
                 # datetime.now(); pin it to the event's append time so a rebuild is
                 # deterministic and does not overwrite the original timestamp.
                 record_ts = _attr(record, "timestamp")

--- a/tests/core/test_session_projection.py
+++ b/tests/core/test_session_projection.py
@@ -153,11 +153,23 @@ class SessionProjectionTest(unittest.TestCase):
         # silent skip would reconstruct a partial projection and quietly weaken the
         # crash-recovery guarantee.
         base = {"github-thread:abc": {"item_id": "github-thread:abc", "item_kind": "github_thread"}}
-        events = [_event("thread_resolved", "github-thread:missing", {"thread_id": "missing"})]
+        events = [_event("thread_resolved", "github-thread:missing", {"thread_id": "missing"}, record_id="ev_orphan")]
         with self.assertRaises(ValueError) as ctx:
             apply_ledger_events(base, events)
-        self.assertIn("github-thread:missing", str(ctx.exception))
-        self.assertIn("thread_resolved", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("github-thread:missing", message)
+        self.assertIn("thread_resolved", message)
+        self.assertIn("ev_orphan", message)
+
+    def test_unprojected_event_types_skip_orphan_guard(self):
+        # The orphan guard must only fire for event types this fold actually projects.
+        # Ledger events outside AGENT_EVENT_TYPES (e.g. request_issued) never mutate
+        # item state and may legitimately reference an item absent from the base map;
+        # they must be skipped, not crash crash-recovery replay.
+        base = {"github-thread:abc": {"item_id": "github-thread:abc", "item_kind": "github_thread"}}
+        ignored = [_event("request_issued", "github-thread:missing", {"request_id": "missing"})]
+        rebuilt = apply_ledger_events(base, ignored)
+        self.assertEqual(set(rebuilt), {"github-thread:abc"})
 
 
 if __name__ == "__main__":

--- a/tests/core/test_session_projection.py
+++ b/tests/core/test_session_projection.py
@@ -147,11 +147,17 @@ class SessionProjectionTest(unittest.TestCase):
     def test_agent_event_types_documents_verification_rejected(self):
         self.assertIn("verification_rejected", AGENT_EVENT_TYPES)
 
-    def test_unknown_item_events_are_ignored(self):
+    def test_orphan_item_event_fails_loud(self):
+        # #137: a ledger event whose item is missing from the base map signals
+        # ledger/cache divergence and must fail loud, not be silently skipped — a
+        # silent skip would reconstruct a partial projection and quietly weaken the
+        # crash-recovery guarantee.
         base = {"github-thread:abc": {"item_id": "github-thread:abc", "item_kind": "github_thread"}}
         events = [_event("thread_resolved", "github-thread:missing", {"thread_id": "missing"})]
-        rebuilt = apply_ledger_events(base, events)
-        self.assertEqual(set(rebuilt), {"github-thread:abc"})
+        with self.assertRaises(ValueError) as ctx:
+            apply_ledger_events(base, events)
+        self.assertIn("github-thread:missing", str(ctx.exception))
+        self.assertIn("thread_resolved", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -2467,7 +2467,7 @@ class TestTelemetry(unittest.TestCase):
 
     @patch("gh_address_cr.core.agent_protocol.submit_lease")
     @patch("gh_address_cr.core.agent_protocol.accept_lease")
-    @patch("gh_address_cr.core.agent_protocol._apply_response_to_item")
+    @patch("gh_address_cr.core.agent_protocol.apply_response_to_item")
     def test_accept_action_response_submission_records_validation_telemetry(self, mock_apply, mock_accept, mock_submit):
         import tempfile
         from pathlib import Path
@@ -2567,7 +2567,7 @@ class TestTelemetry(unittest.TestCase):
 
     @patch("gh_address_cr.core.agent_protocol.submit_lease")
     @patch("gh_address_cr.core.agent_protocol.accept_lease")
-    @patch("gh_address_cr.core.agent_protocol._apply_response_to_item")
+    @patch("gh_address_cr.core.agent_protocol.apply_response_to_item")
     def test_shared_batch_seen_deduplicates_validation_telemetry(self, mock_apply, mock_accept, mock_submit):
         import tempfile
         from pathlib import Path


### PR DESCRIPTION
## Summary

Addresses the two surgical, low-risk findings from the tech-debt audit in #137. The large structural refactors (full god-module split, god-method extraction, port layer) are intentionally left as tracked follow-ups in the issue.

### #2 (Medium) — Event-sourcing rebuild no longer silently drops orphan events
`apply_ledger_events` previously did `if item is None: continue`, silently skipping any ledger event whose `item_id` is absent from the base item map. That contradicts the constitution's "fail-loud, no silent fallbacks" principle and quietly weakens the crash-recovery guarantee the module docstring claims. It now raises `ValueError` with the offending `item_id`/`event_type`, since an orphan event means the durable ledger and the cache have diverged.

Blast radius is minimal: `apply_ledger_events` is only reached via `rebuild_session_items`, which currently has no production caller.

### #1 sub-step (High) — Promote `_apply_response_to_item` to public `apply_response_to_item`
The projection layer (`session_projection.py`) imported a private cross-module symbol. Promoting it to a public projection helper removes that private dependency. The full responsibility split of `agent_protocol.py` remains a follow-up.

### #4 (Low) — Spec drift
No change needed: the `--homogeneous-reason` public CLI contract is already fully documented in `docs/cli-reference.md` (lines 40, 184-191, 346-348, 377), `docs/adr/0001-unified-resolve-surface.md`, and `docs/migration-3.0.md`, with tests in `tests/test_homogeneous_decline.py`. The deleted `specs/019-*` artifacts were removed deliberately in `61bed36`; the constitution's "code, docs, tests together" rule is satisfied via the canonical docs, so no spec is reintroduced.

## Tests
- Rewrote `test_unknown_item_events_are_ignored` → `test_orphan_item_event_fails_loud` (the old test encoded the silent-skip behavior the audit flagged).
- Updated `test_telemetry.py` patch paths to the public symbol.
- Focused suites green; full suite green except one pre-existing failure unrelated to this PR (`test_plugin_packaging` depends on `.agents/plugins/marketplace.json`, which is deleted in the working tree independently of this change).
- `ruff check` clean on all changed files.

## Follow-ups (remain in #137)
- #1 full god-module split of `core/agent_protocol.py` by responsibility
- #3 god-method extraction in `commands/high_level.py::handle`
- #5 port/interface layer to replace ~24 in-function imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
